### PR TITLE
[codex] Authenticated visual polish

### DIFF
--- a/src/AppAuthed.jsx
+++ b/src/AppAuthed.jsx
@@ -326,7 +326,7 @@ function AppAuthedContent() {
                         user={user}
                         isTrainer={isTrainer}
                     />
-                    <div className="lg:hidden fixed bottom-0 left-0 right-0 z-50 pointer-events-none pb-[env(safe-area-inset-bottom)] flex justify-center">
+                    <div className="lg:hidden fixed bottom-0 left-0 right-0 z-50 pointer-events-none pb-[calc(0.75rem+env(safe-area-inset-bottom))] flex justify-center">
                         <Suspense fallback={
                             <div className="h-16 w-full max-w-md rounded-2xl bg-slate-900/50 border border-slate-800/50" />
                         }>
@@ -341,13 +341,13 @@ function AppAuthedContent() {
             )}
 
             <div className={`w-full min-h-screen transition-all duration-300 relative flex flex-col ${user && !location.pathname.startsWith('/execute') && location.pathname !== '/login'
-                ? 'pt-[calc(2rem+env(safe-area-inset-top))] pb-32 lg:pb-8 lg:pt-8 lg:pl-64'
+                ? 'pt-[calc(1rem+env(safe-area-inset-top))] pb-44 lg:pb-8 lg:pt-8 lg:pl-64'
                 : ''
                 }`}>
                 <div className="w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex-1">
                     {showHeader && (
-                        <header className="app-header mb-8">
-                            <h1 className="app-logo-name text-transparent bg-clip-text bg-gradient-to-r from-cyan-400 to-blue-500">Vitalità</h1>
+                        <header className="sr-only">
+                            <h1>Vitalità</h1>
                         </header>
                     )}
 

--- a/src/BottomNavEnhanced.jsx
+++ b/src/BottomNavEnhanced.jsx
@@ -53,14 +53,14 @@ export function BottomNavEnhanced({ activeTab, onTabChange }) {
 
     return (
         <nav
-            className="pointer-events-auto mb-6 mx-4"
+            className="pointer-events-auto mx-3"
             style={{
                 position: 'relative',
                 zIndex: 100,
             }}
         >
             <div
-                className="flex items-center gap-1 p-1.5 rounded-[32px] border border-white/10 relative overflow-hidden backdrop-blur-3xl"
+                className="flex items-center gap-1 p-1.5 rounded-[28px] border border-white/10 relative overflow-hidden backdrop-blur-3xl"
                 style={{
                     background: 'rgba(12, 12, 14, 0.45)', // Base dark glass
                     boxShadow: '0 20px 40px -10px rgba(0,0,0,0.5), 0 0 0 1px rgba(255,255,255,0.05) inset',
@@ -91,8 +91,8 @@ export function BottomNavEnhanced({ activeTab, onTabChange }) {
                                 onTouchEnd={() => setPressedTab(null)}
                                 className="relative group mx-1 flex shrink-0 items-center justify-center p-0 border-0 bg-transparent appearance-none"
                                 style={{
-                                    width: '56px',
-                                    height: '56px',
+                                    width: '50px',
+                                    height: '50px',
                                     transform: 'translateY(-2px)',
                                     WebkitTapHighlightColor: 'transparent',
                                     outline: 'none'
@@ -112,9 +112,9 @@ export function BottomNavEnhanced({ activeTab, onTabChange }) {
                                     }}
                                     transition={{ type: "spring", stiffness: 400, damping: 17 }}
                                     style={{
-                                        width: '48px',
-                                        height: '48px',
-                                        borderRadius: '24px',
+                                        width: '44px',
+                                        height: '44px',
+                                        borderRadius: '22px',
                                         background: 'rgba(6, 182, 212, 0.15)', // Glassy cyan tint
                                         backdropFilter: 'blur(12px)',
                                         border: '1px solid rgba(255, 255, 255, 0.15)',
@@ -134,18 +134,18 @@ export function BottomNavEnhanced({ activeTab, onTabChange }) {
                             onClick={() => handlePress(tab.id)}
                             onTouchStart={() => setPressedTab(tab.id)}
                             onTouchEnd={() => setPressedTab(null)}
-                            className="relative flex flex-col items-center justify-center px-4 py-2"
+                            className="relative flex flex-col items-center justify-center px-3 py-1.5"
                             style={{
                                 WebkitTapHighlightColor: 'transparent',
                                 outline: 'none',
-                                minWidth: '64px'
+                                minWidth: '56px'
                             }}
                         >
                             {/* Sliding Active Indicator */}
                             {isActive && (
                                 <motion.div
                                     layoutId="activeTabIndicator"
-                                    className="absolute inset-0 rounded-[20px] z-0"
+                                    className="absolute inset-0 rounded-[18px] z-0"
                                     initial={false}
                                     transition={{ type: "spring", stiffness: 300, damping: 30 }}
                                     style={{
@@ -156,7 +156,7 @@ export function BottomNavEnhanced({ activeTab, onTabChange }) {
                                 />
                             )}
 
-                            <div className="relative z-10 flex flex-col items-center gap-1">
+                            <div className="relative z-10 flex flex-col items-center gap-0.5">
                                 <motion.div
                                     initial={false}
                                     animate={{
@@ -166,13 +166,13 @@ export function BottomNavEnhanced({ activeTab, onTabChange }) {
                                     transition={{ type: "spring", stiffness: 500, damping: 25 }}
                                 >
                                     <Icon
-                                        size={22}
+                                        size={21}
                                         strokeWidth={isActive ? 2.5 : 2}
                                         className={`transition-colors duration-300 ${isActive ? 'text-cyan-400' : 'text-slate-400'}`}
                                     />
                                 </motion.div>
 
-                                <span className={`text-[10px] font-medium transition-colors duration-300 ${isActive ? 'text-cyan-400' : 'text-slate-500'}`}>
+                                <span className={`text-[9px] font-medium transition-colors duration-300 ${isActive ? 'text-cyan-400' : 'text-slate-500'}`}>
                                     {tab.label}
                                 </span>
                             </div>

--- a/src/components/analytics/EvolutionChart.jsx
+++ b/src/components/analytics/EvolutionChart.jsx
@@ -1,5 +1,6 @@
 
 import React from 'react';
+import { LineChart } from 'lucide-react';
 
 let rechartsPromise;
 const loadRecharts = () => {
@@ -43,8 +44,14 @@ export function EvolutionChart({ data }) {
 
     if (!data || data.length === 0) {
         return (
-            <div className="h-64 flex items-center justify-center border border-dashed border-slate-800 rounded-2xl bg-slate-900/20">
-                <p className="text-slate-500 text-sm">Sem dados suficientes neste período</p>
+            <div className="h-64 flex flex-col items-center justify-center rounded-2xl border border-dashed border-slate-800 bg-slate-900/20 px-6 text-center">
+                <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-2xl bg-cyan-500/10 text-cyan-300 ring-1 ring-cyan-400/20">
+                    <LineChart size={24} />
+                </div>
+                <p className="text-sm font-bold text-slate-200">Sem evolução neste período</p>
+                <p className="mt-1 max-w-xs text-xs leading-relaxed text-slate-500">
+                    Finalize treinos com carga e repetições para montar o gráfico automaticamente.
+                </p>
             </div>
         );
     }

--- a/src/components/design-system/EmptyState.jsx
+++ b/src/components/design-system/EmptyState.jsx
@@ -10,7 +10,7 @@ export function EmptyState({
     return (
         <div className={`rounded-3xl border border-dashed border-slate-700/70 bg-slate-900/35 px-5 py-8 text-center ${className}`}>
             {icon && (
-                <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-slate-950/70 text-slate-400 ring-1 ring-white/10">
+                <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-cyan-500/10 text-cyan-300 ring-1 ring-cyan-400/20">
                     {icon}
                 </div>
             )}

--- a/src/components/design-system/PageHeader.jsx
+++ b/src/components/design-system/PageHeader.jsx
@@ -12,37 +12,37 @@ export function PageHeader({
     className = ''
 }) {
     return (
-        <header className={`mb-6 ${className}`}>
+        <header className={`mb-5 lg:mb-6 ${className}`}>
             {onBack && (
                 <Button
                     variant="outline-primary"
                     size="sm"
                     onClick={onBack}
-                    className="mb-5 rounded-full uppercase"
+                    className="mb-4 rounded-full uppercase lg:mb-5"
                     leftIcon={<ChevronLeft size={16} />}
                 >
                     {backLabel}
                 </Button>
             )}
-            <div className="flex items-start justify-between gap-4">
-                <div className="flex min-w-0 items-start gap-3">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                <div className="flex min-w-0 items-start gap-3 sm:flex-1">
                     {icon && (
                         <div className="mt-0.5 flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-cyan-500/10 text-cyan-300 ring-1 ring-cyan-400/25">
                             {icon}
                         </div>
                     )}
                     <div className="min-w-0">
-                        <h1 className="text-2xl font-bold text-white lg:text-3xl">
+                        <h1 className="text-2xl font-bold leading-tight text-white lg:text-3xl">
                             {title}
                         </h1>
                         {description && (
-                            <p className="mt-1 text-sm leading-relaxed text-slate-400">
+                            <p className="mt-1 max-w-2xl text-sm leading-relaxed text-slate-400">
                                 {description}
                             </p>
                         )}
                     </div>
                 </div>
-                {action && <div className="shrink-0">{action}</div>}
+                {action && <div className="w-full shrink-0 sm:w-auto">{action}</div>}
             </div>
         </header>
     );

--- a/src/components/history/HistoryAnalyticsSection.jsx
+++ b/src/components/history/HistoryAnalyticsSection.jsx
@@ -257,8 +257,14 @@ export function HistoryAnalyticsSection({
                     ) : (
                         ((searchMode === 'template' && selectedTemplate && selectedExercise) || 
                          (searchMode === 'global' && selectedGlobalExercises.length > 0)) && (
-                            <div className="py-12 text-center border border-dashed border-slate-800 rounded-2xl">
-                                <p className="text-slate-500">Nenhum registro encontrado.</p>
+                            <div className="rounded-2xl border border-dashed border-slate-800 bg-slate-900/20 px-5 py-12 text-center">
+                                <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-2xl bg-cyan-500/10 text-cyan-300 ring-1 ring-cyan-400/20">
+                                    <TrendingUp size={24} />
+                                </div>
+                                <p className="text-sm font-bold text-slate-200">Nenhum registro encontrado</p>
+                                <p className="mx-auto mt-1 max-w-sm text-xs leading-relaxed text-slate-500">
+                                    Ajuste os filtros ou finalize novas sessões para alimentar esta análise.
+                                </p>
                             </div>
                         )
                     )}

--- a/src/pages/CreateWorkoutPage.jsx
+++ b/src/pages/CreateWorkoutPage.jsx
@@ -230,7 +230,7 @@ export default function CreateWorkoutPage({ user }) {
     }
 
     return (
-        <div className="w-full max-w-3xl mx-auto px-4 pt-[calc(1.5rem+env(safe-area-inset-top))] pb-32">
+        <div className="w-full max-w-3xl mx-auto px-4 pt-2 pb-48 lg:pt-[calc(1.5rem+env(safe-area-inset-top))] lg:pb-32">
             <PageHeader
                 title={initialData ? 'Editar Treino' : 'Criar Novo Treino'}
                 description="Monte a ficha com exercícios, séries, repetições e método de execução."
@@ -263,6 +263,28 @@ export default function CreateWorkoutPage({ user }) {
                         icon={<Dumbbell size={24} />}
                         title="Nenhum exercício adicionado"
                         description="Adicione o primeiro exercício para habilitar o salvamento da ficha."
+                        action={
+                            <Button
+                                onClick={() => {
+                                    setEditingExerciseId(null);
+                                    setNewExercise({
+                                        muscleGroup: '',
+                                        name: '',
+                                        sets: '3',
+                                        reps: '12',
+                                        method: 'Convencional',
+                                        rest: '',
+                                        notes: ''
+                                    });
+                                    setShowAddExercise(true);
+                                }}
+                                variant="secondary"
+                                size="sm"
+                                leftIcon={<Plus size={16} />}
+                            >
+                                Adicionar Exercício
+                            </Button>
+                        }
                         className="py-8"
                     />
                 ) : (
@@ -482,7 +504,7 @@ export default function CreateWorkoutPage({ user }) {
                 </div>
             )}
 
-            {!showAddExercise && (
+            {!showAddExercise && exercises.length > 0 && (
                 <Button
                     onClick={() => {
                         setEditingExerciseId(null);
@@ -513,10 +535,15 @@ export default function CreateWorkoutPage({ user }) {
                 variant="primary"
                 size="lg"
                 fullWidth
-                className="shadow-xl"
+                className="shadow-xl disabled:border-slate-700 disabled:bg-slate-900/60 disabled:bg-none disabled:text-slate-500 disabled:shadow-none disabled:opacity-100"
             >
                 {loading ? 'Salvando...' : 'Salvar Treino'}
             </Button>
+            {(exercises.length === 0 || !workoutName) && !loading && (
+                <p className="mt-3 text-center text-xs text-slate-500">
+                    Informe o nome e adicione pelo menos um exercício para salvar.
+                </p>
+            )}
 
         </div>
     );

--- a/src/pages/HistoryPage.jsx
+++ b/src/pages/HistoryPage.jsx
@@ -524,9 +524,9 @@ function HistoryPage({ user, isEmbedded = false }) {
     }, [selectedTemplate, selectedExercise, user, activeTab, chartRange, searchMode, globalSearchTerm, selectedGlobalExercises, globalSessionsCache]);
 
     return (
-        <div className="min-h-screen bg-[#020617] pb-32">
+        <div className="min-h-screen bg-[#020617] pb-48 lg:pb-32">
             {/* --- CABEÇALHO --- */}
-            <div className="sticky top-0 z-40 bg-[#020617]/95 backdrop-blur-md pt-[calc(1.5rem+env(safe-area-inset-top))] pb-4">
+            <div className="sticky top-0 z-40 bg-[#020617]/95 backdrop-blur-md pt-2 pb-4 lg:pt-[calc(1.5rem+env(safe-area-inset-top))]">
                 <div className="w-full max-w-5xl mx-auto px-4 space-y-4">
                     {!isEmbedded && (
                         <PageHeader

--- a/src/pages/HomeDashboard.jsx
+++ b/src/pages/HomeDashboard.jsx
@@ -533,11 +533,11 @@ export function HomeDashboard({
 
 
     return (
-        <div className="pb-24 lg:pb-8 max-w-3xl mx-auto w-full">
+        <div className="pb-44 lg:pb-8 max-w-3xl mx-auto w-full">
             <div className="w-full px-4 lg:px-8 flex flex-col">
 
                 {/* 1. SAUDAÇÃO */}
-                <div className="pt-6 pb-6">
+                <div className="pt-2 pb-5 lg:pt-6 lg:pb-6">
                     <h1 className="text-2xl lg:text-3xl mb-1 text-white font-heading font-bold">
                         {greeting}, <span className="bg-gradient-to-r from-blue-400 to-cyan-400 bg-clip-text text-transparent">{firstName}</span>
                     </h1>
@@ -576,7 +576,7 @@ export function HomeDashboard({
                 </div>
 
                 {/* 3. MOTIVACIONAL */}
-                <div className="mb-8 p-6 rounded-2xl text-center bg-gradient-to-br from-blue-500/5 to-cyan-500/5 border border-blue-500/10 relative group">
+                <div className="mb-6 p-5 lg:mb-8 lg:p-6 rounded-2xl text-center bg-gradient-to-br from-blue-500/5 to-cyan-500/5 border border-blue-500/10 relative group">
                     <Star size={20} className="text-cyan-400 mx-auto mb-3" />
                     <p className="text-sm text-slate-300 italic font-medium">
                         &quot;{dailyQuote}&quot;
@@ -603,7 +603,7 @@ export function HomeDashboard({
                 />
 
                 {/* 4. SEÇÃO HERO - PRÓXIMO TREINO */}
-                <div className="mb-8">
+                <div className="mb-6 lg:mb-8">
                     <SectionHeader
                         icon={<Target size={18} />}
                         title="Próximo Treino Sugerido"

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -292,7 +292,7 @@ export default function ProfilePage({ user, onLogout, onNavigateToHistory, onNav
     }
 
     return (
-        <div className="min-h-screen bg-slate-950 pb-32 px-4 pt-6 w-full max-w-3xl mx-auto">
+        <div className="min-h-screen bg-slate-950 pb-48 px-4 pt-2 w-full max-w-3xl mx-auto lg:pb-32 lg:pt-6">
 
             {/* --- CARTÃO DE CABEÇALHO DO PERFIL --- */}
             <div className="bg-slate-900/50 rounded-3xl p-6 mb-6 border border-slate-800 relative overflow-hidden">

--- a/src/pages/TrainerDashboard.jsx
+++ b/src/pages/TrainerDashboard.jsx
@@ -269,7 +269,7 @@ export function TrainerDashboard({ user, onBack, onNavigateToCreateWorkout }) {
 
     // --- VISÃO PRINCIPAL DO DASHBOARD ---
     return (
-        <div className="min-h-screen bg-[#020617] pb-24 lg:pt-0 pt-4 px-4 lg:px-8 max-w-5xl mx-auto">
+        <div className="min-h-screen bg-[#020617] pb-48 pt-2 px-4 lg:px-8 max-w-5xl mx-auto lg:pb-24 lg:pt-0">
 
             <PageHeader
                 title="Área do Personal"
@@ -280,7 +280,7 @@ export function TrainerDashboard({ user, onBack, onNavigateToCreateWorkout }) {
                     <Button
                         onClick={() => setShowInviteModal(true)}
                         size="sm"
-                        className="rounded-xl"
+                        className="w-full rounded-xl sm:w-auto"
                         leftIcon={<UserPlus size={18} />}
                     >
                         Convidar Aluno

--- a/src/pages/WorkoutExecutionPage.jsx
+++ b/src/pages/WorkoutExecutionPage.jsx
@@ -906,7 +906,7 @@ export function WorkoutExecutionPage({ user }) {
 
                 {/* Footer Fim de Treino - Apenas mostra se o modal de finalização NÃO estiver visível */}
                 {!showFinishModal && (
-                    <div className="w-full mt-8 pb-[calc(2rem+env(safe-area-inset-bottom))]">
+                    <div className="w-full mt-8 pb-[calc(6rem+env(safe-area-inset-bottom))] lg:pb-[calc(2rem+env(safe-area-inset-bottom))]">
                         <div className="max-w-2xl mx-auto flex justify-center">
                             <div className="space-y-4 w-full flex flex-col items-center px-4">
                                 <Button

--- a/src/pages/WorkoutsPage.jsx
+++ b/src/pages/WorkoutsPage.jsx
@@ -240,10 +240,10 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
 
     // --- RENDER ---
     return (
-        <div className="min-h-screen pb-32 pt-[calc(1.5rem+env(safe-area-inset-top))] px-4 lg:px-8 w-full max-w-5xl mx-auto">
+        <div className="min-h-screen pb-48 pt-2 px-4 lg:px-8 w-full max-w-5xl mx-auto lg:pt-[calc(1.5rem+env(safe-area-inset-top))] lg:pb-32">
 
             {/* 1. HEADER & SEARCH */}
-            <div className="space-y-8 pt-6 mb-8">
+            <div className="space-y-6 pt-2 mb-8 lg:space-y-8 lg:pt-6">
                 {/* Top Bar - Hide if Trainer Mode */}
                 {!isTrainerMode && (
                     <PageHeader
@@ -251,12 +251,12 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
                         description="Gerencie suas fichas, modelos do personal e treinos arquivados."
                         icon={<Dumbbell size={22} />}
                         action={(
-                            <div className="flex gap-2">
+                            <div className="flex w-full gap-2 sm:w-auto">
                                 <Button
                                     variant="secondary"
                                     size="sm"
                                     onClick={() => setIsAddCardioOpen(true)}
-                                    className="rounded-xl"
+                                    className="flex-1 rounded-xl sm:flex-none"
                                     leftIcon={<Activity size={16} />}
                                 >
                                     <span className="hidden sm:inline">Cardio</span>
@@ -265,7 +265,7 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
                                 <Button
                                     size="sm"
                                     onClick={() => onNavigateToCreate(null, { targetUserId: user.uid })}
-                                    className="rounded-xl"
+                                    className="flex-1 rounded-xl sm:flex-none"
                                     leftIcon={<Plus size={16} />}
                                 >
                                     <span className="hidden sm:inline">Novo Treino</span>


### PR DESCRIPTION
## O que foi alterado
- Compacta a navegação inferior mobile e aumenta o respiro inferior das telas autenticadas.
- Remove a repetição visual do logo global nas telas autenticadas, mantendo a marca na sidebar e acessibilidade via heading oculto.
- Ajusta PageHeader para empilhar ações no mobile e evitar texto espremido.
- Melhora empty states de evolução/histórico e o estado desabilitado de salvar treino.
- Dá mais respiro ao rodapé da execução de treino em mobile.

## Como foi testado
- npm run lint
- npm test -- --run
- npm run build

## Impacto em segurança
- Nenhum. Mudança visual/layout apenas.

## Impacto em Firestore/rules/indexes
- Nenhum.

## Impacto visual
- Melhora desktop e mobile autenticados, especialmente bottom nav, headers, estados vazios e botões desabilitados.