### PR TITLE
[codex] Add user data JSON export

### DIFF
--- a/docs/privacy-lgpd.md
+++ b/docs/privacy-lgpd.md
@@ -164,7 +164,8 @@ Escrita:
 
 ## Exportação de Dados
 
-Primeira versão sugerida: exportação JSON gerada no cliente para o próprio usuário.
+Primeira versão implementada: exportação JSON gerada no cliente para o próprio usuário
+a partir da tela de Perfil.
 
 Escopo mínimo:
 
@@ -178,7 +179,9 @@ Escopo mínimo:
 
 Observações:
 
-- A exportação pode ser paginada para histórico grande.
+- A exportação lê apenas documentos que as regras permitem ao usuário autenticado.
+- A exportação pode consumir leituras proporcionais ao volume de histórico do usuário.
+- Para histórico grande, uma próxima versão pode paginar ou dividir o arquivo.
 - O JSON deve incluir `exportedAt` e `schemaVersion`.
 - CSV pode ser adicionado depois para histórico e evolução por exercício.
 

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -21,7 +21,8 @@ import {
     Zap,
     Crown,
     FileText,
-    ShieldCheck
+    ShieldCheck,
+    FileDown
 } from 'lucide-react';
 import { achievementsCatalog } from '../data/achievementsCatalog';
 import { evaluateAchievements, calculateStats, evaluateHistory } from '../utils/evaluateAchievements';
@@ -42,6 +43,7 @@ export default function ProfilePage({ user, onLogout, onNavigateToHistory, onNav
 
     const [loading, setLoading] = useState(true);
     const [saving, setSaving] = useState(false);
+    const [exportingData, setExportingData] = useState(false);
 
     // --- VINCULAÇÃO DE PERSONAL TRAINER ---
     const [showLinkTrainer, setShowLinkTrainer] = useState(false);
@@ -259,6 +261,23 @@ export default function ProfilePage({ user, onLogout, onNavigateToHistory, onNav
             toast.error("Erro ao salvar perfil.");
         } finally {
             setSaving(false);
+        }
+    };
+
+    const handleExportData = async () => {
+        if (!user?.uid || exportingData) return;
+
+        setExportingData(true);
+        try {
+            const { privacyExportService } = await import('../services/privacyExportService');
+            const exportPayload = await privacyExportService.buildUserDataExport(user);
+            const fileName = privacyExportService.downloadJson(exportPayload);
+            toast.success(`Exportação criada: ${fileName}`);
+        } catch (err) {
+            console.error('Error exporting user data:', err);
+            toast.error('Não foi possível exportar seus dados agora.');
+        } finally {
+            setExportingData(false);
         }
     };
 
@@ -713,7 +732,7 @@ export default function ProfilePage({ user, onLogout, onNavigateToHistory, onNav
                         ? `Consentimento registrado: Política v${privacyConsent.privacyVersion || PRIVACY_POLICY_VERSION} e Termos v${privacyConsent.termsVersion || TERMS_OF_USE_VERSION}.`
                         : `Esta conta é anterior ao registro de versão. Novos cadastros salvam Política v${PRIVACY_POLICY_VERSION} e Termos v${TERMS_OF_USE_VERSION}.`}
                 </p>
-                <div className="grid gap-3 sm:grid-cols-2">
+                <div className="grid gap-3 sm:grid-cols-3">
                     <a
                         href="/privacy"
                         className="inline-flex items-center justify-center gap-2 rounded-2xl border border-cyan-400/20 bg-cyan-400/5 px-4 py-3 text-xs font-bold uppercase tracking-widest text-cyan-300 transition-colors hover:border-cyan-300/50 hover:bg-cyan-400/10"
@@ -728,6 +747,16 @@ export default function ProfilePage({ user, onLogout, onNavigateToHistory, onNav
                         <FileText size={16} />
                         Termos
                     </a>
+                    <Button
+                        variant="outline-primary"
+                        size="sm"
+                        onClick={handleExportData}
+                        loading={exportingData}
+                        className="h-auto rounded-2xl px-4 py-3 text-xs"
+                        leftIcon={<FileDown size={16} />}
+                    >
+                        Exportar dados
+                    </Button>
                 </div>
             </div>
 

--- a/src/services/privacyExportService.js
+++ b/src/services/privacyExportService.js
@@ -1,0 +1,120 @@
+import { getFirestoreDeps } from '../firebaseDb';
+import { PRIVACY_POLICY_VERSION, TERMS_OF_USE_VERSION } from '../constants/legal';
+
+const EXPORT_SCHEMA_VERSION = 1;
+
+function toSerializable(value) {
+    if (value == null) return value;
+    if (value instanceof Date) return value.toISOString();
+    if (typeof value.toDate === 'function') return value.toDate().toISOString();
+    if (Array.isArray(value)) return value.map(toSerializable);
+    if (typeof value === 'object') {
+        return Object.fromEntries(
+            Object.entries(value).map(([key, nestedValue]) => [key, toSerializable(nestedValue)])
+        );
+    }
+    return value;
+}
+
+function mapDoc(docSnap) {
+    return toSerializable({
+        id: docSnap.id,
+        ...docSnap.data()
+    });
+}
+
+async function getDocData(deps, collectionName, docId) {
+    const { db, doc, getDoc } = deps;
+    const snap = await getDoc(doc(db, collectionName, docId));
+    return snap.exists() ? mapDoc(snap) : null;
+}
+
+async function getCollectionByField(deps, collectionName, fieldName, value) {
+    const { db, collection, query, where, getDocs } = deps;
+    const q = query(collection(db, collectionName), where(fieldName, '==', value));
+    const snap = await getDocs(q);
+    return snap.docs.map(mapDoc);
+}
+
+function sortByTimestampDesc(items, fieldName) {
+    return [...items].sort((a, b) => {
+        const aTime = a?.[fieldName] ? new Date(a[fieldName]).getTime() : 0;
+        const bTime = b?.[fieldName] ? new Date(b[fieldName]).getTime() : 0;
+        return bTime - aTime;
+    });
+}
+
+export const privacyExportService = {
+    async buildUserDataExport(user) {
+        if (!user?.uid) {
+            throw new Error('EXPORT_REQUIRES_USER');
+        }
+
+        const deps = await getFirestoreDeps();
+        const userId = user.uid;
+
+        const [
+            profile,
+            workoutTemplates,
+            workoutSessions,
+            activeWorkout,
+            studentLinks,
+            trainerLinks,
+            trainerInvites,
+            userStats
+        ] = await Promise.all([
+            getDocData(deps, 'users', userId),
+            getCollectionByField(deps, 'workout_templates', 'userId', userId),
+            getCollectionByField(deps, 'workout_sessions', 'userId', userId),
+            getDocData(deps, 'active_workouts', userId),
+            getCollectionByField(deps, 'trainer_students', 'studentId', userId),
+            getCollectionByField(deps, 'trainer_students', 'trainerId', userId),
+            getCollectionByField(deps, 'trainer_invites', 'trainerId', userId),
+            getDocData(deps, 'user_stats', userId)
+        ]);
+
+        return {
+            schemaVersion: EXPORT_SCHEMA_VERSION,
+            exportedAt: new Date().toISOString(),
+            legalVersions: {
+                privacyPolicy: PRIVACY_POLICY_VERSION,
+                termsOfUse: TERMS_OF_USE_VERSION
+            },
+            user: {
+                uid: user.uid,
+                email: user.email || profile?.email || null,
+                displayName: user.displayName || profile?.displayName || profile?.fullName || null
+            },
+            data: {
+                profile,
+                workoutTemplates: sortByTimestampDesc(workoutTemplates, 'updatedAt'),
+                workoutSessions: sortByTimestampDesc(workoutSessions, 'completedAt'),
+                activeWorkout,
+                trainerStudentLinks: {
+                    asStudent: sortByTimestampDesc(studentLinks, 'linkedAt'),
+                    asTrainer: sortByTimestampDesc(trainerLinks, 'linkedAt')
+                },
+                trainerInvites: sortByTimestampDesc(trainerInvites, 'createdAt'),
+                userStats
+            }
+        };
+    },
+
+    downloadJson(exportPayload) {
+        const safeDate = new Date().toISOString().slice(0, 10);
+        const fileName = `vitalita-dados-${safeDate}.json`;
+        const blob = new Blob([JSON.stringify(exportPayload, null, 2)], {
+            type: 'application/json;charset=utf-8'
+        });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = fileName;
+        link.rel = 'noopener';
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+        URL.revokeObjectURL(url);
+        return fileName;
+    }
+};

--- a/src/services/privacyExportService.test.js
+++ b/src/services/privacyExportService.test.js
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getFirestoreDeps } from '../firebaseDb';
+import { privacyExportService } from './privacyExportService';
+
+vi.mock('../firebaseDb', () => ({
+    getFirestoreDeps: vi.fn()
+}));
+
+function makeDoc(id, data, exists = true) {
+    return {
+        id,
+        exists: () => exists,
+        data: () => data
+    };
+}
+
+function makeTimestamp(dateString) {
+    return {
+        toDate: () => new Date(dateString)
+    };
+}
+
+describe('privacyExportService', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('builds a serializable user data export payload', async () => {
+        const docsByPath = {
+            'users/user-1': makeDoc('user-1', {
+                displayName: 'Tiago',
+                privacyConsent: {
+                    acceptedAt: makeTimestamp('2026-07-07T10:00:00.000Z')
+                }
+            }),
+            'active_workouts/user-1': makeDoc('user-1', {
+                userId: 'user-1',
+                updatedAt: makeTimestamp('2026-07-07T11:00:00.000Z')
+            }),
+            'user_stats/user-1': makeDoc('user-1', {
+                totalWorkouts: 2,
+                updatedAt: makeTimestamp('2026-07-07T12:00:00.000Z')
+            })
+        };
+
+        const docsByCollection = {
+            workout_templates: [
+                makeDoc('template-1', {
+                    userId: 'user-1',
+                    name: 'Treino A',
+                    updatedAt: makeTimestamp('2026-07-06T12:00:00.000Z')
+                })
+            ],
+            workout_sessions: [
+                makeDoc('session-old', {
+                    userId: 'user-1',
+                    completedAt: makeTimestamp('2026-07-01T12:00:00.000Z')
+                }),
+                makeDoc('session-new', {
+                    userId: 'user-1',
+                    completedAt: makeTimestamp('2026-07-07T12:00:00.000Z')
+                })
+            ],
+            trainer_students: [
+                makeDoc('user-1_trainer-1', {
+                    studentId: 'user-1',
+                    trainerId: 'trainer-1',
+                    linkedAt: makeTimestamp('2026-07-05T12:00:00.000Z')
+                })
+            ],
+            trainer_invites: [
+                makeDoc('invite-1', {
+                    trainerId: 'user-1',
+                    createdAt: makeTimestamp('2026-07-04T12:00:00.000Z')
+                })
+            ]
+        };
+
+        getFirestoreDeps.mockResolvedValue({
+            db: {},
+            doc: (_db, collectionName, docId) => `${collectionName}/${docId}`,
+            getDoc: vi.fn(async (path) => docsByPath[path] || makeDoc(path, {}, false)),
+            collection: (_db, collectionName) => collectionName,
+            where: (fieldName, _operator, value) => ({ fieldName, value }),
+            query: (collectionName, constraint) => ({ collectionName, constraint }),
+            getDocs: vi.fn(async ({ collectionName, constraint }) => {
+                const docs = (docsByCollection[collectionName] || []).filter((docSnap) => {
+                    const data = docSnap.data();
+                    return data[constraint.fieldName] === constraint.value;
+                });
+                return { docs };
+            })
+        });
+
+        const payload = await privacyExportService.buildUserDataExport({
+            uid: 'user-1',
+            email: 'tiago@example.com',
+            displayName: 'Tiago'
+        });
+
+        expect(payload.schemaVersion).toBe(1);
+        expect(payload.user).toMatchObject({
+            uid: 'user-1',
+            email: 'tiago@example.com',
+            displayName: 'Tiago'
+        });
+        expect(payload.data.profile.privacyConsent.acceptedAt).toBe('2026-07-07T10:00:00.000Z');
+        expect(payload.data.workoutTemplates).toHaveLength(1);
+        expect(payload.data.workoutSessions.map(session => session.id)).toEqual(['session-new', 'session-old']);
+        expect(payload.data.trainerStudentLinks.asStudent).toHaveLength(1);
+        expect(payload.data.trainerInvites).toHaveLength(1);
+        expect(payload.data.userStats.totalWorkouts).toBe(2);
+    });
+
+    it('requires an authenticated user', async () => {
+        await expect(privacyExportService.buildUserDataExport(null)).rejects.toThrow('EXPORT_REQUIRES_USER');
+    });
+});


### PR DESCRIPTION
## O que foi alterado

- Adiciona `privacyExportService` para montar exportação JSON dos dados do usuário.
- Adiciona botão "Exportar dados" na seção de Privacidade e termos do Perfil.
- Exporta perfil, fichas próprias, sessões próprias, treino ativo, vínculos aluno/personal, convites criados pelo usuário e `user_stats`.
- Serializa `Timestamp`/`Date` para ISO string para gerar um JSON portátil.
- Atualiza `docs/privacy-lgpd.md` para refletir a exportação implementada no cliente.
- Adiciona testes unitários do serviço de exportação.

## Como foi testado

- `npm run lint`
- `npm test -- --run`
- `npm run build`

## Observações

- A exportação lê apenas documentos permitidos pelas rules para o usuário autenticado.
- Para histórico muito grande, uma próxima versão pode paginar ou dividir o arquivo.