### PR TITLE
[codex] Performance, session resilience and UX baseline

### DIFF
--- a/docs/performance-data.md
+++ b/docs/performance-data.md
@@ -13,7 +13,7 @@ Este documento registra as decisões atuais para reduzir leituras grandes no Fir
 
 Os limites ficam centralizados em `SESSION_LIMITS` no `workoutService`:
 
-- `dashboardRecent`: 120 sessões recentes.
+- `dashboardRecent`: 60 sessões recentes.
 - `analyticsGlobalPage`: 120 sessões por página na busca global de evolução.
 - `profileStats`: 300 sessões recentes para perfil/conquistas.
 - `achievementCheck`: 300 sessões recentes para avaliação pós-treino.

--- a/src/components/design-system/SyncStatusBadge.jsx
+++ b/src/components/design-system/SyncStatusBadge.jsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { AlertTriangle, CheckCircle2, CloudOff, Loader2, RotateCw } from 'lucide-react';
+import { SESSION_SYNC_STATES } from '../../services/sessions/sessionRecoveryService';
+
+const statusConfig = {
+    [SESSION_SYNC_STATES.loading]: {
+        label: 'Carregando sessão',
+        icon: Loader2,
+        className: 'border-slate-700 bg-slate-900/80 text-slate-300',
+        spin: true
+    },
+    [SESSION_SYNC_STATES.active]: {
+        label: 'Sessão ativa',
+        icon: CheckCircle2,
+        className: 'border-cyan-500/30 bg-cyan-500/10 text-cyan-300'
+    },
+    [SESSION_SYNC_STATES.offline]: {
+        label: 'Salvo localmente',
+        icon: CloudOff,
+        className: 'border-amber-500/35 bg-amber-500/10 text-amber-200'
+    },
+    [SESSION_SYNC_STATES.syncing]: {
+        label: 'Sincronizando',
+        icon: RotateCw,
+        className: 'border-blue-500/35 bg-blue-500/10 text-blue-200',
+        spin: true
+    },
+    [SESSION_SYNC_STATES.saved]: {
+        label: 'Salvo agora',
+        icon: CheckCircle2,
+        className: 'border-emerald-500/35 bg-emerald-500/10 text-emerald-200'
+    },
+    [SESSION_SYNC_STATES.syncFailed]: {
+        label: 'Falha ao sincronizar',
+        icon: AlertTriangle,
+        className: 'border-red-500/35 bg-red-500/10 text-red-200'
+    },
+    [SESSION_SYNC_STATES.finishing]: {
+        label: 'Finalizando',
+        icon: Loader2,
+        className: 'border-cyan-500/35 bg-cyan-500/10 text-cyan-200',
+        spin: true
+    },
+    [SESSION_SYNC_STATES.finished]: {
+        label: 'Finalizado',
+        icon: CheckCircle2,
+        className: 'border-emerald-500/35 bg-emerald-500/10 text-emerald-200'
+    },
+    [SESSION_SYNC_STATES.discarding]: {
+        label: 'Descartando',
+        icon: Loader2,
+        className: 'border-slate-700 bg-slate-900/80 text-slate-300',
+        spin: true
+    },
+    [SESSION_SYNC_STATES.discarded]: {
+        label: 'Descartado',
+        icon: CheckCircle2,
+        className: 'border-slate-700 bg-slate-900/80 text-slate-300'
+    },
+    [SESSION_SYNC_STATES.conflict]: {
+        label: 'Recuperado do backup',
+        icon: AlertTriangle,
+        className: 'border-amber-500/35 bg-amber-500/10 text-amber-200'
+    },
+    [SESSION_SYNC_STATES.error]: {
+        label: 'Erro na sessão',
+        icon: AlertTriangle,
+        className: 'border-red-500/35 bg-red-500/10 text-red-200'
+    }
+};
+
+export function SyncStatusBadge({ status, className = '' }) {
+    const config = statusConfig[status] || statusConfig[SESSION_SYNC_STATES.active];
+    const Icon = config.icon;
+
+    return (
+        <div
+            className={`inline-flex h-8 items-center gap-2 rounded-full border px-3 text-[11px] font-bold uppercase backdrop-blur-md ${config.className} ${className}`}
+            role="status"
+            aria-live="polite"
+        >
+            <Icon size={14} className={config.spin ? 'animate-spin' : ''} />
+            <span className="whitespace-nowrap">{config.label}</span>
+        </div>
+    );
+}

--- a/src/components/execution/LinearCardCompactV2.jsx
+++ b/src/components/execution/LinearCardCompactV2.jsx
@@ -27,7 +27,8 @@ export const LinearCardCompactV2 = memo(function LinearCardCompactV2({
     weightMode = 'total',
     baseWeight,
     onUpdateSetMultiple,
-    onToggleWeightMode
+    onToggleWeightMode,
+    onValidationError
 }) {
     const completedCount = completedSets.filter(Boolean).length;
     const isExerciseFullyCompleted = completedCount === totalSets && totalSets > 0;
@@ -196,15 +197,21 @@ export const LinearCardCompactV2 = memo(function LinearCardCompactV2({
             // Validar tds os drops
             const invalid = drops.some(d => !d.weight || parseFloat(d.weight) <= 0 || !d.reps || d.reps.trim() === '');
             if (invalid) {
-                alert('Preencha os valores de peso e repetição em todas as sub-séries (drops)!');
+                onValidationError?.('Preencha peso e repetições em todas as sub-séries.');
                 return;
             }
             onCompleteSet(exerciseId, currentSet, drops[0].weight, drops[0].reps, drops[0].weightMode, drops[0].baseWeight, drops);
         } else {
             const w = (weight && parseFloat(weight) > 0) ? weight : suggestedWeight;
             const r = (actualReps && actualReps.trim() !== '') ? actualReps : suggestedReps;
-            if (!w || parseFloat(w) <= 0) { alert('Informe o peso utilizado!'); return; }
-            if (!r || r.toString().trim() === '') { alert('Informe as repetições alcançadas!'); return; }
+            if (!w || parseFloat(w) <= 0) {
+                onValidationError?.('Informe o peso utilizado.');
+                return;
+            }
+            if (!r || r.toString().trim() === '') {
+                onValidationError?.('Informe as repetições alcançadas.');
+                return;
+            }
             onCompleteSet(exerciseId, currentSet, w.toString(), r.toString(), weightMode, baseWeight);
         }
     };

--- a/src/design/tokens.js
+++ b/src/design/tokens.js
@@ -1,0 +1,42 @@
+export const designTokens = {
+    colors: {
+        surface: '#020617',
+        panel: '#0f172a',
+        border: 'rgba(148, 163, 184, 0.24)',
+        text: '#e2e8f0',
+        muted: '#94a3b8',
+        primary: '#06b6d4',
+        success: '#10b981',
+        warning: '#f59e0b',
+        danger: '#ef4444'
+    },
+    spacing: {
+        xs: '0.25rem',
+        sm: '0.5rem',
+        md: '1rem',
+        lg: '1.5rem',
+        xl: '2rem'
+    },
+    radius: {
+        sm: '0.5rem',
+        md: '0.75rem',
+        lg: '1rem',
+        xl: '1.5rem',
+        pill: '999px'
+    },
+    shadow: {
+        card: '0 20px 45px rgba(2, 6, 23, 0.35)',
+        glow: '0 0 24px rgba(6, 182, 212, 0.28)'
+    },
+    zIndex: {
+        sticky: 50,
+        modal: 200,
+        overlay: 300,
+        toast: 400
+    },
+    motion: {
+        fast: '150ms',
+        normal: '220ms',
+        slow: '360ms'
+    }
+};

--- a/src/hooks/useWorkoutSession.js
+++ b/src/hooks/useWorkoutSession.js
@@ -1,24 +1,19 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { getFirestoreDeps } from '../firebaseDb';
+import { activeSessionService } from '../services/sessions/activeSessionService';
+import {
+    chooseSessionRecoverySource,
+    createSessionBackupKey,
+    createSessionFingerprint,
+    readSessionBackup,
+    removeSessionBackup,
+    SESSION_SYNC_STATES,
+    writeSessionBackup
+} from '../services/sessions/sessionRecoveryService';
 
 // Auxiliar para gerar IDs
 function generateId() {
     return Math.random().toString(36).substr(2, 9);
-}
-
-// Ajusta o tempo decorrido somando a diferença de tempo em que o app ficou suspenso/fechado
-function getAdjustedElapsed(elapsed, savedTimestamp) {
-    if (!savedTimestamp) return elapsed;
-    const ts = typeof savedTimestamp === 'string' ? Date.parse(savedTimestamp) : Number(savedTimestamp);
-    if (isNaN(ts) || ts <= 0) return elapsed;
-    
-    const now = Date.now();
-    const diff = Math.floor((now - ts) / 1000);
-    // Ajusta apenas se a diferença for positiva e menor que 12 horas (43200 segundos)
-    if (diff > 0 && diff < 43200) {
-        return elapsed + diff;
-    }
-    return elapsed;
 }
 
 export function useWorkoutSession(workoutId, user) {
@@ -29,13 +24,13 @@ export function useWorkoutSession(workoutId, user) {
     const [saving, setSaving] = useState(false);
     const [error, setError] = useState(null);
     const [sessionVersion, setSessionVersion] = useState(0);
+    const [syncState, setSyncState] = useState(SESSION_SYNC_STATES.idle);
+    const [lastSavedAt, setLastSavedAt] = useState(null);
 
     const profileId = user?.uid;
     const lastSyncedRef = useRef('');
-    const backupKey = `workout_backup_${profileId}_${workoutId}`;
-
-    // --- BUSCA DE DADOS ---
-
+    const syncInFlightRef = useRef(false);
+    const backupKey = createSessionBackupKey(profileId, workoutId);
 
     // --- BUSCA DE DADOS ---
     useEffect(() => {
@@ -43,15 +38,14 @@ export function useWorkoutSession(workoutId, user) {
 
         async function fetchData() {
             setLoading(true);
+            setSyncState(SESSION_SYNC_STATES.loading);
             try {
                 const { db, doc, getDoc, getDocs, query, collection, where, limit, getDocFromServer } = await getFirestoreDeps();
                 let activeData = null;
 
-                // 1. Verificar Sessão Ativa (Remota) - Apenas se não descartada explicitamente (assumimos que sessionVersion > 0 significa que podemos querer dados frescos)
-                // Na verdade, verificar remotamente de forma consistente é bom, SE confiarmos que o delete funcionou.
+                // 1. Verificar sessão ativa remota.
                 try {
                     const activeRef = doc(db, 'active_workouts', profileId);
-                    // FORÇAR BUSCA NO SERVIDOR para evitar cache obsoleto após descarte
                     const activeSnap = await getDocFromServer(activeRef);
                     if (activeSnap.exists()) {
                         const data = activeSnap.data();
@@ -77,73 +71,24 @@ export function useWorkoutSession(workoutId, user) {
                 }
 
                 // 2. Verificar Backup Local
-                const savedBackup = localStorage.getItem(backupKey);
-                let localBackupData = null;
-                if (savedBackup) {
-                    try {
-                        const parsed = JSON.parse(savedBackup);
-                        if (parsed.exercises && Array.isArray(parsed.exercises)) {
-                            localBackupData = parsed;
-                        }
-                    } catch {
-                        localStorage.removeItem(backupKey);
-                    }
-                }
+                const localBackupData = readSessionBackup(backupKey);
+                const recovery = chooseSessionRecoverySource({ cloudData: activeData, localBackupData });
 
-                // Resolver conflito entre Nuvem e Local
-                // Usar o maior elapsedSeconds se ambos existirem (ajustados pelo tempo de background se aplicável)
-                if (activeData) {
-                    let cloudTimestampMs = 0;
-                    if (activeData.updatedAt) {
-                        if (typeof activeData.updatedAt.toMillis === 'function') {
-                            cloudTimestampMs = activeData.updatedAt.toMillis();
-                        } else if (typeof activeData.updatedAt.toDate === 'function') {
-                            cloudTimestampMs = activeData.updatedAt.toDate().getTime();
-                        } else if (typeof activeData.updatedAt === 'number') {
-                            cloudTimestampMs = activeData.updatedAt;
-                        } else if (activeData.updatedAt.seconds) {
-                            cloudTimestampMs = activeData.updatedAt.seconds * 1000;
-                        }
-                    }
-
-                    const cloudElapsedBase = activeData.elapsedSeconds || 0;
-                    const cloudElapsed = getAdjustedElapsed(cloudElapsedBase, cloudTimestampMs);
-
-                    const localElapsedBase = localBackupData ? (localBackupData.elapsedSeconds || 0) : 0;
-                    const localElapsed = localBackupData 
-                        ? getAdjustedElapsed(localElapsedBase, localBackupData.timestamp)
-                        : 0;
-                    
-                    const bestExercises = (localElapsed > cloudElapsed && localBackupData?.exercises) 
-                        ? localBackupData.exercises 
-                        : activeData.exercises;
-                    
-                    const bestElapsed = Math.max(cloudElapsed, localElapsed);
-
+                if (recovery) {
                     // Carregar dados do template (apenas metadados)
                     const templateDoc = await getDoc(doc(db, 'workout_templates', workoutId));
                     if (templateDoc.exists()) {
                         setTemplate({ id: templateDoc.id, ...templateDoc.data() });
                     }
 
-                    if (bestExercises) {
-                        setExercises(bestExercises);
-                        setInitialElapsed(bestElapsed);
-                        lastSyncedRef.current = JSON.stringify(bestExercises);
-                        setLoading(false);
-                        return;
-                    }
-                } else if (localBackupData) {
-                    const localElapsedBase = localBackupData.elapsedSeconds || 0;
-                    const localElapsed = getAdjustedElapsed(localElapsedBase, localBackupData.timestamp);
-
-                    setExercises(localBackupData.exercises);
-                    setInitialElapsed(localElapsed);
-
-                    const templateDoc = await getDoc(doc(db, 'workout_templates', workoutId));
-                    if (templateDoc.exists()) {
-                        setTemplate({ id: templateDoc.id, ...templateDoc.data() });
-                    }
+                    setExercises(recovery.exercises);
+                    setInitialElapsed(recovery.elapsedSeconds);
+                    lastSyncedRef.current = recovery.source === 'cloud'
+                        ? createSessionFingerprint(recovery.exercises, recovery.elapsedSeconds)
+                        : '';
+                    setSyncState(recovery.conflict
+                        ? SESSION_SYNC_STATES.conflict
+                        : SESSION_SYNC_STATES.active);
                     setLoading(false);
                     return;
                 }
@@ -163,8 +108,7 @@ export function useWorkoutSession(workoutId, user) {
                     const tmplData = templateDoc.data();
                     setTemplate({ id: templateDoc.id, ...tmplData });
 
-                    // ... (Lógica de Normalização e Histórico) ...
-                    // buscar Histórico
+                    // Buscar último histórico do treino para preencher sugestões de carga/reps.
                     let lastSessionExercises = [];
                     try {
                         const historyQuery = query(
@@ -233,13 +177,14 @@ export function useWorkoutSession(workoutId, user) {
                             };
                         });
                         setExercises(mapped);
-                        // Limpar tempo decorrido para nova sessão
                         setInitialElapsed(0);
+                        setSyncState(SESSION_SYNC_STATES.active);
                     }
                 }
             } catch (err) {
                 console.error(err);
                 setError("Falha ao carregar treino.");
+                setSyncState(SESSION_SYNC_STATES.error);
             } finally {
                 setLoading(false);
             }
@@ -248,30 +193,28 @@ export function useWorkoutSession(workoutId, user) {
         fetchData();
     }, [workoutId, profileId, backupKey, sessionVersion]);
 
-    // ... SYNC ...
+    useEffect(() => {
+        if (typeof window === 'undefined') return undefined;
 
-    // ... ACTIONS ...
+        const updateOnlineState = () => {
+            if (!navigator.onLine) {
+                setSyncState(SESSION_SYNC_STATES.offline);
+            } else {
+                setSyncState((current) => (
+                    current === SESSION_SYNC_STATES.offline ? SESSION_SYNC_STATES.saved : current
+                ));
+            }
+        };
 
+        window.addEventListener('online', updateOnlineState);
+        window.addEventListener('offline', updateOnlineState);
+        updateOnlineState();
 
-
-    // Re-declare other functions here to be safe or ensure they are present
-    // But since we are replacing a chunk, we just need to match correctly.
-
-    // The previous `useEffect` block in file was ~140 lines.
-    // The `discardSession` was at the end.
-    // We are replacing from start of `useEffect` to the end of `discardSession`?
-    // No, `useEffect` starts at line 24. `discardSession` ends at 312.
-    // That's too big of a chunk to replace safely without context.
-
-    // Let's replace smaller chunks.
-    // Chunk 1: Add sessionVersion state.
-    // Chunk 2: Update useEffect dependencies.
-    // Chunk 3: Update discardSession.
-
-    // This is safer.
-
-    // ABORTING THIS REPLACE to replace with smaller sequential edits.
-
+        return () => {
+            window.removeEventListener('online', updateOnlineState);
+            window.removeEventListener('offline', updateOnlineState);
+        };
+    }, []);
 
     // --- SINCRONIZAÇÃO ---
     const syncSession = useCallback((currentExercises, currentElapsed) => {
@@ -283,21 +226,40 @@ export function useWorkoutSession(workoutId, user) {
             elapsedSeconds: currentElapsed,
             exercises: currentExercises
         };
-        localStorage.setItem(backupKey, JSON.stringify(backupData));
+        writeSessionBackup(backupKey, backupData);
 
         // Sincronização na Nuvem
-        const currentString = JSON.stringify(currentExercises);
-        if (profileId && currentString !== lastSyncedRef.current) {
-            import('../services/userService')
-                .then(({ userService }) => userService.updateActiveSession(profileId, {
+        const currentFingerprint = createSessionFingerprint(currentExercises, currentElapsed);
+        if (!navigator.onLine) {
+            setSyncState(SESSION_SYNC_STATES.offline);
+            return;
+        }
+
+        if (
+            profileId &&
+            currentFingerprint !== lastSyncedRef.current &&
+            !syncInFlightRef.current
+        ) {
+            syncInFlightRef.current = true;
+            setSyncState(SESSION_SYNC_STATES.syncing);
+            activeSessionService
+                .update(profileId, {
                     templateId: workoutId,
                     elapsedSeconds: currentElapsed,
                     exercises: currentExercises
-                }))
-                .then(() => {
-                    lastSyncedRef.current = currentString;
                 })
-                .catch(console.error);
+                .then(() => {
+                    lastSyncedRef.current = currentFingerprint;
+                    setLastSavedAt(new Date());
+                    setSyncState(SESSION_SYNC_STATES.saved);
+                })
+                .catch((err) => {
+                    console.error(err);
+                    setSyncState(SESSION_SYNC_STATES.syncFailed);
+                })
+                .finally(() => {
+                    syncInFlightRef.current = false;
+                });
         }
     }, [backupKey, profileId, workoutId]);
 
@@ -405,6 +367,7 @@ export function useWorkoutSession(workoutId, user) {
 
     const finishSession = async (finalElapsed) => {
         setSaving(true);
+        setSyncState(SESSION_SYNC_STATES.finishing);
         try {
             const { db, collection, addDoc, serverTimestamp, doc, setDoc } = await getFirestoreDeps();
             const minutes = Math.floor(finalElapsed / 60);
@@ -438,20 +401,21 @@ export function useWorkoutSession(workoutId, user) {
             });
 
             // Limpeza
-            localStorage.removeItem(backupKey);
+            removeSessionBackup(backupKey);
             if (profileId) {
-                const { userService } = await import('../services/userService');
-                await userService.deleteActiveSession(profileId);
+                await activeSessionService.remove(profileId);
             }
 
             // Atualizar Metadados do Template
             const templateRef = doc(db, 'workout_templates', workoutId);
             await setDoc(templateRef, { lastPerformed: serverTimestamp() }, { merge: true });
 
+            setSyncState(SESSION_SYNC_STATES.finished);
             return true; // Sucesso
         } catch (e) {
             console.error(e);
             setError('Erro ao salvar treino.');
+            setSyncState(SESSION_SYNC_STATES.syncFailed);
             return false;
         } finally {
             setSaving(false);
@@ -460,12 +424,12 @@ export function useWorkoutSession(workoutId, user) {
 
     const discardSession = useCallback(async () => {
         setLoading(true);
+        setSyncState(SESSION_SYNC_STATES.discarding);
         try {
             // Limpeza
-            localStorage.removeItem(backupKey);
+            removeSessionBackup(backupKey);
             if (profileId) {
-                const { userService } = await import('../services/userService');
-                await userService.deleteActiveSession(profileId);
+                await activeSessionService.remove(profileId);
             }
 
             // Aguardar um pouco para garantir propagação
@@ -473,10 +437,15 @@ export function useWorkoutSession(workoutId, user) {
 
             // Acionar nova busca
             setSessionVersion(v => v + 1);
+            setSyncState(SESSION_SYNC_STATES.discarded);
+            return true;
         } catch (e) {
             console.error("Error discarding session:", e);
-            // Fallback
-            window.location.reload();
+            setError('Erro ao descartar treino. Seu backup local foi mantido.');
+            setSyncState(SESSION_SYNC_STATES.syncFailed);
+            return false;
+        } finally {
+            setLoading(false);
         }
     }, [backupKey, profileId]);
 
@@ -485,6 +454,8 @@ export function useWorkoutSession(workoutId, user) {
         saving,
         error,
         setError,
+        syncState,
+        lastSavedAt,
         template,
         exercises,
         initialElapsed,

--- a/src/pages/CreateWorkoutPage.jsx
+++ b/src/pages/CreateWorkoutPage.jsx
@@ -8,6 +8,7 @@ import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { getFirestoreDeps } from '../firebaseDb';
 import { Trash2, Plus, ChevronLeft, GripVertical, X } from 'lucide-react';
 import { Button } from '../components/design-system/Button';
+import { toast } from 'sonner';
 
 const muscleGroups = [
     'Peito', 'Costas', 'Ombros', 'Bíceps', 'Tríceps',
@@ -185,6 +186,7 @@ export default function CreateWorkoutPage({ user }) {
 
     async function handleSave() {
         if (!workoutName || exercises.length === 0) {
+            toast.error("Informe um nome e adicione pelo menos um exercício.");
             return;
         }
 
@@ -219,7 +221,7 @@ export default function CreateWorkoutPage({ user }) {
             onBack();
         } catch (err) {
             console.error(err);
-            alert("Erro ao salvar treino.");
+            toast.error("Erro ao salvar treino.");
         } finally {
             setLoading(false);
         }

--- a/src/pages/HomeDashboard.jsx
+++ b/src/pages/HomeDashboard.jsx
@@ -86,6 +86,19 @@ const MOTIVATIONAL_QUOTES = [
 
 const HOME_DASHBOARD_CACHE_TTL_MS = 30 * 60 * 1000;
 
+let toastPromise;
+async function showToastError(message) {
+    try {
+        if (!toastPromise) {
+            toastPromise = import('sonner');
+        }
+        const { toast } = await toastPromise;
+        toast.error(message);
+    } catch {
+        // Evita que falhas de UI escondam o erro original.
+    }
+}
+
 function getHomeDashboardCacheKey(userId) {
     return `home_dashboard_snapshot_v${HOME_DASHBOARD_CACHE_VERSION}_${userId}`;
 }
@@ -217,12 +230,12 @@ export function HomeDashboard({
     const handleShareQuote = async () => {
         if (sharingQuote) return;
         if (!shareQuoteRef.current) {
-            alert("Card de compartilhamento indisponível.");
+            await showToastError("Card de compartilhamento indisponível.");
             return;
         }
 
         if (!window.isSecureContext) {
-            alert("O compartilhamento requer conexão segura (HTTPS).\n\nSe você está testando localmente via IP, use 'localhost' ou configure SSL.");
+            await showToastError("O compartilhamento requer conexão segura. Use HTTPS ou localhost.");
             return;
         }
 
@@ -280,7 +293,7 @@ export function HomeDashboard({
             URL.revokeObjectURL(blobUrl);
         } catch (err) {
             console.error("Error sharing:", err);
-            alert("Erro ao gerar imagem de compartilhamento.");
+            await showToastError("Erro ao gerar imagem de compartilhamento.");
         } finally {
             setSharingQuote(false);
         }
@@ -408,10 +421,15 @@ export function HomeDashboard({
             }
 
             // A. Inscrever-se em Treinos (Templates)
-            unsubscribeTemplates = await workoutService.subscribeToTemplates(user.uid, (data) => {
-                setTemplates(data || []);
+            try {
+                unsubscribeTemplates = await workoutService.subscribeToTemplates(user.uid, (data) => {
+                    setTemplates(data || []);
+                    setLoadingTemplates(false);
+                });
+            } catch (err) {
+                console.error("Template subscription error:", err);
                 setLoadingTemplates(false);
-            });
+            }
 
             // B. Agregado server-side: totais, streaks e conquistas sem leitura vitalícia no cliente.
             try {
@@ -461,6 +479,9 @@ export function HomeDashboard({
                 }, SESSION_LIMITS.dashboardRecent);
             } catch (err) {
                 console.error("Subscription Error:", err);
+                publishStats();
+                publishNextAchievement();
+                setLoadingStats(false);
             }
         }
 

--- a/src/pages/HomeDashboard.test.jsx
+++ b/src/pages/HomeDashboard.test.jsx
@@ -12,7 +12,7 @@ vi.mock('../StreakWeeklyGoalHybrid', () => ({
 
 vi.mock('../services/workoutService', () => ({
     SESSION_LIMITS: {
-        dashboardRecent: 120
+        dashboardRecent: 60
     },
     workoutService: {
         subscribeToTemplates: vi.fn(),

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -49,15 +49,15 @@ export default function ProfilePage({ user, onLogout, onNavigateToHistory, onNav
         try {
             const { userService } = await import('../services/userService');
             await userService.linkTrainer(user.uid, inviteCode);
-            alert("Personal vinculado com sucesso!");
+            toast.success("Personal vinculado com sucesso!");
             setShowLinkTrainer(false);
             setInviteCode('');
         } catch (err) {
             console.error(err);
-            if (err.message === "PERSONAL_NOT_FOUND") alert("Convite inválido ou expirado.");
-            else if (err.message === "ALREADY_LINKED") alert("Você já está vinculado a este personal.");
-            else if (err.message === "LINK_TRAINER_FAILED") alert("Não foi possível vincular. Verifique o código ou se o vínculo já existe.");
-            else alert("Erro ao vincular.");
+            if (err.message === "PERSONAL_NOT_FOUND") toast.error("Convite inválido ou expirado.");
+            else if (err.message === "ALREADY_LINKED") toast.error("Você já está vinculado a este personal.");
+            else if (err.message === "LINK_TRAINER_FAILED") toast.error("Não foi possível vincular. Verifique o código ou se o vínculo já existe.");
+            else toast.error("Erro ao vincular.");
         } finally {
             setLinking(false);
         }
@@ -236,7 +236,7 @@ export default function ProfilePage({ user, onLogout, onNavigateToHistory, onNav
         // Validação de Email
         const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
         if (!emailRegex.test(profile.email)) {
-            alert("Por favor, insira um email válido.");
+            toast.error("Por favor, insira um email válido.");
             return;
         }
 
@@ -248,9 +248,10 @@ export default function ProfilePage({ user, onLogout, onNavigateToHistory, onNav
                 updatedAt: new Date().toISOString()
             });
             setShowEditModal(false);
+            toast.success("Perfil atualizado.");
         } catch (err) {
             console.error("Error saving profile:", err);
-            alert("Erro ao salvar perfil.");
+            toast.error("Erro ao salvar perfil.");
         } finally {
             setSaving(false);
         }

--- a/src/pages/WorkoutExecutionPage.jsx
+++ b/src/pages/WorkoutExecutionPage.jsx
@@ -29,6 +29,7 @@ import MethodModal from '../MethodModal';
 import { LinearCardCompactV2 } from '../components/execution/LinearCardCompactV2';
 import { Toast } from '../components/design-system/Toast';
 import { Skeleton } from '../components/design-system/Skeleton';
+import { SyncStatusBadge } from '../components/design-system/SyncStatusBadge';
 
 // --- HOOKS PERSONALIZADOS ---
 import { useWorkoutTimer } from '../hooks/useWorkoutTimer';
@@ -145,6 +146,7 @@ export function WorkoutExecutionPage({ user }) {
         saving,
         error,
         setError,
+        syncState,
         template,
         exercises,
         initialElapsed,
@@ -343,12 +345,16 @@ export function WorkoutExecutionPage({ user }) {
 
     const confirmDiscard = async () => {
         setIsFinished(true); // Parar sincronização
-        await discardSession();
-        window.location.href = "/"; // Forçar navegação para home
+        const discarded = await discardSession();
+        if (discarded !== false) {
+            onFinish();
+            return;
+        }
+        setIsFinished(false);
+        setShowCancelModal(false);
     };
 
     const handleFinishWorkout = async () => {
-        console.log("DEBUG: handleFinishWorkout started");
         setIsFinishingSession(true);
 
         setFrozenSession({
@@ -358,7 +364,6 @@ export function WorkoutExecutionPage({ user }) {
 
         setIsFinished(true); // Parar sincronização imediatamente
         const success = await finishSession(elapsedSeconds);
-        console.log("DEBUG: finishSession result:", success);
         
         if (success) {
             const { default: confetti } = await import('canvas-confetti');
@@ -369,7 +374,6 @@ export function WorkoutExecutionPage({ user }) {
             });
 
             if (user) {
-                console.log("DEBUG: Checking achievements for user", user.uid);
                 const sessionPayload = {
                     id: 'temp_current',
                     completedAt: new Date(),
@@ -388,7 +392,7 @@ export function WorkoutExecutionPage({ user }) {
                         setShowFinishModal(true);
                     }
                 } catch (err) {
-                    console.error("DEBUG: checkNewAchievements error", err);
+                    console.error("checkNewAchievements error", err);
                     setIsFinishingSession(false);
                     setShowFinishModal(true);
                 }
@@ -397,7 +401,6 @@ export function WorkoutExecutionPage({ user }) {
                 setShowFinishModal(true);
             }
         } else {
-            console.error("DEBUG: finishSession returned false");
             setIsFinishingSession(false);
             setIsFinished(false); // Reativar se falhar
             setFrozenSession(null);
@@ -417,7 +420,7 @@ export function WorkoutExecutionPage({ user }) {
 
         // Verificação de Segurança: API Files requer Contexto Seguro (HTTPS ou localhost)
         if (!window.isSecureContext) {
-            alert("O compartilhamento requer conexão segura (HTTPS).\n\nSe você está testando localmente via IP, use 'localhost' ou configure SSL.");
+            setError("O compartilhamento requer conexão segura. Use HTTPS ou localhost.");
             return;
         }
 
@@ -680,6 +683,10 @@ export function WorkoutExecutionPage({ user }) {
 
                 <div style={{ height: 'calc(65px + env(safe-area-inset-top))' }}></div>
 
+                <div className="px-4 mt-2 mb-2 flex justify-end">
+                    <SyncStatusBadge status={syncState} />
+                </div>
+
                 {focusMode && (
                     <div className="px-4 mb-2 mt-0 flex items-center justify-between pointer-events-auto relative z-40">
                         <Button
@@ -755,6 +762,7 @@ export function WorkoutExecutionPage({ user }) {
                                     onCompleteSet={handleCompleteSetWrapper}
                                     onUpdateNotes={updateNotes}
                                     onToggleWeightMode={() => toggleExerciseWeightMode(ex.id)}
+                                    onValidationError={setError}
                                 />
                             );
                         })()
@@ -770,31 +778,32 @@ export function WorkoutExecutionPage({ user }) {
                                 <div id={`exercise-${ex.id}`} key={ex.id}>
                                     <LinearCardCompactV2
                                         exerciseId={ex.id}
-                                    setId={activeSet.id}
-                                    exerciseName={ex.name}
-                                    muscleGroup={ex.muscleFocus?.primary || ex.group || 'Geral'}
-                                    method={ex.method || "Convencional"}
-                                    repsGoal={ex.reps || (ex.target ? ex.target.replace(/^\d+\s*x\s*/i, '').trim() : "12")}
-                                    currentSet={safeIdx + 1}
-                                    totalSets={ex.sets.length}
-                                    completedSets={ex.sets.map(s => s.completed)}
-                                    weight={activeSet.weight}
-                                    actualReps={activeSet.reps}
-                                    observation={ex.notes}
-                                    suggestedWeight={activeSet.targetWeight || activeSet.weight}
-                                    suggestedReps={activeSet.targetReps || ex.reps || (ex.target ? ex.target.replace(/^\d+\s*x\s*/i, '').trim() : "12")}
-                                    lastWeight={activeSet.lastWeight}
-                                    lastReps={activeSet.lastReps}
-                                    weightMode={activeSet.weightMode || 'total'}
-                                    baseWeight={activeSet.baseWeight}
-                                    drops={activeSet.drops}
-                                    onUpdateSet={updateExerciseSet}
-                                    onUpdateSetMultiple={updateSetMultiple}
-                                    onSetChange={(setNum) => handleSetNavigation(ex.id, setNum - 1)}
-                                    onMethodClick={() => setSelectedMethod(ex.method)}
-                                    onCompleteSet={handleCompleteSetWrapper}
-                                    onUpdateNotes={updateNotes}
+                                        setId={activeSet.id}
+                                        exerciseName={ex.name}
+                                        muscleGroup={ex.muscleFocus?.primary || ex.group || 'Geral'}
+                                        method={ex.method || "Convencional"}
+                                        repsGoal={ex.reps || (ex.target ? ex.target.replace(/^\d+\s*x\s*/i, '').trim() : "12")}
+                                        currentSet={safeIdx + 1}
+                                        totalSets={ex.sets.length}
+                                        completedSets={ex.sets.map(s => s.completed)}
+                                        weight={activeSet.weight}
+                                        actualReps={activeSet.reps}
+                                        observation={ex.notes}
+                                        suggestedWeight={activeSet.targetWeight || activeSet.weight}
+                                        suggestedReps={activeSet.targetReps || ex.reps || (ex.target ? ex.target.replace(/^\d+\s*x\s*/i, '').trim() : "12")}
+                                        lastWeight={activeSet.lastWeight}
+                                        lastReps={activeSet.lastReps}
+                                        weightMode={activeSet.weightMode || 'total'}
+                                        baseWeight={activeSet.baseWeight}
+                                        drops={activeSet.drops}
+                                        onUpdateSet={updateExerciseSet}
+                                        onUpdateSetMultiple={updateSetMultiple}
+                                        onSetChange={(setNum) => handleSetNavigation(ex.id, setNum - 1)}
+                                        onMethodClick={() => setSelectedMethod(ex.method)}
+                                        onCompleteSet={handleCompleteSetWrapper}
+                                        onUpdateNotes={updateNotes}
                                         onToggleWeightMode={() => toggleExerciseWeightMode(ex.id)}
+                                        onValidationError={setError}
                                     />
                                 </div>
                             );

--- a/src/pages/WorkoutExecutionPage.test.jsx
+++ b/src/pages/WorkoutExecutionPage.test.jsx
@@ -14,8 +14,10 @@ vi.mock('../hooks/useWorkoutTimer', () => ({
     useWorkoutTimer: vi.fn()
 }));
 
+const mockFinishWorkout = vi.fn();
+
 vi.mock('../context/WorkoutContext', () => ({
-    useWorkout: () => ({ finishWorkout: vi.fn() })
+    useWorkout: () => ({ finishWorkout: mockFinishWorkout })
 }));
 
 vi.mock('../components/design-system/Button', () => ({
@@ -103,6 +105,7 @@ describe('WorkoutExecutionPage', () => {
     let baseReturn;
     beforeEach(() => {
         vi.clearAllMocks();
+        mockFinishWorkout.mockClear();
         useWorkoutTimer.mockReturnValue({
             elapsedSeconds: 0,
             setElapsedSeconds: vi.fn()
@@ -133,10 +136,6 @@ describe('WorkoutExecutionPage', () => {
     });
 
     it('opens cancel modal and confirms discard', async () => {
-        const originalLocation = window.location;
-        delete window.location;
-        window.location = { href: '' };
-
         render(<WorkoutExecutionPage user={{ uid: 'u1' }} />);
 
         fireEvent.click(screen.getByRole('button', { name: 'CANCELAR' }));
@@ -149,9 +148,7 @@ describe('WorkoutExecutionPage', () => {
         });
 
         expect(baseReturn.discardSession).toHaveBeenCalled();
-        expect(window.location.href).toBe('/');
-
-        window.location = originalLocation;
+        expect(mockFinishWorkout).toHaveBeenCalled();
     });
 
     it('finishes workout and shows finish modal', async () => {

--- a/src/services/sessions/activeSessionService.js
+++ b/src/services/sessions/activeSessionService.js
@@ -1,0 +1,11 @@
+export const activeSessionService = {
+    async update(userId, sessionData) {
+        const { userService } = await import('../userService');
+        return userService.updateActiveSession(userId, sessionData);
+    },
+
+    async remove(userId) {
+        const { userService } = await import('../userService');
+        return userService.deleteActiveSession(userId);
+    }
+};

--- a/src/services/sessions/sessionRecoveryService.js
+++ b/src/services/sessions/sessionRecoveryService.js
@@ -1,0 +1,158 @@
+import { safeGetJSON, safeRemoveItem, safeSetJSON } from '../../utils/storage';
+
+export const SESSION_SYNC_STATES = {
+    idle: 'idle',
+    loading: 'loading',
+    active: 'active',
+    offline: 'offline',
+    syncing: 'syncing',
+    saved: 'saved',
+    syncFailed: 'sync_failed',
+    finishing: 'finishing',
+    finished: 'finished',
+    discarding: 'discarding',
+    discarded: 'discarded',
+    conflict: 'conflict',
+    error: 'error'
+};
+
+const CLOUD_SYNC_ELAPSED_BUCKET_SECONDS = 30;
+
+export function createSessionBackupKey(userId, workoutId) {
+    if (!userId || !workoutId) return null;
+    return `workout_backup_${userId}_${workoutId}`;
+}
+
+export function readSessionBackup(backupKey) {
+    if (!backupKey) return null;
+    const parsed = safeGetJSON(backupKey);
+    if (!parsed || !Array.isArray(parsed.exercises)) return null;
+    return parsed;
+}
+
+export function writeSessionBackup(backupKey, payload) {
+    if (!backupKey) return;
+    safeSetJSON(backupKey, {
+        ...payload,
+        timestamp: Date.now()
+    });
+}
+
+export function removeSessionBackup(backupKey) {
+    if (!backupKey) return;
+    safeRemoveItem(backupKey);
+}
+
+export function getTimestampMs(raw) {
+    if (!raw) return 0;
+    if (raw instanceof Date) return Number.isNaN(raw.getTime()) ? 0 : raw.getTime();
+    if (typeof raw === 'number') return Number.isFinite(raw) ? raw : 0;
+    if (typeof raw === 'string') {
+        const parsed = Date.parse(raw);
+        return Number.isNaN(parsed) ? 0 : parsed;
+    }
+    if (typeof raw.toMillis === 'function') return raw.toMillis();
+    if (typeof raw.toDate === 'function') {
+        const date = raw.toDate();
+        return date instanceof Date && !Number.isNaN(date.getTime()) ? date.getTime() : 0;
+    }
+    if (typeof raw.seconds === 'number') return raw.seconds * 1000;
+    return 0;
+}
+
+export function getAdjustedElapsed(elapsed, savedTimestamp) {
+    const baseElapsed = Number(elapsed) || 0;
+    const timestampMs = getTimestampMs(savedTimestamp);
+    if (!timestampMs) return baseElapsed;
+
+    const diff = Math.floor((Date.now() - timestampMs) / 1000);
+    if (diff > 0 && diff < 43200) {
+        return baseElapsed + diff;
+    }
+    return baseElapsed;
+}
+
+function fingerprintDrops(drops) {
+    if (!Array.isArray(drops)) return '';
+    return drops
+        .map(drop => [
+            drop.id || '',
+            drop.completed ? 1 : 0,
+            drop.weight || '',
+            drop.reps || '',
+            drop.weightMode || 'total',
+            drop.baseWeight || ''
+        ].join(':'))
+        .join(',');
+}
+
+function fingerprintExercises(exercises) {
+    if (!Array.isArray(exercises)) return '';
+    return exercises
+        .map(exercise => {
+            const sets = Array.isArray(exercise.sets)
+                ? exercise.sets.map(set => [
+                    set.id || '',
+                    set.completed ? 1 : 0,
+                    set.weight || '',
+                    set.reps || '',
+                    set.weightMode || 'total',
+                    set.baseWeight || '',
+                    fingerprintDrops(set.drops)
+                ].join(':')).join(';')
+                : '';
+
+            return [
+                exercise.id || '',
+                exercise.name || '',
+                exercise.notes || '',
+                sets
+            ].join('|');
+        })
+        .join('||');
+}
+
+export function createSessionFingerprint(exercises, elapsedSeconds = 0) {
+    const elapsedBucket = Math.floor((Number(elapsedSeconds) || 0) / CLOUD_SYNC_ELAPSED_BUCKET_SECONDS);
+    return `${elapsedBucket}::${fingerprintExercises(exercises)}`;
+}
+
+export function chooseSessionRecoverySource({ cloudData, localBackupData }) {
+    const hasCloud = Boolean(cloudData?.exercises);
+    const hasLocal = Boolean(localBackupData?.exercises);
+    if (!hasCloud && !hasLocal) return null;
+
+    const cloudTimestampMs = getTimestampMs(cloudData?.updatedAt);
+    const localTimestampMs = getTimestampMs(localBackupData?.timestamp);
+    const cloudElapsed = hasCloud ? getAdjustedElapsed(cloudData.elapsedSeconds || 0, cloudTimestampMs) : 0;
+    const localElapsed = hasLocal ? getAdjustedElapsed(localBackupData.elapsedSeconds || 0, localTimestampMs) : 0;
+
+    if (hasCloud && hasLocal) {
+        const localWinsByTime = localTimestampMs && cloudTimestampMs
+            ? localTimestampMs > cloudTimestampMs
+            : localElapsed > cloudElapsed;
+        const source = localWinsByTime ? 'local' : 'cloud';
+        return {
+            source,
+            conflict: true,
+            elapsedSeconds: source === 'local' ? localElapsed : cloudElapsed,
+            exercises: source === 'local' ? localBackupData.exercises : cloudData.exercises
+        };
+    }
+
+    if (hasLocal) {
+        return {
+            source: 'local',
+            conflict: false,
+            elapsedSeconds: localElapsed,
+            exercises: localBackupData.exercises
+        };
+    }
+
+    return {
+        source: 'cloud',
+        conflict: false,
+        elapsedSeconds: cloudElapsed,
+        exercises: cloudData.exercises
+    };
+}

--- a/src/services/sessions/sessionRecoveryService.test.js
+++ b/src/services/sessions/sessionRecoveryService.test.js
@@ -1,0 +1,66 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import {
+    chooseSessionRecoverySource,
+    createSessionBackupKey,
+    createSessionFingerprint,
+    readSessionBackup,
+    removeSessionBackup,
+    writeSessionBackup
+} from './sessionRecoveryService';
+
+describe('sessionRecoveryService', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it('creates scoped backup keys only when user and workout are available', () => {
+        expect(createSessionBackupKey('user-1', 'workout-1')).toBe('workout_backup_user-1_workout-1');
+        expect(createSessionBackupKey('', 'workout-1')).toBeNull();
+        expect(createSessionBackupKey('user-1', '')).toBeNull();
+    });
+
+    it('persists and removes local backups safely', () => {
+        const key = createSessionBackupKey('user-1', 'workout-1');
+        writeSessionBackup(key, {
+            elapsedSeconds: 42,
+            exercises: [{ id: 'ex-1', sets: [] }]
+        });
+
+        const backup = readSessionBackup(key);
+        expect(backup.elapsedSeconds).toBe(42);
+        expect(backup.exercises[0].id).toBe('ex-1');
+        expect(backup.timestamp).toEqual(expect.any(Number));
+
+        removeSessionBackup(key);
+        expect(readSessionBackup(key)).toBeNull();
+    });
+
+    it('prefers a newer local backup when both local and cloud sessions exist', () => {
+        const cloudData = {
+            updatedAt: new Date('2026-07-04T10:00:00Z'),
+            elapsedSeconds: 300,
+            exercises: [{ id: 'cloud', sets: [] }]
+        };
+        const localBackupData = {
+            timestamp: new Date('2026-07-04T10:05:00Z').getTime(),
+            elapsedSeconds: 330,
+            exercises: [{ id: 'local', sets: [] }]
+        };
+
+        const recovery = chooseSessionRecoverySource({ cloudData, localBackupData });
+        expect(recovery.conflict).toBe(true);
+        expect(recovery.source).toBe('local');
+        expect(recovery.exercises[0].id).toBe('local');
+    });
+
+    it('keeps the sync fingerprint stable inside the elapsed sync bucket', () => {
+        const exercises = [{
+            id: 'ex-1',
+            name: 'Supino',
+            sets: [{ id: 'set-1', completed: false, weight: '40', reps: '10' }]
+        }];
+
+        expect(createSessionFingerprint(exercises, 1)).toBe(createSessionFingerprint(exercises, 29));
+        expect(createSessionFingerprint(exercises, 31)).not.toBe(createSessionFingerprint(exercises, 29));
+    });
+});

--- a/src/services/workoutService.js
+++ b/src/services/workoutService.js
@@ -3,7 +3,7 @@ import { getFirestoreDeps } from '../firebaseDb';
 const TEMPLATES_COLLECTION = 'workout_templates';
 const SESSIONS_COLLECTION = 'workout_sessions';
 export const SESSION_LIMITS = {
-    dashboardRecent: 120,
+    dashboardRecent: 60,
     analyticsGlobalPage: 120,
     profileStats: 300,
     achievementCheck: 300

--- a/vite.config.js
+++ b/vite.config.js
@@ -53,14 +53,25 @@ export default defineConfig(({ mode }) => {
     },
     rollupOptions: {
       output: {
-        manualChunks: {
-          'vendor-react': ['react', 'react-dom', 'react-router-dom'],
-          'vendor-firebase-app': ['firebase/app'],
-          'vendor-firebase-auth': ['firebase/auth'],
-          'vendor-firebase-firestore': ['firebase/firestore'],
-          'vendor-charts': ['recharts'],
-          'vendor-lucide': ['lucide-react'],
-          'vendor-sonner': ['sonner'],
+        onlyExplicitManualChunks: true,
+        manualChunks(id) {
+          if (!id.includes('node_modules')) return undefined
+
+          const packageId = id.split('node_modules/').pop()
+
+          if (packageId.startsWith('react/') || packageId.startsWith('react-dom/') || packageId.startsWith('scheduler/')) {
+            return 'vendor-react'
+          }
+          if (packageId.startsWith('react-router/') || packageId.startsWith('react-router-dom/')) return 'vendor-router'
+          if (packageId.startsWith('firebase/app') || packageId.startsWith('@firebase/app')) return 'vendor-firebase-app'
+          if (packageId.startsWith('firebase/auth') || packageId.startsWith('@firebase/auth')) return 'vendor-firebase-auth'
+          if (packageId.startsWith('firebase/firestore') || packageId.startsWith('@firebase/firestore')) return 'vendor-firebase-firestore'
+          if (packageId.startsWith('recharts/')) return 'vendor-recharts'
+          if (packageId.startsWith('victory-vendor/') || packageId.startsWith('d3-')) return 'vendor-chart-vendor'
+          if (packageId.startsWith('lucide-react/')) return 'vendor-lucide'
+          if (packageId.startsWith('sonner/')) return 'vendor-sonner'
+
+          return undefined
         },
       },
     },


### PR DESCRIPTION
## O que mudou
- Reduz leituras do dashboard recente de 120 para 60 sessões e mantém fallback de cache/local stats quando subscriptions falham.
- Isola chunks de React, Firebase, Recharts e dependências de gráficos para remover o warning de chunks acima de 500 kB.
- Refatora a sessão ativa com serviços de backup/recuperação/sync, fingerprint leve, estados de sincronização e badge visual no treino.
- Remove alguns alerts críticos em treino, dashboard, perfil e criação de treino, usando erro em tela ou toast.
- Inicia tokens de design e adiciona testes para recuperação/fingerprint de sessão.

## Como foi testado
- npm run lint
- npm test -- --run
- npm run build

## Observações
- O build ainda mostra aviso informativo de Browserslist desatualizado.
- O build também avisa que userService é importado dinamicamente e estaticamente; fica como próximo refinamento de arquitetura/performance.