### PR TITLE
[codex] Limit Workout History Reads

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,3 +25,10 @@ O Vitalità é um PWA em React/Vite com Firebase Authentication e Cloud Firestor
 - Trocar leituras completas de histórico por agregados em `user_stats`.
 - Migrar convites e ações sensíveis para Cloud Functions.
 - Expandir observabilidade do Sentry com tags de rota, versão, PWA/offline e erros de Firestore.
+
+## Referências
+
+- `docs/firestore-model.md`
+- `docs/security-rules.md`
+- `docs/performance-data.md`
+- `docs/testing.md`

--- a/docs/performance-data.md
+++ b/docs/performance-data.md
@@ -1,0 +1,30 @@
+# Performance e dados
+
+Este documento registra as decisões atuais para reduzir leituras grandes no Firestore sem mudar o modelo de produto.
+
+## Leituras de sessões
+
+- `getHistory(userId, templateName, lastDoc, pageSize)` é a API principal para histórico paginado.
+- `getRecentSessions(userId, limitCount)` deve ser usada em telas de resumo e estatísticas recentes.
+- `subscribeToRecentSessions(userId, callback, limitCount)` deve ser usada em dashboards que precisam de atualização em tempo real.
+- `getAllSessions(userId)` continua existindo apenas como compatibilidade para fluxos que ainda dependem de histórico completo.
+
+## Limites atuais
+
+Os limites ficam centralizados em `SESSION_LIMITS` no `workoutService`:
+
+- `dashboardRecent`: 120 sessões recentes.
+- `analyticsGlobalPage`: 120 sessões por página na busca global de evolução.
+- `profileStats`: 300 sessões recentes para perfil/conquistas.
+- `achievementCheck`: 300 sessões recentes para avaliação pós-treino.
+
+## Comportamento por tela
+
+- HomeDashboard: assina somente as sessões recentes, em vez de observar todo o histórico.
+- HistoryPage/Diário: usa paginação com `getHistory`.
+- HistoryPage/Evolução global: carrega uma página recente e permite carregar mais histórico sob demanda.
+- ProfilePage: calcula estatísticas e conquistas com uma janela recente grande.
+
+## Próxima evolução
+
+A próxima etapa profissional é criar `user_stats/{userId}` e atualizar esses agregados quando uma sessão é finalizada. Com isso, totais vitalícios, streaks e conquistas podem ser exibidos sem buscar centenas de documentos no cliente.

--- a/src/components/history/HistoryAnalyticsSection.jsx
+++ b/src/components/history/HistoryAnalyticsSection.jsx
@@ -23,7 +23,11 @@ export function HistoryAnalyticsSection({
     onGlobalSearchChange,
     allUserExercises = [],
     selectedGlobalExercises = [],
-    toggleGlobalExercise
+    toggleGlobalExercise,
+    globalHistorySessionCount = 0,
+    hasMoreGlobalHistory = false,
+    loadingMoreGlobalHistory = false,
+    onLoadMoreGlobalHistory
 }) {
     // Filtrar sugestões baseadas no termo digitado
     const suggestedExercises = React.useMemo(() => {
@@ -121,6 +125,12 @@ export function HistoryAnalyticsSection({
                                     <p className="text-[10px] text-slate-500 ml-1 mt-1">
                                         Digite para buscar. Selecione abaixo as variações que deseja agrupar no gráfico.
                                     </p>
+                                    {globalHistorySessionCount > 0 && (
+                                        <p className="text-[10px] text-slate-500 ml-1">
+                                            Analisando {globalHistorySessionCount} sessões recentes
+                                            {hasMoreGlobalHistory ? '. Carregue mais para ampliar a busca.' : '.'}
+                                        </p>
+                                    )}
                                 </div>
 
                                 {/* Chips de Seleção */}
@@ -210,7 +220,9 @@ export function HistoryAnalyticsSection({
 
                             {/* Lista Detalhada */}
                             <div className="space-y-2">
-                                <h3 className="font-bold text-slate-400 uppercase tracking-wide text-xs pl-1">Histórico Completo</h3>
+                                <h3 className="font-bold text-slate-400 uppercase tracking-wide text-xs pl-1">
+                                    {searchMode === 'global' ? 'Registros Encontrados' : 'Histórico Completo'}
+                                </h3>
                                 <div className="space-y-2">
                                     {historyRows.map(row => (
                                         <div key={row.id} className="flex items-center justify-between p-4 bg-slate-900/30 border border-slate-800 rounded-xl">
@@ -228,6 +240,18 @@ export function HistoryAnalyticsSection({
                                         </div>
                                     ))}
                                 </div>
+                                {searchMode === 'global' && hasMoreGlobalHistory && (
+                                    <div className="pt-3 text-center">
+                                        <button
+                                            type="button"
+                                            onClick={onLoadMoreGlobalHistory}
+                                            disabled={loadingMoreGlobalHistory}
+                                            className="px-4 py-2 rounded-xl border border-slate-700 bg-slate-900/70 text-xs font-bold uppercase tracking-wide text-slate-300 hover:border-cyan-500/60 hover:text-cyan-300 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                                        >
+                                            {loadingMoreGlobalHistory ? 'Carregando...' : 'Carregar mais histórico'}
+                                        </button>
+                                    </div>
+                                )}
                             </div>
                         </>
                     ) : (

--- a/src/pages/HistoryPage.jsx
+++ b/src/pages/HistoryPage.jsx
@@ -7,12 +7,26 @@ import {
     Activity
 } from 'lucide-react';
 import { PremiumCard } from '../components/design-system/PremiumCard';
-import { workoutService } from '../services/workoutService';
+import { SESSION_LIMITS, workoutService } from '../services/workoutService';
 import { getJournalWindowConfig, recordJournalRenderMetric } from '../utils/performanceTuning';
 
 import { Button } from '../components/design-system/Button';
 const HistoryAnalyticsSection = React.lazy(() => import('../components/history/HistoryAnalyticsSection').then(module => ({ default: module.HistoryAnalyticsSection })));
 const WorkoutDetailsModal = React.lazy(() => import('../components/history/WorkoutDetailsModal').then(module => ({ default: module.WorkoutDetailsModal })));
+const TEMPLATE_ANALYTICS_PAGE_SIZE = 100;
+
+function extractExerciseNamesFromSessions(docs) {
+    const uniqueNames = new Set();
+    docs.forEach(data => {
+        const results = data.results || data.exercises || [];
+        if (Array.isArray(results)) {
+            results.forEach(e => { if (e.name) uniqueNames.add(e.name); });
+        } else {
+            Object.keys(results).forEach(key => uniqueNames.add(key));
+        }
+    });
+    return Array.from(uniqueNames).sort();
+}
 
 function HistoryPage({ user, isEmbedded = false }) {
     const navigate = useNavigate();
@@ -52,6 +66,9 @@ function HistoryPage({ user, isEmbedded = false }) {
     const [selectedGlobalExercises, setSelectedGlobalExercises] = useState([]);
     const [allUserExercises, setAllUserExercises] = useState([]);
     const [globalSessionsCache, setGlobalSessionsCache] = useState(null);
+    const globalSessionsLastDocRef = useRef(null);
+    const [hasMoreGlobalSessions, setHasMoreGlobalSessions] = useState(false);
+    const [loadingMoreGlobalSessions, setLoadingMoreGlobalSessions] = useState(false);
 
     const toggleGlobalExercise = (exName) => {
         setSelectedGlobalExercises(prev => 
@@ -66,6 +83,39 @@ function HistoryPage({ user, isEmbedded = false }) {
     const [chartRange, setChartRange] = useState('3M');
 
     const hasAppliedInitialFilters = useRef(false);
+
+    const loadMoreGlobalSessions = React.useCallback(async () => {
+        if (!user || loadingMoreGlobalSessions || !hasMoreGlobalSessions) return;
+
+        setLoadingMoreGlobalSessions(true);
+        try {
+            const result = await workoutService.getHistory(
+                user.uid,
+                null,
+                globalSessionsLastDocRef.current,
+                SESSION_LIMITS.analyticsGlobalPage
+            );
+
+            globalSessionsLastDocRef.current = result.lastDoc;
+            setHasMoreGlobalSessions(result.hasMore);
+            setGlobalSessionsCache(prev => {
+                const merged = [...(prev || []), ...result.data];
+                setAllUserExercises(extractExerciseNamesFromSessions(merged));
+                return merged;
+            });
+        } catch (err) {
+            console.error("Error loading more global history:", err);
+        } finally {
+            setLoadingMoreGlobalSessions(false);
+        }
+    }, [hasMoreGlobalSessions, loadingMoreGlobalSessions, user]);
+
+    useEffect(() => {
+        setGlobalSessionsCache(null);
+        setAllUserExercises([]);
+        setHasMoreGlobalSessions(false);
+        globalSessionsLastDocRef.current = null;
+    }, [user?.uid]);
 
     // Layout de Filtro Inicial
     useEffect(() => {
@@ -315,10 +365,10 @@ function HistoryPage({ user, isEmbedded = false }) {
             }
 
             if (searchMode === 'global' && selectedGlobalExercises.length === 0 && (!globalSearchTerm || globalSearchTerm.length < 2)) {
-                // If nothing is selected and no search term, don't fetch chart data
-                // But we still need to fetch the session cache if it's empty so the search bar can work!
-                // Wait, if we return early, we never populate allUserExercises.
-                // We should only return early from drawing the chart, but we must populate the cache.
+                setHistoryRows([]);
+                setPrRows([]);
+                setChartData([]);
+                return;
             }
 
             setLoadingHistory(true);
@@ -329,22 +379,20 @@ function HistoryPage({ user, isEmbedded = false }) {
                     if (globalSessionsCache) {
                         docs = globalSessionsCache;
                     } else {
-                        docs = await workoutService.getAllSessions(user.uid);
+                        const result = await workoutService.getHistory(
+                            user.uid,
+                            null,
+                            null,
+                            SESSION_LIMITS.analyticsGlobalPage
+                        );
+                        docs = result.data;
                         setGlobalSessionsCache(docs);
-
-                        const uniqueNames = new Set();
-                        docs.forEach(data => {
-                            const results = data.results || data.exercises || [];
-                            if (Array.isArray(results)) {
-                                results.forEach(e => { if (e.name) uniqueNames.add(e.name); });
-                            } else {
-                                Object.keys(results).forEach(key => uniqueNames.add(key));
-                            }
-                        });
-                        setAllUserExercises(Array.from(uniqueNames).sort());
+                        setAllUserExercises(extractExerciseNamesFromSessions(docs));
+                        globalSessionsLastDocRef.current = result.lastDoc;
+                        setHasMoreGlobalSessions(result.hasMore);
                     }
                 } else {
-                    const result = await workoutService.getHistory(user.uid, selectedTemplate, null, 100);
+                    const result = await workoutService.getHistory(user.uid, selectedTemplate, null, TEMPLATE_ANALYTICS_PAGE_SIZE);
                     docs = result.data;
                 }
 
@@ -654,6 +702,10 @@ function HistoryPage({ user, isEmbedded = false }) {
                             allUserExercises={allUserExercises}
                             selectedGlobalExercises={selectedGlobalExercises}
                             toggleGlobalExercise={toggleGlobalExercise}
+                            globalHistorySessionCount={globalSessionsCache?.length || 0}
+                            hasMoreGlobalHistory={hasMoreGlobalSessions}
+                            loadingMoreGlobalHistory={loadingMoreGlobalSessions}
+                            onLoadMoreGlobalHistory={loadMoreGlobalSessions}
                         />
                     </React.Suspense>
                 )}

--- a/src/pages/HistoryPage.test.jsx
+++ b/src/pages/HistoryPage.test.jsx
@@ -11,6 +11,9 @@ vi.mock('react-router-dom', () => ({
 }));
 
 vi.mock('../services/workoutService', () => ({
+    SESSION_LIMITS: {
+        analyticsGlobalPage: 120
+    },
     workoutService: {
         getHistory: vi.fn(),
         getTemplates: vi.fn()

--- a/src/pages/HomeDashboard.jsx
+++ b/src/pages/HomeDashboard.jsx
@@ -32,7 +32,7 @@ import { StreakWeeklyGoalHybrid } from '../StreakWeeklyGoalHybrid';
 import { getFirestoreDeps } from '../firebaseDb';
 import { ShareableQuoteCard } from '../components/sharing/ShareableQuoteCard';
 import { calculateWeeklyStats } from '../utils/workoutStats';
-import { workoutService } from '../services/workoutService';
+import { SESSION_LIMITS, workoutService } from '../services/workoutService';
 import { safeGetJSON, safeSetJSON, safeRemoveItem } from '../utils/storage';
 import { achievementsCatalog } from '../data/achievementsCatalog';
 import { evaluateAchievements, calculateStats } from '../utils/evaluateAchievements';
@@ -375,9 +375,9 @@ export function HomeDashboard({
                 setLoadingTemplates(false);
             });
 
-            // B. Inscrever-se no Histórico (Sessões)
+            // B. Inscrever-se apenas no histórico recente para manter o dashboard leve.
             try {
-                unsubscribeSessions = await workoutService.subscribeToSessions(user.uid, (data) => {
+                unsubscribeSessions = await workoutService.subscribeToRecentSessions(user.uid, (data) => {
                     const sessions = data.map(d => {
                         let dateObj = new Date();
                         // Lógica defensiva para parse de data
@@ -420,7 +420,7 @@ export function HomeDashboard({
                         setNextAchievement(null);
                     }
                     setLoadingStats(false);
-                });
+                }, SESSION_LIMITS.dashboardRecent);
             } catch (err) {
                 console.error("Subscription Error:", err);
             }

--- a/src/pages/HomeDashboard.test.jsx
+++ b/src/pages/HomeDashboard.test.jsx
@@ -10,9 +10,12 @@ vi.mock('../StreakWeeklyGoalHybrid', () => ({
 }));
 
 vi.mock('../services/workoutService', () => ({
+    SESSION_LIMITS: {
+        dashboardRecent: 120
+    },
     workoutService: {
         subscribeToTemplates: vi.fn(),
-        subscribeToSessions: vi.fn()
+        subscribeToRecentSessions: vi.fn()
     }
 }));
 
@@ -51,7 +54,7 @@ describe('HomeDashboard', () => {
             cb([{ id: 't1', name: 'Treino A', exercises: [{ name: 'Supino' }] }]);
             return vi.fn();
         });
-        workoutService.subscribeToSessions.mockImplementation((_uid, cb) => {
+        workoutService.subscribeToRecentSessions.mockImplementation((_uid, cb) => {
             cb([
                 {
                     id: 's1',

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -25,6 +25,7 @@ import { achievementsCatalog } from '../data/achievementsCatalog';
 import { evaluateAchievements, calculateStats, evaluateHistory } from '../utils/evaluateAchievements';
 import { calculateWeeklyStats } from '../utils/workoutStats';
 import { Button } from '../components/design-system/Button';
+import { SESSION_LIMITS, workoutService } from '../services/workoutService';
 const AchievementUnlockedModal = React.lazy(() => import('../components/achievements/AchievementUnlockedModal').then(module => ({ default: module.AchievementUnlockedModal })));
 
 
@@ -165,9 +166,8 @@ export default function ProfilePage({ user, onLogout, onNavigateToHistory, onNav
         async function loadAchievementsData() {
             setLoadingAchievements(true);
             try {
-                // 1. Buscar todas as sessões de treino (Usando Serviço)
-                const { workoutService } = await import('../services/workoutService');
-                const sessions = await workoutService.getAllSessions(user.uid);
+                // 1. Buscar uma janela recente e limitada para evitar leituras completas do histórico.
+                const sessions = await workoutService.getRecentSessions(user.uid, SESSION_LIMITS.profileStats);
 
                 // 2. Calcular Estatísticas
                 const computedStats = calculateStats(sessions);

--- a/src/pages/ProfilePage.test.jsx
+++ b/src/pages/ProfilePage.test.jsx
@@ -10,7 +10,14 @@ vi.mock('../AuthContext');
 vi.mock('../services/userService');
 
 // Mock workoutService
-vi.mock('../services/workoutService');
+vi.mock('../services/workoutService', () => ({
+    SESSION_LIMITS: {
+        profileStats: 300
+    },
+    workoutService: {
+        getRecentSessions: vi.fn()
+    }
+}));
 
 // Mock react-router-dom
 const navigateMock = vi.fn();
@@ -71,7 +78,7 @@ describe('ProfilePage Integration', () => {
         userService.linkTrainer.mockResolvedValue({});
 
         // Mock workoutService sessions return
-        workoutService.getAllSessions.mockResolvedValue(mockSessions);
+        workoutService.getRecentSessions.mockResolvedValue(mockSessions);
     });
 
     afterEach(() => {
@@ -103,7 +110,7 @@ describe('ProfilePage Integration', () => {
             // However, '2' might be ambiguous (level, other nums). 
             // Let's look for "Treinos" label and nearby value if possible, or just the number if unique enough context.
             // Best is to assert that workoutService was called.
-            expect(workoutService.getAllSessions).toHaveBeenCalledWith('user123');
+            expect(workoutService.getRecentSessions).toHaveBeenCalledWith('user123', 300);
         });
 
         // Use visible text assertions for stats if possible, or data-testid in future.

--- a/src/services/workoutService.js
+++ b/src/services/workoutService.js
@@ -2,6 +2,12 @@ import { getFirestoreDeps } from '../firebaseDb';
 
 const TEMPLATES_COLLECTION = 'workout_templates';
 const SESSIONS_COLLECTION = 'workout_sessions';
+export const SESSION_LIMITS = {
+    dashboardRecent: 120,
+    analyticsGlobalPage: 120,
+    profileStats: 300,
+    achievementCheck: 300
+};
 
 let sonnerPromise;
 async function showToastError(message) {
@@ -23,6 +29,10 @@ let templatesCache = {
     timestamp: 0
 };
 const CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
+
+function mapSessionDoc(doc) {
+    return { id: doc.id, ...doc.data() };
+}
 
 export const workoutService = {
     /**
@@ -216,7 +226,7 @@ export const workoutService = {
             const q = query(sessionsRef, ...constraints);
             const snap = await getDocs(q);
 
-            const data = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+            const data = snap.docs.map(mapSessionDoc);
             const newLastDoc = snap.docs[snap.docs.length - 1];
 
             return {
@@ -239,6 +249,28 @@ export const workoutService = {
     },
 
     /**
+     * Busca as sessões concluídas mais recentes com limite explícito.
+     * Use este método para dashboards, estatísticas recentes e telas que não precisam
+     * materializar todo o histórico do usuário.
+     * @param {string} userId
+     * @param {number} limitCount
+     * @returns {Promise<Array>}
+     */
+    async getRecentSessions(userId, limitCount = SESSION_LIMITS.dashboardRecent) {
+        const { db, collection, query, where, orderBy, limit, getDocs } = await getFirestoreDeps();
+        const safeLimit = Math.max(1, Math.min(Number(limitCount) || SESSION_LIMITS.dashboardRecent, 500));
+        const sessionsRef = collection(db, SESSIONS_COLLECTION);
+        const q = query(
+            sessionsRef,
+            where('userId', '==', userId),
+            orderBy('completedAt', 'desc'),
+            limit(safeLimit)
+        );
+        const snap = await getDocs(q);
+        return snap.docs.map(mapSessionDoc);
+    },
+
+    /**
      * Buscar todas as sessões para análise (sem paginação)
      * @param {string} userId 
      * @returns {Promise<Array>}
@@ -253,6 +285,32 @@ export const workoutService = {
         );
         const snap = await getDocs(q);
         return snap.docs.map(d => ({ id: d.id, ...d.data() }));
+    },
+
+    /**
+     * Inscrever-se nas sessões recentes do usuário.
+     * Mantém o dashboard em tempo real sem abrir stream sobre todo o histórico.
+     * @param {string} userId
+     * @param {function} callback
+     * @param {number} limitCount
+     * @returns {function} unsubscribe
+     */
+    async subscribeToRecentSessions(userId, callback, limitCount = SESSION_LIMITS.dashboardRecent) {
+        const { db, collection, query, where, orderBy, limit, onSnapshot } = await getFirestoreDeps();
+        const safeLimit = Math.max(1, Math.min(Number(limitCount) || SESSION_LIMITS.dashboardRecent, 500));
+        const sessionsRef = collection(db, SESSIONS_COLLECTION);
+        const q = query(
+            sessionsRef,
+            where('userId', '==', userId),
+            orderBy('completedAt', 'desc'),
+            limit(safeLimit)
+        );
+        return onSnapshot(q, (snapshot) => {
+            const sessions = snapshot.docs.map(mapSessionDoc);
+            callback(sessions);
+        }, (error) => {
+            console.error("Error subscribing to recent sessions:", error);
+        });
     },
 
     /**

--- a/src/services/workoutService.test.js
+++ b/src/services/workoutService.test.js
@@ -243,4 +243,78 @@ describe('workoutService', () => {
             }
         });
     });
+
+    describe('getRecentSessions', () => {
+        it('fetches recent sessions ordered by completion date with an explicit limit', async () => {
+            const mockDate = { toDate: () => new Date('2024-01-02') };
+            getDocs.mockResolvedValue({
+                docs: [
+                    {
+                        id: 'session-1',
+                        data: () => ({
+                            userId: mockUserId,
+                            completedAt: mockDate,
+                            workoutName: 'Treino A'
+                        })
+                    }
+                ]
+            });
+
+            const result = await workoutService.getRecentSessions(mockUserId, 25);
+
+            expect(collection).toHaveBeenCalledWith(expect.anything(), 'workout_sessions');
+            expect(where).toHaveBeenCalledWith('userId', '==', mockUserId);
+            expect(orderBy).toHaveBeenCalledWith('completedAt', 'desc');
+            expect(limit).toHaveBeenCalledWith(25);
+            expect(result).toEqual([
+                {
+                    id: 'session-1',
+                    userId: mockUserId,
+                    completedAt: mockDate,
+                    workoutName: 'Treino A'
+                }
+            ]);
+        });
+
+        it('clamps very large recent session limits', async () => {
+            getDocs.mockResolvedValue({ docs: [] });
+
+            await workoutService.getRecentSessions(mockUserId, 5000);
+
+            expect(limit).toHaveBeenCalledWith(500);
+        });
+    });
+
+    describe('subscribeToRecentSessions', () => {
+        it('subscribes only to a bounded recent session window', async () => {
+            const onUpdate = vi.fn();
+            const unsubscribe = vi.fn();
+            let snapshotCallback;
+
+            onSnapshot.mockImplementation((_q, cb) => {
+                snapshotCallback = cb;
+                return unsubscribe;
+            });
+
+            const result = await workoutService.subscribeToRecentSessions(mockUserId, onUpdate, 30);
+
+            expect(result).toBe(unsubscribe);
+            expect(where).toHaveBeenCalledWith('userId', '==', mockUserId);
+            expect(orderBy).toHaveBeenCalledWith('completedAt', 'desc');
+            expect(limit).toHaveBeenCalledWith(30);
+
+            snapshotCallback({
+                docs: [
+                    {
+                        id: 'session-2',
+                        data: () => ({ userId: mockUserId, workoutName: 'Treino B' })
+                    }
+                ]
+            });
+
+            expect(onUpdate).toHaveBeenCalledWith([
+                { id: 'session-2', userId: mockUserId, workoutName: 'Treino B' }
+            ]);
+        });
+    });
 });

--- a/src/utils/evaluateAchievements.js
+++ b/src/utils/evaluateAchievements.js
@@ -384,9 +384,11 @@ export async function checkNewAchievements(userId, currentSessionData, workoutSe
     if (!userId || !workoutServiceInstance) return [];
 
     try {
-        // 1. Get all history (including the one just saved, hopefully, or we assume consistent read)
-        // Note: Firestore might have latency. It's safer to fetch history and append current manually if missing.
-        const allSessions = await workoutServiceInstance.getAllSessions(userId);
+        // 1. Prefer a bounded recent window to keep post-workout evaluation fast.
+        // A future user_stats aggregate can make lifetime achievements exact without full reads.
+        const allSessions = typeof workoutServiceInstance.getRecentSessions === 'function'
+            ? await workoutServiceInstance.getRecentSessions(userId, 300)
+            : await workoutServiceInstance.getAllSessions(userId);
 
         // 2. Filter out the current session to get "Previous State"
         // We identify current session by ID or exact timestamp


### PR DESCRIPTION
## O que mudou

Primeiro corte da sprint de performance/dados para reduzir leituras grandes de histórico no Firestore.

- Adiciona `SESSION_LIMITS` no `workoutService`.
- Adiciona `getRecentSessions` para leituras recentes com limite explícito.
- Adiciona `subscribeToRecentSessions` para dashboards em tempo real sem stream do histórico inteiro.
- Troca o `HomeDashboard` para assinar somente sessões recentes.
- Troca o `ProfilePage` para calcular estatísticas/conquistas sobre uma janela recente grande.
- Troca a busca global da aba Evolução para usar paginação com `getHistory` em vez de `getAllSessions`.
- Adiciona botão para carregar mais histórico na busca global quando houver mais páginas.
- Mantém `getAllSessions` apenas como compatibilidade/fallback.
- Documenta a estratégia em `docs/performance-data.md`.

## Impacto

- Reduz custo e latência do dashboard ao evitar `onSnapshot` sobre todo o histórico.
- Evita que a busca global de evolução carregue todos os treinos do usuário de uma vez.
- Dá um caminho claro para `user_stats` como próxima evolução para totais vitalícios e conquistas exatas sem leituras grandes no cliente.

## Validação local

- `npm run lint`
- `npm test -- --run` — 92 testes passando
- `npm run test:rules` — 11 testes passando
- `npm run build`
- `npm run test:coverage`
- `npm audit --omit=dev` — 0 vulnerabilidades de produção

## Observações

O build mantém o alerta conhecido de chunks grandes (`vendor-charts`, Firestore e bundle principal). Isso fica como próxima frente de performance de bundle depois deste corte de dados.