### PR TITLE
fix: restore legacy session stats fallback

### DIFF
--- a/src/pages/HomeDashboard.jsx
+++ b/src/pages/HomeDashboard.jsx
@@ -453,7 +453,7 @@ export function HomeDashboard({
                         let dateObj = new Date();
                         // Lógica defensiva para parse de data
                         try {
-                            const raw = d.completedAtClient || d.completedAt || d.timestamp;
+                            const raw = d.completedAtClient || d.completedAt || d.date || d.createdAt || d.timestamp;
                             const parsedDate = parseToDate(raw);
                             if (parsedDate) dateObj = parsedDate;
                         } catch (e) { console.warn("Date parsing error", d.id, e); }

--- a/src/services/workoutService.js
+++ b/src/services/workoutService.js
@@ -34,6 +34,33 @@ function mapSessionDoc(doc) {
     return { id: doc.id, ...doc.data() };
 }
 
+function getSessionTimestampMs(session) {
+    const raw = session?.completedAt || session?.completedAtClient || session?.date || session?.createdAt || session?.timestamp;
+    if (!raw) return 0;
+    if (typeof raw.toDate === 'function') return raw.toDate().getTime();
+    if (raw instanceof Date) return raw.getTime();
+    if (typeof raw === 'object' && typeof raw.seconds === 'number') return raw.seconds * 1000;
+
+    const parsed = new Date(raw).getTime();
+    return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function sortSessionsByMostRecent(sessions) {
+    return [...sessions].sort((a, b) => getSessionTimestampMs(b) - getSessionTimestampMs(a));
+}
+
+async function getLegacyRecentSessions(deps, userId, safeLimit) {
+    const { db, collection, query, where, limit, getDocs } = deps;
+    const sessionsRef = collection(db, SESSIONS_COLLECTION);
+    const fallbackQuery = query(
+        sessionsRef,
+        where('userId', '==', userId),
+        limit(safeLimit)
+    );
+    const snap = await getDocs(fallbackQuery);
+    return sortSessionsByMostRecent(snap.docs.map(mapSessionDoc));
+}
+
 export const workoutService = {
     /**
      * Busca templates de treino para um usuário específico.
@@ -257,7 +284,8 @@ export const workoutService = {
      * @returns {Promise<Array>}
      */
     async getRecentSessions(userId, limitCount = SESSION_LIMITS.dashboardRecent) {
-        const { db, collection, query, where, orderBy, limit, getDocs } = await getFirestoreDeps();
+        const deps = await getFirestoreDeps();
+        const { db, collection, query, where, orderBy, limit, getDocs } = deps;
         const safeLimit = Math.max(1, Math.min(Number(limitCount) || SESSION_LIMITS.dashboardRecent, 500));
         const sessionsRef = collection(db, SESSIONS_COLLECTION);
         const q = query(
@@ -266,8 +294,16 @@ export const workoutService = {
             orderBy('completedAt', 'desc'),
             limit(safeLimit)
         );
-        const snap = await getDocs(q);
-        return snap.docs.map(mapSessionDoc);
+
+        try {
+            const snap = await getDocs(q);
+            const sessions = snap.docs.map(mapSessionDoc);
+            if (sessions.length > 0) return sessions;
+        } catch (error) {
+            console.warn('Falling back to legacy recent sessions query.', error);
+        }
+
+        return getLegacyRecentSessions(deps, userId, safeLimit);
     },
 
     /**

--- a/src/services/workoutService.test.js
+++ b/src/services/workoutService.test.js
@@ -283,6 +283,73 @@ describe('workoutService', () => {
 
             expect(limit).toHaveBeenCalledWith(500);
         });
+
+        it('falls back to a bounded legacy query when ordered sessions are empty', async () => {
+            getDocs
+                .mockResolvedValueOnce({ docs: [] })
+                .mockResolvedValueOnce({
+                    docs: [
+                        {
+                            id: 'legacy-old',
+                            data: () => ({
+                                userId: mockUserId,
+                                date: '2024-01-01T12:00:00.000Z',
+                                workoutName: 'Treino Antigo'
+                            })
+                        },
+                        {
+                            id: 'legacy-new',
+                            data: () => ({
+                                userId: mockUserId,
+                                completedAtClient: '2024-01-03T12:00:00.000Z',
+                                workoutName: 'Treino Novo'
+                            })
+                        }
+                    ]
+                });
+
+            const result = await workoutService.getRecentSessions(mockUserId, 25);
+
+            expect(getDocs).toHaveBeenCalledTimes(2);
+            expect(result.map(session => session.id)).toEqual(['legacy-new', 'legacy-old']);
+        });
+
+        it('falls back to legacy sessions when ordered recent query fails', async () => {
+            const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            getDocs
+                .mockRejectedValueOnce(new Error('missing index'))
+                .mockResolvedValueOnce({
+                    docs: [
+                        {
+                            id: 'legacy-session',
+                            data: () => ({
+                                userId: mockUserId,
+                                createdAt: { seconds: 1704283200 },
+                                workoutName: 'Treino Legado'
+                            })
+                        }
+                    ]
+                });
+
+            try {
+                const result = await workoutService.getRecentSessions(mockUserId, 25);
+
+                expect(result).toEqual([
+                    {
+                        id: 'legacy-session',
+                        userId: mockUserId,
+                        createdAt: { seconds: 1704283200 },
+                        workoutName: 'Treino Legado'
+                    }
+                ]);
+                expect(consoleSpy).toHaveBeenCalledWith(
+                    'Falling back to legacy recent sessions query.',
+                    expect.any(Error)
+                );
+            } finally {
+                consoleSpy.mockRestore();
+            }
+        });
     });
 
     describe('subscribeToRecentSessions', () => {

--- a/src/utils/evaluateAchievements.js
+++ b/src/utils/evaluateAchievements.js
@@ -44,6 +44,17 @@ function format(a, value) {
     return `${Math.min(value, a.target)} / ${a.target}`;
 }
 
+function getSessionDate(session) {
+    const raw = session?.completedAt || session?.completedAtClient || session?.date || session?.createdAt || session?.timestamp;
+    if (!raw) return new Date(0);
+    if (typeof raw.toDate === 'function') return raw.toDate();
+    if (raw instanceof Date) return raw;
+    if (typeof raw === 'object' && typeof raw.seconds === 'number') return new Date(raw.seconds * 1000);
+
+    const parsed = new Date(raw);
+    return Number.isNaN(parsed.getTime()) ? new Date(0) : parsed;
+}
+
 /**
  * Calcula estatísticas do usuário a partir do histórico de sessões.
  * @param {Array} sessions - Array de sessões de treino ordenadas por data (qualquer ordem, será ordenado internamente se necessário).
@@ -66,8 +77,8 @@ export function calculateStats(sessions) {
 
     // Ordenar por data ascendente para cálculo de PR e Streak
     const sortedSessions = [...sessions].sort((a, b) => {
-        const dateA = a.completedAt?.toDate ? a.completedAt.toDate() : new Date(a.completedAt || 0);
-        const dateB = b.completedAt?.toDate ? b.completedAt.toDate() : new Date(b.completedAt || 0);
+        const dateA = getSessionDate(a);
+        const dateB = getSessionDate(b);
         return dateA - dateB;
     });
 
@@ -97,7 +108,7 @@ export function calculateStats(sessions) {
         // Basic Counts
         totalWorkouts++;
 
-        const date = session.completedAt?.toDate ? session.completedAt.toDate() : new Date(session.completedAt || 0);
+        const date = getSessionDate(session);
 
         if (date >= oneWeekAgo) workoutsLast7Days++;
         if (date >= startOfYear) workoutsCurrentYear++;
@@ -224,8 +235,8 @@ export function evaluateHistory(sessions, catalog) {
 
     // 1. Sort sessions
     const sortedSessions = [...sessions].sort((a, b) => {
-        const dateA = a.completedAt?.toDate ? a.completedAt.toDate() : new Date(a.completedAt || 0);
-        const dateB = b.completedAt?.toDate ? b.completedAt.toDate() : new Date(b.completedAt || 0);
+        const dateA = getSessionDate(a);
+        const dateB = getSessionDate(b);
         return dateA - dateB;
     });
 
@@ -252,7 +263,7 @@ export function evaluateHistory(sessions, catalog) {
     let workoutsInYear = 0;
 
     sortedSessions.forEach(session => {
-        const dateObj = session.completedAt?.toDate ? session.completedAt.toDate() : new Date(session.completedAt || 0);
+        const dateObj = getSessionDate(session);
         const timestamp = dateObj.getTime();
         const isoDate = dateObj.toISOString();
 
@@ -393,14 +404,14 @@ export async function checkNewAchievements(userId, currentSessionData, workoutSe
         // 2. Filter out the current session to get "Previous State"
         // We identify current session by ID or exact timestamp
         const currentId = currentSessionData.id;
-        const currentTime = currentSessionData.completedAt?.toDate ? currentSessionData.completedAt.toDate().getTime() : new Date(currentSessionData.completedAt).getTime();
+        const currentTime = getSessionDate(currentSessionData).getTime();
 
         const previousSessions = allSessions.filter(s => {
             // Check ID if available
             if (s.id && currentId && s.id === currentId) return false;
 
             // Check Timestamp (if within 1s, assume same)
-            const t = s.completedAt?.toDate ? s.completedAt.toDate().getTime() : new Date(s.completedAt || 0).getTime();
+            const t = getSessionDate(s).getTime();
             if (Math.abs(t - currentTime) < 1000) return false;
 
             return true;

--- a/src/utils/workoutStats.js
+++ b/src/utils/workoutStats.js
@@ -8,7 +8,7 @@ export function calculateWeeklyStats(sessions, currentWeeklyGoal = 4) {
     const now = new Date();
     const startOfCurrentWeek = getStartOfWeek(now);
     const getSessionDate = (session) => {
-        const raw = session?.date || session?.completedAt || session?.timestamp;
+        const raw = session?.date || session?.completedAt || session?.completedAtClient || session?.createdAt || session?.timestamp;
         if (!raw) return null;
         if (typeof raw.toDate === 'function') return raw.toDate();
         if (raw instanceof Date) return raw;


### PR DESCRIPTION
## O que foi alterado

## Como foi testado

## Impacto em segurança

## Impacto em Firestore/rules/indexes

## Impacto visual

## Checklist

- [ ] Rodei `npm run lint`
- [ ] Rodei `npm test -- --run`
- [ ] Rodei `npm run test:rules`
- [ ] Rodei `npm run build`
- [ ] Revisei regras do Firestore, se aplicável
- [ ] Atualizei documentação, se aplicável
