### PR TITLE
[codex] Split workout session flow and remove blocking alerts

### DIFF
--- a/src/components/achievements/AchievementUnlockedModal.jsx
+++ b/src/components/achievements/AchievementUnlockedModal.jsx
@@ -1,7 +1,8 @@
 import React, { useRef, useState } from 'react';
 import { VitalitaGlassCard } from './VitalitaGlassCard';
-import { Share2, X, Trophy, Download } from 'lucide-react';
+import { Share2 } from 'lucide-react';
 import { Button } from '../design-system/Button';
+import { toast } from 'sonner';
 
 // Lazy load for performance
 
@@ -48,7 +49,8 @@ export function AchievementUnlockedModal({ achievements, onClose }) {
             }
         } catch (err) {
             console.error(err);
-            alert("Erro ao gerar card: " + err.message);
+            toast.error(`Erro ao gerar card: ${err.message}`);
+        } finally {
             setSharing(false);
         }
     };

--- a/src/components/design-system/ConfirmDialog.jsx
+++ b/src/components/design-system/ConfirmDialog.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { AlertTriangle, X } from 'lucide-react';
+import { Button } from './Button';
+
+export function ConfirmDialog({
+    isOpen,
+    title,
+    description,
+    confirmLabel = 'Confirmar',
+    cancelLabel = 'Cancelar',
+    variant = 'danger',
+    loading = false,
+    onConfirm,
+    onCancel
+}) {
+    if (!isOpen) return null;
+
+    return (
+        <div
+            className="fixed inset-0 z-[220] flex items-center justify-center bg-black/80 p-4 backdrop-blur-sm"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="confirm-dialog-title"
+        >
+            <div className="w-full max-w-sm rounded-3xl border border-slate-700/70 bg-slate-950 p-5 shadow-2xl">
+                <div className="mb-5 flex items-start justify-between gap-4">
+                    <div className="flex items-start gap-3">
+                        <div className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-red-500/10 text-red-300 ring-1 ring-red-500/25">
+                            <AlertTriangle size={20} />
+                        </div>
+                        <div>
+                            <h2 id="confirm-dialog-title" className="text-base font-bold text-white">
+                                {title}
+                            </h2>
+                            {description && (
+                                <p className="mt-1 text-sm leading-relaxed text-slate-400">
+                                    {description}
+                                </p>
+                            )}
+                        </div>
+                    </div>
+                    <button
+                        type="button"
+                        onClick={onCancel}
+                        disabled={loading}
+                        className="rounded-full p-2 text-slate-500 transition-colors hover:bg-slate-800 hover:text-white disabled:pointer-events-none disabled:opacity-50"
+                        aria-label={cancelLabel}
+                    >
+                        <X size={18} />
+                    </button>
+                </div>
+
+                <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+                    <Button
+                        variant="secondary"
+                        onClick={onCancel}
+                        disabled={loading}
+                        className="rounded-xl"
+                    >
+                        {cancelLabel}
+                    </Button>
+                    <Button
+                        variant={variant}
+                        onClick={onConfirm}
+                        loading={loading}
+                        className="rounded-xl"
+                    >
+                        {confirmLabel}
+                    </Button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/history/WorkoutDetailsModal.jsx
+++ b/src/components/history/WorkoutDetailsModal.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef } from 'react';
 import { X, Calendar, Clock, Dumbbell, TrendingUp, Notebook, Share2, Activity, Navigation, Flame } from 'lucide-react';
 import { ShareableWorkoutCard } from '../sharing/ShareableWorkoutCard';
+import { toast } from 'sonner';
 
 export function WorkoutDetailsModal({ session, onClose, user }) {
     const shareCardRef = useRef(null);
@@ -71,12 +72,12 @@ export function WorkoutDetailsModal({ session, onClose, user }) {
     const handleShare = async () => {
         if (sharing) return;
         if (!shareCardRef.current) {
-            alert("Card de compartilhamento indisponível.");
+            toast.error("Card de compartilhamento indisponível.");
             return;
         }
 
         if (!window.isSecureContext) {
-            alert("O compartilhamento requer conexão segura (HTTPS).\n\nSe você está testando localmente via IP, use 'localhost' ou configure SSL.");
+            toast.error("O compartilhamento requer conexão segura. Use HTTPS ou localhost.");
             return;
         }
 
@@ -134,7 +135,7 @@ export function WorkoutDetailsModal({ session, onClose, user }) {
             URL.revokeObjectURL(blobUrl);
         } catch (err) {
             console.error("Error sharing:", err);
-            alert("Erro ao gerar imagem de compartilhamento.");
+            toast.error("Erro ao gerar imagem de compartilhamento.");
         } finally {
             setSharing(false);
         }

--- a/src/context/WorkoutContext.jsx
+++ b/src/context/WorkoutContext.jsx
@@ -4,9 +4,13 @@ import React, { createContext, useContext, useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { getFirestoreDeps } from '../firebaseDb';
 import { useAuth } from '../AuthContext';
-import { userService } from '../services/userService';
 
 const WorkoutContext = createContext();
+
+async function loadUserService() {
+    const { userService } = await import('../services/userService');
+    return userService;
+}
 
 export function WorkoutProvider({ children }) {
     const { user } = useAuth();
@@ -51,6 +55,7 @@ export function WorkoutProvider({ children }) {
                     if (manualExit) {
                         try {
                             if (remoteActiveId) {
+                                const userService = await loadUserService();
                                 await userService.clearActiveWorkout(user.uid);
                             }
                         } catch (err) {
@@ -80,6 +85,7 @@ export function WorkoutProvider({ children }) {
                             } else {
                                 // É um fantasma! Limpar.
                                 console.warn("Ghost active session detected. Clearing...");
+                                const userService = await loadUserService();
                                 await userService.clearActiveWorkout(user.uid);
                                 clearLocalActiveWorkout();
                             }
@@ -115,6 +121,7 @@ export function WorkoutProvider({ children }) {
     async function startWorkout(id) {
         setLocalActiveWorkout(id);
         if (user) {
+            const userService = await loadUserService();
             await userService.setActiveWorkout(user.uid, id);
         }
         navigate(`/execute/${id}`);
@@ -131,7 +138,9 @@ export function WorkoutProvider({ children }) {
         sessionStorage.setItem('manual_exit', '1');
         clearLocalActiveWorkout();
         if (user) {
-            userService.clearActiveWorkout(user.uid).catch(console.error);
+            loadUserService()
+                .then(userService => userService.clearActiveWorkout(user.uid))
+                .catch(console.error);
         }
         navigate('/');
     }

--- a/src/context/WorkoutContext.test.jsx
+++ b/src/context/WorkoutContext.test.jsx
@@ -109,7 +109,9 @@ describe('WorkoutContext', () => {
         });
 
         expect(screen.getByTestId('active-id')).toHaveTextContent('workout-123');
-        expect(mockSetActiveWorkout).toHaveBeenCalledWith('user123', 'workout-123');
+        await waitFor(() => {
+            expect(mockSetActiveWorkout).toHaveBeenCalledWith('user123', 'workout-123');
+        });
         expect(mockNavigate).toHaveBeenCalledWith('/execute/workout-123');
         expect(localStorage.getItem('activeWorkoutId')).toBe('workout-123');
     });

--- a/src/hooks/useWorkoutSession.js
+++ b/src/hooks/useWorkoutSession.js
@@ -1,27 +1,14 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
-import { getFirestoreDeps } from '../firebaseDb';
-import { activeSessionService } from '../services/sessions/activeSessionService';
-import {
-    chooseSessionRecoverySource,
-    createSessionBackupKey,
-    createSessionFingerprint,
-    readSessionBackup,
-    removeSessionBackup,
-    SESSION_SYNC_STATES,
-    writeSessionBackup
-} from '../services/sessions/sessionRecoveryService';
-
-// Auxiliar para gerar IDs
-function generateId() {
-    return Math.random().toString(36).substr(2, 9);
-}
+import { useRef, useState } from 'react';
+import { createSessionBackupKey, SESSION_SYNC_STATES } from '../services/sessions/sessionRecoveryService';
+import { useSessionExerciseActions } from './workout-session/useSessionExerciseActions';
+import { useSessionFinish } from './workout-session/useSessionFinish';
+import { useSessionLoader } from './workout-session/useSessionLoader';
+import { useSessionConnectivity, useSessionSync } from './workout-session/useSessionSync';
 
 export function useWorkoutSession(workoutId, user) {
-    const [loading, setLoading] = useState(true);
     const [template, setTemplate] = useState(null);
     const [exercises, setExercises] = useState([]);
     const [initialElapsed, setInitialElapsed] = useState(0);
-    const [saving, setSaving] = useState(false);
     const [error, setError] = useState(null);
     const [sessionVersion, setSessionVersion] = useState(0);
     const [syncState, setSyncState] = useState(SESSION_SYNC_STATES.idle);
@@ -32,422 +19,55 @@ export function useWorkoutSession(workoutId, user) {
     const syncInFlightRef = useRef(false);
     const backupKey = createSessionBackupKey(profileId, workoutId);
 
-    // --- BUSCA DE DADOS ---
-    useEffect(() => {
-        if (!workoutId || !profileId) return;
+    const { loading, setLoading } = useSessionLoader({
+        workoutId,
+        profileId,
+        backupKey,
+        sessionVersion,
+        setTemplate,
+        setExercises,
+        setInitialElapsed,
+        setError,
+        setSyncState,
+        lastSyncedRef
+    });
 
-        async function fetchData() {
-            setLoading(true);
-            setSyncState(SESSION_SYNC_STATES.loading);
-            try {
-                const { db, doc, getDoc, getDocs, query, collection, where, limit, getDocFromServer } = await getFirestoreDeps();
-                let activeData = null;
+    useSessionConnectivity(setSyncState);
 
-                // 1. Verificar sessão ativa remota.
-                try {
-                    const activeRef = doc(db, 'active_workouts', profileId);
-                    const activeSnap = await getDocFromServer(activeRef);
-                    if (activeSnap.exists()) {
-                        const data = activeSnap.data();
-                        if (data.templateId === workoutId) {
-                            activeData = data;
-                        }
-                    }
-                } catch (e) {
-                    console.warn("Could not fetch active remote session (Server)", e);
-                    // Fallback para cache se offline
-                    try {
-                        const activeRef = doc(db, 'active_workouts', profileId);
-                        const activeSnap = await getDoc(activeRef);
-                        if (activeSnap.exists()) {
-                            const data = activeSnap.data();
-                            if (data.templateId === workoutId) {
-                                activeData = data;
-                            }
-                        }
-                    } catch (cacheErr) {
-                        console.warn("Could not fetch active remote session (Cache)", cacheErr);
-                    }
-                }
+    const syncSession = useSessionSync({
+        backupKey,
+        profileId,
+        workoutId,
+        lastSyncedRef,
+        syncInFlightRef,
+        setSyncState,
+        setLastSavedAt
+    });
 
-                // 2. Verificar Backup Local
-                const localBackupData = readSessionBackup(backupKey);
-                const recovery = chooseSessionRecoverySource({ cloudData: activeData, localBackupData });
+    const {
+        updateExerciseSet,
+        toggleSet,
+        updateNotes,
+        updateSetMultiple,
+        completeSetAutoFill,
+        toggleExerciseWeightMode
+    } = useSessionExerciseActions(setExercises);
 
-                if (recovery) {
-                    // Carregar dados do template (apenas metadados)
-                    const templateDoc = await getDoc(doc(db, 'workout_templates', workoutId));
-                    if (templateDoc.exists()) {
-                        setTemplate({ id: templateDoc.id, ...templateDoc.data() });
-                    }
-
-                    setExercises(recovery.exercises);
-                    setInitialElapsed(recovery.elapsedSeconds);
-                    lastSyncedRef.current = recovery.source === 'cloud'
-                        ? createSessionFingerprint(recovery.exercises, recovery.elapsedSeconds)
-                        : '';
-                    setSyncState(recovery.conflict
-                        ? SESSION_SYNC_STATES.conflict
-                        : SESSION_SYNC_STATES.active);
-                    setLoading(false);
-                    return;
-                }
-
-                // 3. Nova Sessão / Carregar Template (FRESCO)
-                const templateRef = doc(db, 'workout_templates', workoutId);
-                let templateDoc;
-                try {
-                    // Forçar busca no servidor para obter últimas edições
-                    templateDoc = await getDocFromServer(templateRef);
-                } catch (e) {
-                    console.warn("Template server fetch failed, falling back to cache", e);
-                    templateDoc = await getDoc(templateRef);
-                }
-
-                if (templateDoc.exists()) {
-                    const tmplData = templateDoc.data();
-                    setTemplate({ id: templateDoc.id, ...tmplData });
-
-                    // Buscar último histórico do treino para preencher sugestões de carga/reps.
-                    let lastSessionExercises = [];
-                    try {
-                        const historyQuery = query(
-                            collection(db, 'workout_sessions'),
-                            where('userId', '==', profileId),
-                            where('templateId', '==', workoutId),
-                            limit(20)
-                        );
-                        const historySnap = await getDocs(historyQuery);
-                        const validDocs = historySnap.docs.filter(d => d.data().completedAt);
-                        if (validDocs.length > 0) {
-                            const sortedDocs = validDocs.sort((a, b) => {
-                                const dateA = a.data().completedAt?.toDate?.() || 0;
-                                const dateB = b.data().completedAt?.toDate?.() || 0;
-                                return dateB - dateA;
-                            });
-                            const lastData = sortedDocs[0].data();
-                            if (lastData.exercises) lastSessionExercises = lastData.exercises;
-                        }
-                    } catch (err) {
-                        console.error("Error fetching history:", err);
-                    }
-
-                    // Mapear Exercícios
-                    if (tmplData.exercises) {
-                        const mapped = tmplData.exercises.map(ex => {
-                            const exId = ex.id || generateId();
-
-                            // Encontrar Correspondência no Histórico
-                            const lastEx = lastSessionExercises.find(le => le.id === exId) ||
-                                lastSessionExercises.find(le => le.name && ex.name && le.name.trim().toLowerCase() === ex.name.trim().toLowerCase());
-
-                            const sets = normalizeSets(ex.sets, ex.reps, ex.target).map((s, idx) => {
-                                let lastSet = null;
-                                // Propagar histórico
-                                if (lastEx && lastEx.sets && lastEx.sets.length > 0) {
-                                    if (idx < lastEx.sets.length) lastSet = lastEx.sets[idx];
-                                    else lastSet = lastEx.sets[lastEx.sets.length - 1];
-                                }
-
-                                return {
-                                    ...s,
-                                    id: s.id || generateId(),
-                                    completed: false,
-                                    weight: lastSet?.weight || s.weight || '',
-                                    reps: lastSet?.reps || s.reps || '',
-                                    targetReps: s.reps || ex.reps,
-                                    targetWeight: lastSet?.weight || '',
-                                    lastWeight: lastSet?.weight || null,
-                                    lastReps: lastSet?.reps || null,
-                                    weightMode: lastSet?.weightMode || s.weightMode || 'total',
-                                    baseWeight: lastSet?.baseWeight || null,
-                                    drops: lastSet?.drops ? lastSet.drops.map(d => ({ 
-                                        ...d, 
-                                        id: generateId(), 
-                                        completed: false // Ensures drops from history are copied fresh
-                                    })) : null
-                                };
-                            });
-
-                            return {
-                                ...ex,
-                                id: exId,
-                                sets,
-                                notes: lastEx?.notes || ''
-                            };
-                        });
-                        setExercises(mapped);
-                        setInitialElapsed(0);
-                        setSyncState(SESSION_SYNC_STATES.active);
-                    }
-                }
-            } catch (err) {
-                console.error(err);
-                setError("Falha ao carregar treino.");
-                setSyncState(SESSION_SYNC_STATES.error);
-            } finally {
-                setLoading(false);
-            }
-        }
-
-        fetchData();
-    }, [workoutId, profileId, backupKey, sessionVersion]);
-
-    useEffect(() => {
-        if (typeof window === 'undefined') return undefined;
-
-        const updateOnlineState = () => {
-            if (!navigator.onLine) {
-                setSyncState(SESSION_SYNC_STATES.offline);
-            } else {
-                setSyncState((current) => (
-                    current === SESSION_SYNC_STATES.offline ? SESSION_SYNC_STATES.saved : current
-                ));
-            }
-        };
-
-        window.addEventListener('online', updateOnlineState);
-        window.addEventListener('offline', updateOnlineState);
-        updateOnlineState();
-
-        return () => {
-            window.removeEventListener('online', updateOnlineState);
-            window.removeEventListener('offline', updateOnlineState);
-        };
-    }, []);
-
-    // --- SINCRONIZAÇÃO ---
-    const syncSession = useCallback((currentExercises, currentElapsed) => {
-        if (typeof window === 'undefined') return;
-
-        // Backup Local
-        const backupData = {
-            timestamp: Date.now(),
-            elapsedSeconds: currentElapsed,
-            exercises: currentExercises
-        };
-        writeSessionBackup(backupKey, backupData);
-
-        // Sincronização na Nuvem
-        const currentFingerprint = createSessionFingerprint(currentExercises, currentElapsed);
-        if (!navigator.onLine) {
-            setSyncState(SESSION_SYNC_STATES.offline);
-            return;
-        }
-
-        if (
-            profileId &&
-            currentFingerprint !== lastSyncedRef.current &&
-            !syncInFlightRef.current
-        ) {
-            syncInFlightRef.current = true;
-            setSyncState(SESSION_SYNC_STATES.syncing);
-            activeSessionService
-                .update(profileId, {
-                    templateId: workoutId,
-                    elapsedSeconds: currentElapsed,
-                    exercises: currentExercises
-                })
-                .then(() => {
-                    lastSyncedRef.current = currentFingerprint;
-                    setLastSavedAt(new Date());
-                    setSyncState(SESSION_SYNC_STATES.saved);
-                })
-                .catch((err) => {
-                    console.error(err);
-                    setSyncState(SESSION_SYNC_STATES.syncFailed);
-                })
-                .finally(() => {
-                    syncInFlightRef.current = false;
-                });
-        }
-    }, [backupKey, profileId, workoutId]);
-
-
-    // --- AÇÕES ---
-    const updateExerciseSet = useCallback((exId, setId, field, val) => {
-        setExercises(prev => prev.map(ex => ex.id === exId ? {
-            ...ex, sets: ex.sets.map(s => s.id === setId ? { ...s, [field]: val } : s)
-        } : ex));
-    }, []);
-
-    const toggleSet = useCallback((exId, setId) => {
-        setExercises(prev => prev.map(ex => ex.id === exId ? {
-            ...ex, sets: ex.sets.map(s => s.id === setId ? { ...s, completed: !s.completed } : s)
-        } : ex));
-    }, []);
-
-    const updateNotes = useCallback((exId, val) => {
-        setExercises(prev => prev.map(ex => ex.id === exId ? { ...ex, notes: val } : ex));
-    }, []);
-
-    const updateSetMultiple = useCallback((exId, setId, updates) => {
-        setExercises(prev => prev.map(ex => ex.id === exId ? {
-            ...ex, sets: ex.sets.map(s => s.id === setId ? { ...s, ...updates } : s)
-        } : ex));
-    }, []);
-
-    const completeSetAutoFill = useCallback((exId, setNumber, weight, actualReps, weightMode = 'total', baseWeight = null, drops = null) => {
-        setExercises(prev => prev.map(ex => {
-            if (ex.id !== exId) return ex;
-
-            const currentSetIdx = setNumber - 1;
-            const nextSetIdx = currentSetIdx + 1;
-
-            return {
-                ...ex,
-                sets: ex.sets.map((s, idx) => {
-                    // Atualizar Série Atual
-                    if (idx === currentSetIdx) {
-                        return {
-                            ...s,
-                            completed: true,
-                            weight,
-                            reps: actualReps,
-                            weightMode,
-                            baseWeight
-                        };
-                    }
-                    // Auto-preencher Próxima Série
-                    if (idx === nextSetIdx) {
-                        // FIX: Sempre sobrescrever com os dados da série anterior,
-                        // priorizando o input recente do usuário sobre o histórico.
-                        return {
-                            ...s,
-                            weight: weight,
-                            reps: actualReps,
-                            weightMode: weightMode,
-                            baseWeight: baseWeight,
-                            drops: drops ? drops.map(d => ({ ...d, id: generateId(), reps: d.reps })) : null
-                        };
-                    }
-                    return s;
-                })
-            };
-        }));
-    }, []);
-
-    const toggleExerciseWeightMode = useCallback((exId) => {
-        setExercises(prev => prev.map(ex => {
-            if (ex.id !== exId) return ex;
-
-            // Determinar modo alvo baseado na primeira série (ou maioria, mas a primeira é previsível)
-            // Se atualmente for 'total' (padrão), mudar para 'per_side' (por lado).
-            // Se 'per_side', mudar para 'total'.
-            const currentMode = ex.sets[0]?.weightMode || 'total';
-            const targetMode = currentMode === 'total' ? 'per_side' : 'total';
-
-            const newSets = ex.sets.map(s => {
-                const currentWeight = parseFloat(s.weight) || 0;
-
-                if (targetMode === 'per_side') {
-                    // Alternando para POR LADO
-                    // Peso atual é Total. PesoBase torna-se Metade.
-                    const newBase = currentWeight > 0 ? (currentWeight / 2) : 0;
-                    return {
-                        ...s,
-                        weightMode: 'per_side',
-                        baseWeight: newBase.toString(),
-                        // O peso permanece o valor total (fonte da verdade padrão)
-                    };
-                } else {
-                    // Alternando para TOTAL
-                    // Apenas limpar a flag de modo e o peso base.
-                    return {
-                        ...s,
-                        weightMode: 'total',
-                        baseWeight: null
-                    };
-                }
-            });
-
-            return { ...ex, sets: newSets };
-        }));
-    }, []);
-
-    const finishSession = async (finalElapsed) => {
-        setSaving(true);
-        setSyncState(SESSION_SYNC_STATES.finishing);
-        try {
-            const { db, collection, addDoc, serverTimestamp, doc, setDoc } = await getFirestoreDeps();
-            const minutes = Math.floor(finalElapsed / 60);
-            const durationStr = `${minutes}min`;
-
-            const now = new Date();
-            await addDoc(collection(db, 'workout_sessions'), {
-                duration: durationStr,
-                elapsedSeconds: finalElapsed,
-                templateId: workoutId,
-                templateName: template?.name || 'Treino Personalizado',
-                workoutName: template?.name || 'Treino Personalizado',
-                userId: profileId,
-                createdAt: serverTimestamp(),
-                completedAt: serverTimestamp(), // Usar tempo do servidor para consistência
-                completedAtClient: now, // Backup para atualizações otimistas imediatas na UI
-                exercises: exercises.map(ex => ({
-                    id: ex.id || generateId(),
-                    name: ex.name || 'Exercício sem nome',
-                    sets: ex.sets.map(s => ({
-                        id: s.id || generateId(),
-                        weight: s.weight || '',
-                        reps: s.reps || '',
-                        completed: !!s.completed,
-                        weightMode: s.weightMode || 'total',
-                        baseWeight: s.baseWeight || null,
-                        drops: s.drops || null
-                    })),
-                    notes: ex.notes || ''
-                }))
-            });
-
-            // Limpeza
-            removeSessionBackup(backupKey);
-            if (profileId) {
-                await activeSessionService.remove(profileId);
-            }
-
-            // Atualizar Metadados do Template
-            const templateRef = doc(db, 'workout_templates', workoutId);
-            await setDoc(templateRef, { lastPerformed: serverTimestamp() }, { merge: true });
-
-            setSyncState(SESSION_SYNC_STATES.finished);
-            return true; // Sucesso
-        } catch (e) {
-            console.error(e);
-            setError('Erro ao salvar treino.');
-            setSyncState(SESSION_SYNC_STATES.syncFailed);
-            return false;
-        } finally {
-            setSaving(false);
-        }
-    };
-
-    const discardSession = useCallback(async () => {
-        setLoading(true);
-        setSyncState(SESSION_SYNC_STATES.discarding);
-        try {
-            // Limpeza
-            removeSessionBackup(backupKey);
-            if (profileId) {
-                await activeSessionService.remove(profileId);
-            }
-
-            // Aguardar um pouco para garantir propagação
-            await new Promise(r => setTimeout(r, 600));
-
-            // Acionar nova busca
-            setSessionVersion(v => v + 1);
-            setSyncState(SESSION_SYNC_STATES.discarded);
-            return true;
-        } catch (e) {
-            console.error("Error discarding session:", e);
-            setError('Erro ao descartar treino. Seu backup local foi mantido.');
-            setSyncState(SESSION_SYNC_STATES.syncFailed);
-            return false;
-        } finally {
-            setLoading(false);
-        }
-    }, [backupKey, profileId]);
+    const {
+        saving,
+        finishSession,
+        discardSession
+    } = useSessionFinish({
+        workoutId,
+        profileId,
+        backupKey,
+        template,
+        exercises,
+        setError,
+        setLoading,
+        setSessionVersion,
+        setSyncState
+    });
 
     return {
         loading,
@@ -469,30 +89,4 @@ export function useWorkoutSession(workoutId, user) {
         updateSetMultiple,
         toggleExerciseWeightMode
     };
-}
-
-
-// Auxiliar Compartilhado
-function normalizeSets(exSets, exReps, exTarget) {
-    let count = 3;
-    if (exSets) {
-        const parsed = Number(exSets);
-        if (!isNaN(parsed) && parsed > 0) count = parsed;
-    } else if (exTarget && typeof exTarget === 'string') {
-        const match = exTarget.match(/^(\d+)x/i);
-        if (match && match[1]) count = parseInt(match[1], 10);
-    }
-
-    let defaultReps = exReps || '8-12';
-    if (exTarget && typeof exTarget === 'string') {
-        const parts = exTarget.split('x');
-        if (parts.length > 1) defaultReps = parts[1].trim();
-    }
-
-    return Array.from({ length: count }, () => ({
-        id: generateId(),
-        reps: defaultReps,
-        weight: '',
-        completed: false
-    }));
 }

--- a/src/hooks/workout-session/normalizeSets.js
+++ b/src/hooks/workout-session/normalizeSets.js
@@ -1,0 +1,74 @@
+export function generateId() {
+    return Math.random().toString(36).substr(2, 9);
+}
+
+export function normalizeSets(exSets, exReps, exTarget) {
+    let count = 3;
+    if (exSets) {
+        const parsed = Number(exSets);
+        if (!Number.isNaN(parsed) && parsed > 0) count = parsed;
+    } else if (exTarget && typeof exTarget === 'string') {
+        const match = exTarget.match(/^(\d+)x/i);
+        if (match && match[1]) count = parseInt(match[1], 10);
+    }
+
+    let defaultReps = exReps || '8-12';
+    if (exTarget && typeof exTarget === 'string') {
+        const parts = exTarget.split('x');
+        if (parts.length > 1) defaultReps = parts[1].trim();
+    }
+
+    return Array.from({ length: count }, () => ({
+        id: generateId(),
+        reps: defaultReps,
+        weight: '',
+        completed: false
+    }));
+}
+
+export function mapTemplateExercises(tmplData, lastSessionExercises = []) {
+    if (!Array.isArray(tmplData?.exercises)) return [];
+
+    return tmplData.exercises.map(ex => {
+        const exId = ex.id || generateId();
+        const lastEx = lastSessionExercises.find(le => le.id === exId) ||
+            lastSessionExercises.find(le => le.name && ex.name && le.name.trim().toLowerCase() === ex.name.trim().toLowerCase());
+
+        const sets = normalizeSets(ex.sets, ex.reps, ex.target).map((set, idx) => {
+            let lastSet = null;
+            if (lastEx?.sets?.length > 0) {
+                lastSet = idx < lastEx.sets.length
+                    ? lastEx.sets[idx]
+                    : lastEx.sets[lastEx.sets.length - 1];
+            }
+
+            return {
+                ...set,
+                id: set.id || generateId(),
+                completed: false,
+                weight: lastSet?.weight || set.weight || '',
+                reps: lastSet?.reps || set.reps || '',
+                targetReps: set.reps || ex.reps,
+                targetWeight: lastSet?.weight || '',
+                lastWeight: lastSet?.weight || null,
+                lastReps: lastSet?.reps || null,
+                weightMode: lastSet?.weightMode || set.weightMode || 'total',
+                baseWeight: lastSet?.baseWeight || null,
+                drops: lastSet?.drops
+                    ? lastSet.drops.map(drop => ({
+                        ...drop,
+                        id: generateId(),
+                        completed: false
+                    }))
+                    : null
+            };
+        });
+
+        return {
+            ...ex,
+            id: exId,
+            sets,
+            notes: lastEx?.notes || ''
+        };
+    });
+}

--- a/src/hooks/workout-session/useSessionExerciseActions.js
+++ b/src/hooks/workout-session/useSessionExerciseActions.js
@@ -1,0 +1,106 @@
+import { useCallback } from 'react';
+import { generateId } from './normalizeSets';
+
+export function useSessionExerciseActions(setExercises) {
+    const updateExerciseSet = useCallback((exId, setId, field, val) => {
+        setExercises(prev => prev.map(ex => ex.id === exId ? {
+            ...ex,
+            sets: ex.sets.map(set => set.id === setId ? { ...set, [field]: val } : set)
+        } : ex));
+    }, [setExercises]);
+
+    const toggleSet = useCallback((exId, setId) => {
+        setExercises(prev => prev.map(ex => ex.id === exId ? {
+            ...ex,
+            sets: ex.sets.map(set => set.id === setId ? { ...set, completed: !set.completed } : set)
+        } : ex));
+    }, [setExercises]);
+
+    const updateNotes = useCallback((exId, val) => {
+        setExercises(prev => prev.map(ex => ex.id === exId ? { ...ex, notes: val } : ex));
+    }, [setExercises]);
+
+    const updateSetMultiple = useCallback((exId, setId, updates) => {
+        setExercises(prev => prev.map(ex => ex.id === exId ? {
+            ...ex,
+            sets: ex.sets.map(set => set.id === setId ? { ...set, ...updates } : set)
+        } : ex));
+    }, [setExercises]);
+
+    const completeSetAutoFill = useCallback((exId, setNumber, weight, actualReps, weightMode = 'total', baseWeight = null, drops = null) => {
+        setExercises(prev => prev.map(ex => {
+            if (ex.id !== exId) return ex;
+
+            const currentSetIdx = setNumber - 1;
+            const nextSetIdx = currentSetIdx + 1;
+
+            return {
+                ...ex,
+                sets: ex.sets.map((set, idx) => {
+                    if (idx === currentSetIdx) {
+                        return {
+                            ...set,
+                            completed: true,
+                            weight,
+                            reps: actualReps,
+                            weightMode,
+                            baseWeight
+                        };
+                    }
+
+                    if (idx === nextSetIdx) {
+                        return {
+                            ...set,
+                            weight,
+                            reps: actualReps,
+                            weightMode,
+                            baseWeight,
+                            drops: drops ? drops.map(drop => ({ ...drop, id: generateId(), reps: drop.reps })) : null
+                        };
+                    }
+
+                    return set;
+                })
+            };
+        }));
+    }, [setExercises]);
+
+    const toggleExerciseWeightMode = useCallback((exId) => {
+        setExercises(prev => prev.map(ex => {
+            if (ex.id !== exId) return ex;
+
+            const currentMode = ex.sets[0]?.weightMode || 'total';
+            const targetMode = currentMode === 'total' ? 'per_side' : 'total';
+
+            const newSets = ex.sets.map(set => {
+                const currentWeight = parseFloat(set.weight) || 0;
+
+                if (targetMode === 'per_side') {
+                    const newBase = currentWeight > 0 ? (currentWeight / 2) : 0;
+                    return {
+                        ...set,
+                        weightMode: 'per_side',
+                        baseWeight: newBase.toString()
+                    };
+                }
+
+                return {
+                    ...set,
+                    weightMode: 'total',
+                    baseWeight: null
+                };
+            });
+
+            return { ...ex, sets: newSets };
+        }));
+    }, [setExercises]);
+
+    return {
+        updateExerciseSet,
+        toggleSet,
+        updateNotes,
+        updateSetMultiple,
+        completeSetAutoFill,
+        toggleExerciseWeightMode
+    };
+}

--- a/src/hooks/workout-session/useSessionFinish.js
+++ b/src/hooks/workout-session/useSessionFinish.js
@@ -1,0 +1,108 @@
+import { useCallback, useState } from 'react';
+import { getFirestoreDeps } from '../../firebaseDb';
+import { activeSessionService } from '../../services/sessions/activeSessionService';
+import {
+    removeSessionBackup,
+    SESSION_SYNC_STATES
+} from '../../services/sessions/sessionRecoveryService';
+import { generateId } from './normalizeSets';
+
+export function useSessionFinish({
+    workoutId,
+    profileId,
+    backupKey,
+    template,
+    exercises,
+    setError,
+    setLoading,
+    setSessionVersion,
+    setSyncState
+}) {
+    const [saving, setSaving] = useState(false);
+
+    const finishSession = useCallback(async (finalElapsed) => {
+        setSaving(true);
+        setSyncState(SESSION_SYNC_STATES.finishing);
+        try {
+            const { db, collection, addDoc, serverTimestamp, doc, setDoc } = await getFirestoreDeps();
+            const minutes = Math.floor(finalElapsed / 60);
+            const now = new Date();
+
+            await addDoc(collection(db, 'workout_sessions'), {
+                duration: `${minutes}min`,
+                elapsedSeconds: finalElapsed,
+                templateId: workoutId,
+                templateName: template?.name || 'Treino Personalizado',
+                workoutName: template?.name || 'Treino Personalizado',
+                userId: profileId,
+                createdAt: serverTimestamp(),
+                completedAt: serverTimestamp(),
+                completedAtClient: now,
+                exercises: exercises.map(ex => ({
+                    id: ex.id || generateId(),
+                    name: ex.name || 'Exercício sem nome',
+                    sets: ex.sets.map(set => ({
+                        id: set.id || generateId(),
+                        weight: set.weight || '',
+                        reps: set.reps || '',
+                        completed: !!set.completed,
+                        weightMode: set.weightMode || 'total',
+                        baseWeight: set.baseWeight || null,
+                        drops: set.drops || null
+                    })),
+                    notes: ex.notes || ''
+                }))
+            });
+
+            removeSessionBackup(backupKey);
+            if (profileId) {
+                await activeSessionService.remove(profileId);
+            }
+
+            await setDoc(
+                doc(db, 'workout_templates', workoutId),
+                { lastPerformed: serverTimestamp() },
+                { merge: true }
+            );
+
+            setSyncState(SESSION_SYNC_STATES.finished);
+            return true;
+        } catch (err) {
+            console.error(err);
+            setError('Erro ao salvar treino.');
+            setSyncState(SESSION_SYNC_STATES.syncFailed);
+            return false;
+        } finally {
+            setSaving(false);
+        }
+    }, [workoutId, profileId, backupKey, template, exercises, setError, setSyncState]);
+
+    const discardSession = useCallback(async () => {
+        setLoading(true);
+        setSyncState(SESSION_SYNC_STATES.discarding);
+        try {
+            removeSessionBackup(backupKey);
+            if (profileId) {
+                await activeSessionService.remove(profileId);
+            }
+
+            await new Promise(resolve => setTimeout(resolve, 600));
+            setSessionVersion(version => version + 1);
+            setSyncState(SESSION_SYNC_STATES.discarded);
+            return true;
+        } catch (err) {
+            console.error('Error discarding session:', err);
+            setError('Erro ao descartar treino. Seu backup local foi mantido.');
+            setSyncState(SESSION_SYNC_STATES.syncFailed);
+            return false;
+        } finally {
+            setLoading(false);
+        }
+    }, [backupKey, profileId, setError, setLoading, setSessionVersion, setSyncState]);
+
+    return {
+        saving,
+        finishSession,
+        discardSession
+    };
+}

--- a/src/hooks/workout-session/useSessionLoader.js
+++ b/src/hooks/workout-session/useSessionLoader.js
@@ -1,0 +1,164 @@
+import { useEffect, useState } from 'react';
+import { getFirestoreDeps } from '../../firebaseDb';
+import {
+    chooseSessionRecoverySource,
+    createSessionFingerprint,
+    readSessionBackup,
+    SESSION_SYNC_STATES
+} from '../../services/sessions/sessionRecoveryService';
+import { mapTemplateExercises } from './normalizeSets';
+
+async function getActiveSession({ db, doc, getDoc, getDocFromServer }, profileId, workoutId) {
+    const activeRef = doc(db, 'active_workouts', profileId);
+
+    try {
+        const activeSnap = await getDocFromServer(activeRef);
+        if (!activeSnap.exists()) return null;
+        const data = activeSnap.data();
+        return data.templateId === workoutId ? data : null;
+    } catch (serverErr) {
+        console.warn('Could not fetch active remote session (Server)', serverErr);
+    }
+
+    try {
+        const activeSnap = await getDoc(activeRef);
+        if (!activeSnap.exists()) return null;
+        const data = activeSnap.data();
+        return data.templateId === workoutId ? data : null;
+    } catch (cacheErr) {
+        console.warn('Could not fetch active remote session (Cache)', cacheErr);
+        return null;
+    }
+}
+
+async function getTemplate(deps, workoutId) {
+    const { db, doc, getDoc, getDocFromServer } = deps;
+    const templateRef = doc(db, 'workout_templates', workoutId);
+
+    try {
+        return await getDocFromServer(templateRef);
+    } catch (err) {
+        console.warn('Template server fetch failed, falling back to cache', err);
+        return getDoc(templateRef);
+    }
+}
+
+async function getLastSessionExercises(deps, profileId, workoutId) {
+    const { db, getDocs, query, collection, where, limit } = deps;
+    try {
+        const historyQuery = query(
+            collection(db, 'workout_sessions'),
+            where('userId', '==', profileId),
+            where('templateId', '==', workoutId),
+            limit(20)
+        );
+        const historySnap = await getDocs(historyQuery);
+        const validDocs = historySnap.docs.filter(docSnap => docSnap.data().completedAt);
+        if (validDocs.length === 0) return [];
+
+        const sortedDocs = validDocs.sort((a, b) => {
+            const dateA = a.data().completedAt?.toDate?.() || 0;
+            const dateB = b.data().completedAt?.toDate?.() || 0;
+            return dateB - dateA;
+        });
+
+        return sortedDocs[0].data().exercises || [];
+    } catch (err) {
+        console.error('Error fetching history:', err);
+        return [];
+    }
+}
+
+export function useSessionLoader({
+    workoutId,
+    profileId,
+    backupKey,
+    sessionVersion,
+    setTemplate,
+    setExercises,
+    setInitialElapsed,
+    setError,
+    setSyncState,
+    lastSyncedRef
+}) {
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        if (!workoutId || !profileId) return undefined;
+
+        let cancelled = false;
+
+        async function fetchSession() {
+            setLoading(true);
+            setSyncState(SESSION_SYNC_STATES.loading);
+
+            try {
+                const deps = await getFirestoreDeps();
+                const activeData = await getActiveSession(deps, profileId, workoutId);
+                const localBackupData = readSessionBackup(backupKey);
+                const recovery = chooseSessionRecoverySource({ cloudData: activeData, localBackupData });
+
+                if (cancelled) return;
+
+                if (recovery) {
+                    const templateDoc = await deps.getDoc(deps.doc(deps.db, 'workout_templates', workoutId));
+                    if (cancelled) return;
+
+                    if (templateDoc.exists()) {
+                        setTemplate({ id: templateDoc.id, ...templateDoc.data() });
+                    }
+
+                    setExercises(recovery.exercises);
+                    setInitialElapsed(recovery.elapsedSeconds);
+                    lastSyncedRef.current = recovery.source === 'cloud'
+                        ? createSessionFingerprint(recovery.exercises, recovery.elapsedSeconds)
+                        : '';
+                    setSyncState(recovery.conflict
+                        ? SESSION_SYNC_STATES.conflict
+                        : SESSION_SYNC_STATES.active);
+                    return;
+                }
+
+                const templateDoc = await getTemplate(deps, workoutId);
+                if (cancelled) return;
+
+                if (templateDoc.exists()) {
+                    const tmplData = templateDoc.data();
+                    setTemplate({ id: templateDoc.id, ...tmplData });
+                    const lastSessionExercises = await getLastSessionExercises(deps, profileId, workoutId);
+                    if (cancelled) return;
+
+                    setExercises(mapTemplateExercises(tmplData, lastSessionExercises));
+                    setInitialElapsed(0);
+                    setSyncState(SESSION_SYNC_STATES.active);
+                }
+            } catch (err) {
+                if (cancelled) return;
+                console.error(err);
+                setError('Falha ao carregar treino.');
+                setSyncState(SESSION_SYNC_STATES.error);
+            } finally {
+                if (!cancelled) setLoading(false);
+            }
+        }
+
+        fetchSession();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [
+        workoutId,
+        profileId,
+        backupKey,
+        sessionVersion,
+        setTemplate,
+        setExercises,
+        setInitialElapsed,
+        setError,
+        setSyncState,
+        lastSyncedRef
+    ]);
+
+    return { loading, setLoading };
+}

--- a/src/hooks/workout-session/useSessionSync.js
+++ b/src/hooks/workout-session/useSessionSync.js
@@ -1,0 +1,84 @@
+import { useCallback, useEffect } from 'react';
+import { activeSessionService } from '../../services/sessions/activeSessionService';
+import {
+    createSessionFingerprint,
+    SESSION_SYNC_STATES,
+    writeSessionBackup
+} from '../../services/sessions/sessionRecoveryService';
+
+export function useSessionConnectivity(setSyncState) {
+    useEffect(() => {
+        if (typeof window === 'undefined') return undefined;
+
+        const updateOnlineState = () => {
+            if (!navigator.onLine) {
+                setSyncState(SESSION_SYNC_STATES.offline);
+            } else {
+                setSyncState(current => (
+                    current === SESSION_SYNC_STATES.offline ? SESSION_SYNC_STATES.saved : current
+                ));
+            }
+        };
+
+        window.addEventListener('online', updateOnlineState);
+        window.addEventListener('offline', updateOnlineState);
+        updateOnlineState();
+
+        return () => {
+            window.removeEventListener('online', updateOnlineState);
+            window.removeEventListener('offline', updateOnlineState);
+        };
+    }, [setSyncState]);
+}
+
+export function useSessionSync({
+    backupKey,
+    profileId,
+    workoutId,
+    lastSyncedRef,
+    syncInFlightRef,
+    setSyncState,
+    setLastSavedAt
+}) {
+    return useCallback((currentExercises, currentElapsed) => {
+        if (typeof window === 'undefined') return;
+
+        writeSessionBackup(backupKey, {
+            elapsedSeconds: currentElapsed,
+            exercises: currentExercises
+        });
+
+        const currentFingerprint = createSessionFingerprint(currentExercises, currentElapsed);
+        if (!navigator.onLine) {
+            setSyncState(SESSION_SYNC_STATES.offline);
+            return;
+        }
+
+        if (
+            profileId &&
+            currentFingerprint !== lastSyncedRef.current &&
+            !syncInFlightRef.current
+        ) {
+            syncInFlightRef.current = true;
+            setSyncState(SESSION_SYNC_STATES.syncing);
+            activeSessionService
+                .update(profileId, {
+                    templateId: workoutId,
+                    elapsedSeconds: currentElapsed,
+                    exercises: currentExercises
+                })
+                .then(() => {
+                    lastSyncedRef.current = currentFingerprint;
+                    setLastSavedAt(new Date());
+                    setSyncState(SESSION_SYNC_STATES.saved);
+                })
+                .catch(err => {
+                    console.error(err);
+                    setSyncState(SESSION_SYNC_STATES.syncFailed);
+                })
+                .finally(() => {
+                    syncInFlightRef.current = false;
+                });
+        }
+    }, [backupKey, profileId, workoutId, lastSyncedRef, syncInFlightRef, setSyncState, setLastSavedAt]);
+}

--- a/src/pages/TrainerDashboard.jsx
+++ b/src/pages/TrainerDashboard.jsx
@@ -2,7 +2,9 @@ import React, { useState, useEffect } from 'react';
 import { Users, UserPlus, Copy, Check, ChevronLeft, PlusCircle, Trash2, X, RotateCw } from 'lucide-react';
 import { getFirestoreDeps } from '../firebaseDb';
 import { Button } from '../components/design-system/Button';
+import { ConfirmDialog } from '../components/design-system/ConfirmDialog';
 import { PremiumCard } from '../components/design-system/PremiumCard';
+import { toast } from 'sonner';
 
 import HistoryPage from './HistoryPage';
 import WorkoutsPage from './WorkoutsPage';
@@ -18,6 +20,8 @@ export function TrainerDashboard({ user, onBack, onNavigateToCreateWorkout }) {
     // Estados de UI
     const [showInviteModal, setShowInviteModal] = useState(false);
     const [copied, setCopied] = useState(false);
+    const [studentPendingUnlink, setStudentPendingUnlink] = useState(null);
+    const [unlinking, setUnlinking] = useState(false);
 
     // Estado de Seleção
     const [selectedStudent, setSelectedStudent] = useState(null);
@@ -97,22 +101,27 @@ export function TrainerDashboard({ user, onBack, onNavigateToCreateWorkout }) {
             setInviteCode(newInvite?.code || '');
         } catch (error) {
             console.error("Error creating trainer invite:", error);
-            alert("Erro ao gerar convite.");
+            toast.error("Erro ao gerar convite.");
         } finally {
             setInviteLoading(false);
         }
     };
 
-    const handleUnlink = async (student) => {
-        if (!window.confirm(`Tem certeza que deseja desvincular ${student.displayName}?`)) return;
+    const confirmUnlink = async () => {
+        if (!studentPendingUnlink) return;
+        setUnlinking(true);
         try {
             const { userService } = await import('../services/userService');
-            await userService.unlinkTrainer(student.id, user.uid);
+            await userService.unlinkTrainer(studentPendingUnlink.id, user.uid);
             await fetchStudents();
+            toast.success("Aluno desvinculado.");
             setSelectedStudent(null);
+            setStudentPendingUnlink(null);
         } catch (error) {
             console.error(error);
-            alert("Erro ao desvincular aluno.");
+            toast.error("Erro ao desvincular aluno.");
+        } finally {
+            setUnlinking(false);
         }
     };
 
@@ -150,7 +159,7 @@ export function TrainerDashboard({ user, onBack, onNavigateToCreateWorkout }) {
                             <Button
                                 variant="danger"
                                 size="sm"
-                                onClick={() => handleUnlink(selectedStudent)}
+                                onClick={() => setStudentPendingUnlink(selectedStudent)}
                                 leftIcon={<Trash2 size={16} />}
                                 className="bg-red-500/10 text-red-400 hover:bg-red-500/20 border-red-500/20"
                             >
@@ -226,7 +235,7 @@ export function TrainerDashboard({ user, onBack, onNavigateToCreateWorkout }) {
                                 user={selectedStudent}
                                 isTrainerMode={true}
                                 onNavigateToCreate={handleNavigateToCreate}
-                                onNavigateToWorkout={() => alert("Modo visualização de Personal: Execução desabilitada.")}
+                                onNavigateToWorkout={() => toast.info("Modo visualização de Personal: execução desabilitada.")}
                             />
                         </div>
                     ) : (
@@ -239,6 +248,15 @@ export function TrainerDashboard({ user, onBack, onNavigateToCreateWorkout }) {
                         </div>
                     )}
                 </div>
+                <ConfirmDialog
+                    isOpen={Boolean(studentPendingUnlink)}
+                    title="Desvincular aluno?"
+                    description={`Você vai remover o vínculo com ${studentPendingUnlink?.displayName || 'este aluno'}. O histórico do aluno será preservado.`}
+                    confirmLabel="Desvincular"
+                    loading={unlinking}
+                    onConfirm={confirmUnlink}
+                    onCancel={() => setStudentPendingUnlink(null)}
+                />
             </div>
         );
     }

--- a/src/pages/TrainerDashboard.test.jsx
+++ b/src/pages/TrainerDashboard.test.jsx
@@ -172,8 +172,10 @@ describe('TrainerDashboard', () => {
         fireEvent.click(screen.getByText('Aluno 1'));
         expect(screen.getByText('Treinos Atribuídos')).toBeInTheDocument();
 
-        vi.spyOn(window, 'confirm').mockReturnValue(true);
         fireEvent.click(screen.getByRole('button', { name: 'Desvincular' }));
+        expect(screen.getByText('Desvincular aluno?')).toBeInTheDocument();
+
+        fireEvent.click(screen.getAllByRole('button', { name: 'Desvincular' })[1]);
 
         await waitFor(() => {
             expect(userService.unlinkTrainer).toHaveBeenCalledWith('student-1', 'trainer-1');

--- a/src/pages/WorkoutExecutionPage.jsx
+++ b/src/pages/WorkoutExecutionPage.jsx
@@ -35,7 +35,7 @@ import { SyncStatusBadge } from '../components/design-system/SyncStatusBadge';
 import { useWorkoutTimer } from '../hooks/useWorkoutTimer';
 import { useWorkoutSession } from '../hooks/useWorkoutSession';
 import { checkNewAchievements } from '../utils/evaluateAchievements';
-import { userService } from '../services/userService';
+import { userPreferencesService } from '../services/userPreferencesService';
 import { workoutService } from '../services/workoutService';
 const AchievementUnlockedModal = React.lazy(() => import('../components/achievements/AchievementUnlockedModal').then(module => ({ default: module.AchievementUnlockedModal })));
 const loadShareableWorkoutCard = () => import('../components/sharing/ShareableWorkoutCard').then(module => ({ default: module.ShareableWorkoutCard }));
@@ -212,7 +212,7 @@ export function WorkoutExecutionPage({ user }) {
     // --- CARREGAR PREFERÊNCIAS DO USUÁRIO ---
     useEffect(() => {
         if (user?.uid) {
-            userService.getUserProfile(user.uid)
+            userPreferencesService.getWorkoutPreferences(user.uid)
                 .then(profile => {
                     if (profile?.defaultRestTime) {
                         setRestDuration(profile.defaultRestTime);
@@ -230,8 +230,8 @@ export function WorkoutExecutionPage({ user }) {
         setRestDuration(newDuration);
         if (user?.uid) {
             // Atualização "fire and forget"
-            userService
-                .updateUserProfile(user.uid, { defaultRestTime: newDuration })
+            userPreferencesService
+                .updateWorkoutPreferences(user.uid, { defaultRestTime: newDuration })
                 .catch(err => console.error("Failed to save rest preference:", err));
         }
     };
@@ -239,8 +239,8 @@ export function WorkoutExecutionPage({ user }) {
     const handleAutoStartChange = (newVal) => {
         setAutoStartTimer(newVal);
         if (user?.uid) {
-            userService
-                .updateUserProfile(user.uid, { autoStartTimer: newVal })
+            userPreferencesService
+                .updateWorkoutPreferences(user.uid, { autoStartTimer: newVal })
                 .catch(err => console.error("Failed to save auto start preference:", err));
         }
     };

--- a/src/pages/WorkoutExecutionPage.test.jsx
+++ b/src/pages/WorkoutExecutionPage.test.jsx
@@ -84,10 +84,10 @@ vi.mock('../utils/evaluateAchievements', () => ({
     checkNewAchievements: vi.fn()
 }));
 
-vi.mock('../services/userService', () => ({
-    userService: {
-        getUserProfile: vi.fn().mockResolvedValue({}),
-        updateUserProfile: vi.fn().mockResolvedValue()
+vi.mock('../services/userPreferencesService', () => ({
+    userPreferencesService: {
+        getWorkoutPreferences: vi.fn().mockResolvedValue({}),
+        updateWorkoutPreferences: vi.fn().mockResolvedValue()
     }
 }));
 

--- a/src/pages/WorkoutsPage.jsx
+++ b/src/pages/WorkoutsPage.jsx
@@ -26,6 +26,8 @@ import {
 import { RippleButton } from '../components/design-system/RippleButton';
 import { PremiumCard } from '../components/design-system/PremiumCard';
 import { AddCardioModal } from '../components/AddCardioModal';
+import { ConfirmDialog } from '../components/design-system/ConfirmDialog';
+import { toast } from 'sonner';
 const ExerciseCard = React.lazy(() => import('../components/workout/ExerciseCard').then(module => ({ default: module.ExerciseCard })));
 const EditExerciseModal = React.lazy(() => import('../components/workout/EditExerciseModal').then(module => ({ default: module.EditExerciseModal })));
 
@@ -45,6 +47,8 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
     // Menus
     const [activeCardMenu, setActiveCardMenu] = useState(null);
     const [isAddCardioOpen, setIsAddCardioOpen] = useState(false);
+    const [workoutPendingDelete, setWorkoutPendingDelete] = useState(null);
+    const [deletingWorkout, setDeletingWorkout] = useState(false);
     
     useEffect(() => {
         async function fetchWorkouts() {
@@ -134,18 +138,7 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
         setActiveCardMenu(null);
 
         if (action === 'delete') {
-            if (window.confirm(`Tem certeza que deseja excluir "${workout.name}"?`)) {
-                try {
-                    const { db, doc, deleteDoc } = await getFirestoreDeps();
-                    await deleteDoc(doc(db, 'workout_templates', workout.id));
-                    
-                    // Limpar cache após mutação
-                    const { workoutService } = await import('../services/workoutService');
-                    workoutService.clearCache();
-
-                    setWorkouts(prev => prev.filter(w => w.id !== workout.id));
-                } catch (err) { alert(err.message); }
-            }
+            setWorkoutPendingDelete(workout);
         } else if (action === 'duplicate') {
             const newWorkoutData = {
                 name: `${workout.name} (Cópia)`,
@@ -189,8 +182,9 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
                     },
                     ...prev
                 ]));
+                toast.success("Treino duplicado.");
             } catch (err) {
-                alert(err.message);
+                toast.error(err.message || "Erro ao duplicar treino.");
             }
         } else if (action === 'edit') {
             onNavigateToCreate(workout);
@@ -205,7 +199,8 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
                 workoutService.clearCache();
 
                 setWorkouts(prev => prev.map(w => w.id === workout.id ? { ...w, isArchived: true } : w));
-            } catch (err) { alert(err.message); }
+                toast.success("Treino arquivado.");
+            } catch (err) { toast.error(err.message || "Erro ao arquivar treino."); }
         } else if (action === 'unarchive') {
             try {
                 const { db, doc, updateDoc } = await getFirestoreDeps();
@@ -217,7 +212,28 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
                 workoutService.clearCache();
 
                 setWorkouts(prev => prev.map(w => w.id === workout.id ? { ...w, isArchived: false } : w));
-            } catch (err) { alert(err.message); }
+                toast.success("Treino desarquivado.");
+            } catch (err) { toast.error(err.message || "Erro ao desarquivar treino."); }
+        }
+    };
+
+    const confirmDeleteWorkout = async () => {
+        if (!workoutPendingDelete) return;
+        setDeletingWorkout(true);
+        try {
+            const { db, doc, deleteDoc } = await getFirestoreDeps();
+            await deleteDoc(doc(db, 'workout_templates', workoutPendingDelete.id));
+
+            const { workoutService } = await import('../services/workoutService');
+            workoutService.clearCache();
+
+            setWorkouts(prev => prev.filter(w => w.id !== workoutPendingDelete.id));
+            toast.success("Treino excluído.");
+            setWorkoutPendingDelete(null);
+        } catch (err) {
+            toast.error(err.message || "Erro ao excluir treino.");
+        } finally {
+            setDeletingWorkout(false);
         }
     };
 
@@ -481,6 +497,16 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
                 isOpen={isAddCardioOpen} 
                 onClose={() => setIsAddCardioOpen(false)} 
                 user={user} 
+            />
+
+            <ConfirmDialog
+                isOpen={Boolean(workoutPendingDelete)}
+                title="Excluir treino?"
+                description={`"${workoutPendingDelete?.name || 'Este treino'}" será removido das suas fichas. Essa ação não altera sessões já concluídas.`}
+                confirmLabel="Excluir"
+                loading={deletingWorkout}
+                onConfirm={confirmDeleteWorkout}
+                onCancel={() => setWorkoutPendingDelete(null)}
             />
 
         </div>

--- a/src/services/userPreferencesService.js
+++ b/src/services/userPreferencesService.js
@@ -1,0 +1,39 @@
+import { getFirestoreDeps } from '../firebaseDb';
+
+function pickWorkoutPreferences(profile) {
+    if (!profile) return {};
+
+    return {
+        defaultRestTime: profile.defaultRestTime,
+        autoStartTimer: profile.autoStartTimer
+    };
+}
+
+export const userPreferencesService = {
+    async getWorkoutPreferences(userId) {
+        if (!userId) return {};
+
+        const { db, doc, getDoc } = await getFirestoreDeps();
+        const userRef = doc(db, 'users', userId);
+        const userSnap = await getDoc(userRef);
+
+        return userSnap.exists() ? pickWorkoutPreferences(userSnap.data()) : {};
+    },
+
+    async updateWorkoutPreferences(userId, preferences) {
+        if (!userId) return;
+
+        const allowedUpdates = {};
+        if (Object.prototype.hasOwnProperty.call(preferences, 'defaultRestTime')) {
+            allowedUpdates.defaultRestTime = preferences.defaultRestTime;
+        }
+        if (Object.prototype.hasOwnProperty.call(preferences, 'autoStartTimer')) {
+            allowedUpdates.autoStartTimer = preferences.autoStartTimer;
+        }
+
+        if (Object.keys(allowedUpdates).length === 0) return;
+
+        const { db, doc, setDoc } = await getFirestoreDeps();
+        await setDoc(doc(db, 'users', userId), allowedUpdates, { merge: true });
+    }
+};


### PR DESCRIPTION
## O que mudou
- Resolve o warning de arquitetura/performance do `userService` removendo imports estáticos do fluxo principal e criando `userPreferencesService` para preferências leves da execução de treino.
- Remove os `alert`/`confirm` restantes em telas/componentes principais, usando `toast` e um `ConfirmDialog` reutilizável para ações perigosas.
- Divide `useWorkoutSession` em módulos menores: loader/recuperação, sync/conectividade, finalização/descarte, ações de exercícios e normalização de séries.

## Impacto
- Build deixa de emitir o aviso de import dinâmico/estático misto do `userService`; o serviço agora sai como chunk separado pequeno.
- UX fica mais profissional, sem diálogos bloqueantes nativos do navegador.
- A sessão de treino fica mais fácil de manter sem alterar a API pública consumida pela `WorkoutExecutionPage`.

## Como foi testado
- `npm run lint`
- `npm test -- --run src/context/WorkoutContext.test.jsx src/pages/WorkoutExecutionPage.test.jsx src/pages/TrainerDashboard.test.jsx src/pages/WorkoutsPage.test.jsx src/services/sessions/sessionRecoveryService.test.js`
- `npm test -- --run`
- `npm run build`

## Observações
- O build mantém apenas o aviso já conhecido de Browserslist/caniuse-lite desatualizado.