### PR TITLE
feat: order active workouts and default history

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -85,6 +85,7 @@ service cloud.firestore {
         'muscleGroups',
         'isFavorite',
         'isArchived',
+        'displayOrder',
         'lastPerformed',
         'timesPerformed'
       ];
@@ -100,6 +101,7 @@ service cloud.firestore {
         'muscleGroups',
         'isFavorite',
         'isArchived',
+        'displayOrder',
         'lastPerformed',
         'timesPerformed'
       ];
@@ -112,6 +114,8 @@ service cloud.firestore {
         && request.resource.data.createdBy is string
         && request.resource.data.name is string
         && request.resource.data.exercises is list
+        && (!request.resource.data.keys().hasAny(['displayOrder'])
+          || (request.resource.data.displayOrder is int && request.resource.data.displayOrder >= 0))
         && request.resource.data.createdBy == request.auth.uid
         && (
           request.resource.data.userId == request.auth.uid
@@ -121,6 +125,8 @@ service cloud.firestore {
 
     function validTemplateUpdate() {
       return request.resource.data.userId == resource.data.userId
+        && (!request.resource.data.keys().hasAny(['displayOrder'])
+          || (request.resource.data.displayOrder is int && request.resource.data.displayOrder >= 0))
         && request.resource.data.diff(resource.data).affectedKeys().hasOnly(templateMutableFields());
     }
 

--- a/src/pages/HistoryPage.jsx
+++ b/src/pages/HistoryPage.jsx
@@ -10,6 +10,7 @@ import { EmptyState } from '../components/design-system/EmptyState';
 import { PageHeader } from '../components/design-system/PageHeader';
 import { SESSION_LIMITS, workoutService } from '../services/workoutService';
 import { getJournalWindowConfig, recordJournalRenderMetric } from '../utils/performanceTuning';
+import { sortWorkoutTemplates } from '../utils/workoutTemplateOrder';
 
 import { Button } from '../components/design-system/Button';
 const HistoryAnalyticsSection = React.lazy(() => import('../components/history/HistoryAnalyticsSection').then(module => ({ default: module.HistoryAnalyticsSection })));
@@ -307,11 +308,12 @@ function HistoryPage({ user, isEmbedded = false }) {
 
             setLoadingTemplates(true);
             try {
-                const list = await workoutService.getTemplates(user.uid);
+                const list = sortWorkoutTemplates(await workoutService.getTemplates(user.uid));
                 setTemplates(list);
 
                 if (list.length > 0 && !selectedTemplate) {
-                    let defaultTemplateName = list[0].name;
+                    const firstActiveTemplate = list.find(template => !template.isArchived);
+                    let defaultTemplateName = firstActiveTemplate?.name || list[0].name;
                     if (initialTemplate) {
                         const found = list.find((t) => t.name === initialTemplate);
                         if (found) defaultTemplateName = found.name;

--- a/src/pages/HistoryPage.test.jsx
+++ b/src/pages/HistoryPage.test.jsx
@@ -71,6 +71,20 @@ describe('HistoryPage', () => {
         expect(screen.getByText('Evolução')).toBeInTheDocument();
     });
 
+    it('selects the first ordered active workout instead of an archived workout', async () => {
+        workoutService.getTemplates.mockResolvedValue([
+            { id: 'archived', name: 'Treino 1 Antigo', isArchived: true, displayOrder: 0, exercises: [] },
+            { id: 'b', name: 'Treino B', displayOrder: 1, exercises: [{ name: 'Remada' }] },
+            { id: 'a', name: 'Treino A', displayOrder: 0, exercises: [{ name: 'Supino' }] }
+        ]);
+
+        render(<HistoryPage user={mockUser} />);
+
+        await waitFor(() => {
+            expect(screen.getAllByRole('combobox')[0]).toHaveValue('Treino A');
+        });
+    });
+
     it('switches to journal tab and loads history', async () => {
         render(<HistoryPage user={mockUser} />);
 

--- a/src/pages/WorkoutsPage.jsx
+++ b/src/pages/WorkoutsPage.jsx
@@ -18,7 +18,11 @@ import {
     Trash2,
     Archive,
     ArchiveRestore,
-    Activity
+    Activity,
+    ArrowDown,
+    ArrowUp,
+    Check,
+    ListOrdered
 } from 'lucide-react';
 
 import { RippleButton } from '../components/design-system/RippleButton';
@@ -28,6 +32,7 @@ import { PageHeader } from '../components/design-system/PageHeader';
 import { PremiumCard } from '../components/design-system/PremiumCard';
 import { AddCardioModal } from '../components/AddCardioModal';
 import { ConfirmDialog } from '../components/design-system/ConfirmDialog';
+import { normalizeActiveWorkoutOrder, sortWorkoutTemplates } from '../utils/workoutTemplateOrder';
 import { toast } from 'sonner';
 const ExerciseCard = React.lazy(() => import('../components/workout/ExerciseCard').then(module => ({ default: module.ExerciseCard })));
 const EditExerciseModal = React.lazy(() => import('../components/workout/EditExerciseModal').then(module => ({ default: module.EditExerciseModal })));
@@ -50,6 +55,8 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
     const [isAddCardioOpen, setIsAddCardioOpen] = useState(false);
     const [workoutPendingDelete, setWorkoutPendingDelete] = useState(null);
     const [deletingWorkout, setDeletingWorkout] = useState(false);
+    const [isOrganizing, setIsOrganizing] = useState(false);
+    const [savingOrder, setSavingOrder] = useState(false);
     
     useEffect(() => {
         async function fetchWorkouts() {
@@ -74,7 +81,8 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
                     createdBy: data.createdBy,
                     assignedByTrainer: data.assignedByTrainer,
                     completedToday: false,
-                    isArchived: !!data.isArchived
+                    isArchived: !!data.isArchived,
+                    displayOrder: Number.isInteger(data.displayOrder) ? data.displayOrder : null
                 }));
 
                 setWorkouts(formattedWorkouts);
@@ -99,7 +107,7 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
 
 
     // --- FILTER LOGIC ---
-    const filteredWorkouts = workouts.filter(workout => {
+    const filteredWorkouts = sortWorkoutTemplates(workouts.filter(workout => {
         // 1. Search
         const matchesSearch = workout.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
             (workout.muscleGroups && workout.muscleGroups.some(g => g.toLowerCase().includes(searchQuery.toLowerCase())));
@@ -122,16 +130,67 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
         }
 
         return matchesSearch && matchesSource;
-    }).sort((a, b) => {
-        // Default sort by recent
-        if (!a.lastPerformedDate) return 1;
-        if (!b.lastPerformedDate) return -1;
-        return new Date(b.lastPerformedDate) - new Date(a.lastPerformedDate);
-    });
+    }));
 
     // --- ACTIONS ---
     const handleCardClick = (id, name) => {
+        if (isOrganizing) return;
         onNavigateToWorkout(id, name);
+    };
+
+    const toggleOrganizing = () => {
+        setIsOrganizing(current => {
+            const next = !current;
+            if (next) {
+                setSourceFilter('all');
+                setSearchQuery('');
+                setSelectedWorkout(null);
+                setActiveCardMenu(null);
+            }
+            return next;
+        });
+    };
+
+    const moveWorkout = async (workoutId, direction) => {
+        if (savingOrder) return;
+
+        const activeWorkouts = normalizeActiveWorkoutOrder(workouts);
+        const currentIndex = activeWorkouts.findIndex(workout => workout.id === workoutId);
+        const targetIndex = currentIndex + direction;
+        if (currentIndex < 0 || targetIndex < 0 || targetIndex >= activeWorkouts.length) return;
+
+        const reordered = [...activeWorkouts];
+        const [movedWorkout] = reordered.splice(currentIndex, 1);
+        reordered.splice(targetIndex, 0, movedWorkout);
+        const normalized = reordered.map((workout, displayOrder) => ({ ...workout, displayOrder }));
+        const orderById = new Map(normalized.map(workout => [workout.id, workout]));
+
+        setWorkouts(current => current.map(workout => orderById.get(workout.id) || workout));
+        setSavingOrder(true);
+
+        try {
+            const { workoutService } = await import('../services/workoutService');
+            await workoutService.saveTemplateOrder(normalized);
+        } catch (error) {
+            console.error('Erro ao salvar ordem dos treinos:', error);
+            toast.error('Não foi possível salvar a nova ordem.');
+
+            try {
+                const { workoutService } = await import('../services/workoutService');
+                const freshWorkouts = await workoutService.getTemplates(user.uid, true);
+                const freshById = new Map(freshWorkouts.map(workout => [workout.id, workout]));
+                setWorkouts(current => current.map(workout => {
+                    const fresh = freshById.get(workout.id);
+                    return fresh
+                        ? { ...workout, displayOrder: Number.isInteger(fresh.displayOrder) ? fresh.displayOrder : null }
+                        : workout;
+                }));
+            } catch (refreshError) {
+                console.error('Erro ao restaurar ordem dos treinos:', refreshError);
+            }
+        } finally {
+            setSavingOrder(false);
+        }
     };
 
     const handleMenuAction = async (e, action, workout) => {
@@ -148,7 +207,8 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
                 estimatedDuration: workout.duration,
                 userId: user.uid,
                 createdBy: user.uid,
-                assignedByTrainer: false
+                assignedByTrainer: false,
+                displayOrder: workouts.filter(workout => !workout.isArchived).length
             };
 
             try {
@@ -179,7 +239,9 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
                         category: newWorkoutData.category || 'fullbody',
                         createdBy: user.uid,
                         assignedByTrainer: false,
-                        completedToday: false
+                        completedToday: false,
+                        isArchived: false,
+                        displayOrder: newWorkoutData.displayOrder
                     },
                     ...prev
                 ]));
@@ -250,26 +312,43 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
                         title="Meus Treinos"
                         description="Gerencie suas fichas, modelos do personal e treinos arquivados."
                         icon={<Dumbbell size={22} />}
-                        action={(
+                        action={isOrganizing ? (
+                            <Button
+                                size="sm"
+                                onClick={toggleOrganizing}
+                                disabled={savingOrder}
+                                className="w-full rounded-xl sm:w-auto"
+                                leftIcon={<Check size={16} />}
+                            >
+                                Concluir
+                            </Button>
+                        ) : (
                             <div className="flex w-full gap-2 sm:w-auto">
                                 <Button
                                     variant="secondary"
                                     size="sm"
                                     onClick={() => setIsAddCardioOpen(true)}
-                                    className="flex-1 rounded-xl sm:flex-none"
+                                    className="flex-1 rounded-xl px-2 sm:flex-none sm:px-4"
                                     leftIcon={<Activity size={16} />}
                                 >
-                                    <span className="hidden sm:inline">Cardio</span>
-                                    <span className="sm:hidden">Cardio</span>
+                                    Cardio
+                                </Button>
+                                <Button
+                                    variant="secondary"
+                                    size="sm"
+                                    onClick={toggleOrganizing}
+                                    className="flex-1 rounded-xl px-2 sm:flex-none sm:px-4"
+                                    leftIcon={<ListOrdered size={16} />}
+                                >
+                                    Ordem
                                 </Button>
                                 <Button
                                     size="sm"
                                     onClick={() => onNavigateToCreate(null, { targetUserId: user.uid })}
-                                    className="flex-1 rounded-xl sm:flex-none"
+                                    className="flex-1 rounded-xl px-2 sm:flex-none sm:px-4"
                                     leftIcon={<Plus size={16} />}
                                 >
-                                    <span className="hidden sm:inline">Novo Treino</span>
-                                    <span className="sm:hidden">Novo</span>
+                                    Novo
                                 </Button>
                             </div>
                         )}
@@ -280,13 +359,13 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
 
 
                 {/* New: Source Tabs - Hide if Trainer Mode (since trainer sees all relevant) */}
-                {!isTrainerMode && (
-                    <div className="flex p-1 bg-slate-900/50 rounded-xl mb-6 border border-slate-800 backdrop-blur-sm overflow-x-auto no-scrollbar">
+                {!isTrainerMode && !isOrganizing && (
+                    <div className="grid grid-cols-2 gap-1 p-1 bg-slate-900/50 rounded-xl mb-6 border border-slate-800 backdrop-blur-sm sm:grid-cols-4">
                         {['all', 'meus', 'personal', 'arquivados'].map((filter) => (
                             <button
                                 key={filter}
                                 onClick={() => setSourceFilter(filter)}
-                                className={`flex-1 py-2 px-4 rounded-lg text-sm font-semibold transition-all duration-300 whitespace-nowrap ${sourceFilter === filter
+                                className={`min-w-0 py-2 px-2 rounded-lg text-sm font-semibold transition-colors duration-200 whitespace-nowrap ${sourceFilter === filter
                                     ? 'bg-cyan-500 text-black shadow-lg shadow-cyan-500/20'
                                     : 'text-slate-400 hover:text-white hover:bg-slate-800'
                                     }`}
@@ -297,19 +376,30 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
                     </div>
                 )}
 
-                {/* Search Bar */}
-                <PremiumCard className="p-0">
-                    <div className="relative">
-                        <Search className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-500" size={20} />
-                        <input
-                            type="text"
-                            value={searchQuery}
-                            onChange={(e) => setSearchQuery(e.target.value)}
-                            placeholder="Buscar por nome ou músculo..."
-                            className="w-full pl-12 pr-4 py-4 bg-transparent border-none text-white placeholder:text-slate-500 focus:ring-1 focus:ring-cyan-500 rounded-xl transition-all"
-                        />
+                {isOrganizing ? (
+                    <div className="flex min-h-14 items-center justify-between gap-3 rounded-xl border border-cyan-500/25 bg-cyan-500/5 px-4 py-3">
+                        <div className="flex min-w-0 items-center gap-3 text-cyan-300">
+                            <ListOrdered size={20} className="shrink-0" />
+                            <span className="truncate text-sm font-semibold">Ordem dos treinos ativos</span>
+                        </div>
+                        <span className="shrink-0 text-xs font-medium text-slate-500">
+                            {savingOrder ? 'Salvando...' : `${filteredWorkouts.length} treinos`}
+                        </span>
                     </div>
-                </PremiumCard>
+                ) : (
+                    <PremiumCard className="p-0">
+                        <div className="relative">
+                            <Search className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-500" size={20} />
+                            <input
+                                type="text"
+                                value={searchQuery}
+                                onChange={(e) => setSearchQuery(e.target.value)}
+                                placeholder="Buscar por nome ou músculo..."
+                                className="w-full pl-12 pr-4 py-4 bg-transparent border-none text-white placeholder:text-slate-500 focus:ring-1 focus:ring-cyan-500 rounded-xl transition-colors"
+                            />
+                        </div>
+                    </PremiumCard>
+                )}
             </div>
 
 
@@ -352,43 +442,73 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
                                     </div>
                                 </div>
 
-                                {/* Menu */}
-                                <div className="relative">
-                                    <RippleButton
-                                        onClick={(e) => {
-                                            e.stopPropagation();
-                                            setActiveCardMenu(activeCardMenu === workout.id ? null : workout.id);
-                                        }}
-                                        className="p-2 rounded-lg hover:bg-slate-800 text-slate-400 hover:text-white transition-colors card-menu-btn"
-                                    >
-                                        <MoreVertical size={20} />
-                                    </RippleButton>
+                                {/* Menu / order controls */}
+                                {isOrganizing ? (
+                                    <div className="flex shrink-0 flex-col gap-1">
+                                        <RippleButton
+                                            aria-label={`Mover ${workout.name} para cima`}
+                                            title="Mover para cima"
+                                            disabled={idx === 0 || savingOrder}
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                void moveWorkout(workout.id, -1);
+                                            }}
+                                            className="flex h-9 w-9 items-center justify-center rounded-lg border border-slate-700 bg-slate-800/70 text-slate-300 disabled:cursor-not-allowed disabled:opacity-25"
+                                        >
+                                            <ArrowUp size={18} />
+                                        </RippleButton>
+                                        <RippleButton
+                                            aria-label={`Mover ${workout.name} para baixo`}
+                                            title="Mover para baixo"
+                                            disabled={idx === filteredWorkouts.length - 1 || savingOrder}
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                void moveWorkout(workout.id, 1);
+                                            }}
+                                            className="flex h-9 w-9 items-center justify-center rounded-lg border border-slate-700 bg-slate-800/70 text-slate-300 disabled:cursor-not-allowed disabled:opacity-25"
+                                        >
+                                            <ArrowDown size={18} />
+                                        </RippleButton>
+                                    </div>
+                                ) : (
+                                    <div className="relative">
+                                        <RippleButton
+                                            aria-label={`Abrir opções de ${workout.name}`}
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                setActiveCardMenu(activeCardMenu === workout.id ? null : workout.id);
+                                            }}
+                                            className="p-2 rounded-lg hover:bg-slate-800 text-slate-400 hover:text-white transition-colors card-menu-btn"
+                                        >
+                                            <MoreVertical size={20} />
+                                        </RippleButton>
 
-                                    {/* Dropdown */}
-                                    {activeCardMenu === workout.id && (
-                                        <>
-                                            <div className="fixed inset-0 z-10" onClick={(e) => { e.stopPropagation(); setActiveCardMenu(null); }} />
-                                            <div 
-                                                className="absolute right-0 top-full mt-2 w-48 bg-slate-900/95 backdrop-blur-xl border border-slate-700 rounded-xl shadow-2xl z-20 overflow-hidden card-menu-dropdown" 
-                                                onClick={(e) => e.stopPropagation()}
-                                                onMouseDown={(e) => e.stopPropagation()}
-                                                onTouchStart={(e) => e.stopPropagation()}
-                                            >
-                                                <button onClick={(e) => handleMenuAction(e, 'edit', workout)} className="w-full flex items-center gap-3 px-4 py-3 text-sm text-slate-300 hover:bg-slate-800 hover:text-cyan-400"><Edit2 size={16} /> Editar</button>
-                                                <button onClick={(e) => handleMenuAction(e, 'duplicate', workout)} className="w-full flex items-center gap-3 px-4 py-3 text-sm text-slate-300 hover:bg-slate-800 hover:text-white"><Copy size={16} /> Duplicar</button>
-                                                
-                                                {workout.isArchived ? (
-                                                    <button onClick={(e) => handleMenuAction(e, 'unarchive', workout)} className="w-full flex items-center gap-3 px-4 py-3 text-sm text-slate-300 hover:bg-slate-800 hover:text-white"><ArchiveRestore size={16} /> Desarquivar</button>
-                                                ) : (
-                                                    <button onClick={(e) => handleMenuAction(e, 'archive', workout)} className="w-full flex items-center gap-3 px-4 py-3 text-sm text-slate-300 hover:bg-slate-800 hover:text-white"><Archive size={16} /> Arquivar</button>
-                                                )}
+                                        {/* Dropdown */}
+                                        {activeCardMenu === workout.id && (
+                                            <>
+                                                <div className="fixed inset-0 z-10" onClick={(e) => { e.stopPropagation(); setActiveCardMenu(null); }} />
+                                                <div
+                                                    className="absolute right-0 top-full mt-2 w-48 bg-slate-900/95 backdrop-blur-xl border border-slate-700 rounded-xl shadow-2xl z-20 overflow-hidden card-menu-dropdown"
+                                                    onClick={(e) => e.stopPropagation()}
+                                                    onMouseDown={(e) => e.stopPropagation()}
+                                                    onTouchStart={(e) => e.stopPropagation()}
+                                                >
+                                                    <button onClick={(e) => handleMenuAction(e, 'edit', workout)} className="w-full flex items-center gap-3 px-4 py-3 text-sm text-slate-300 hover:bg-slate-800 hover:text-cyan-400"><Edit2 size={16} /> Editar</button>
+                                                    <button onClick={(e) => handleMenuAction(e, 'duplicate', workout)} className="w-full flex items-center gap-3 px-4 py-3 text-sm text-slate-300 hover:bg-slate-800 hover:text-white"><Copy size={16} /> Duplicar</button>
 
-                                                <div className="h-px bg-slate-800" />
-                                                <button onClick={(e) => handleMenuAction(e, 'delete', workout)} className="w-full flex items-center gap-3 px-4 py-3 text-sm text-red-400 hover:bg-red-500/10"><Trash2 size={16} /> Excluir</button>
-                                            </div>
-                                        </>
-                                    )}
-                                </div>
+                                                    {workout.isArchived ? (
+                                                        <button onClick={(e) => handleMenuAction(e, 'unarchive', workout)} className="w-full flex items-center gap-3 px-4 py-3 text-sm text-slate-300 hover:bg-slate-800 hover:text-white"><ArchiveRestore size={16} /> Desarquivar</button>
+                                                    ) : (
+                                                        <button onClick={(e) => handleMenuAction(e, 'archive', workout)} className="w-full flex items-center gap-3 px-4 py-3 text-sm text-slate-300 hover:bg-slate-800 hover:text-white"><Archive size={16} /> Arquivar</button>
+                                                    )}
+
+                                                    <div className="h-px bg-slate-800" />
+                                                    <button onClick={(e) => handleMenuAction(e, 'delete', workout)} className="w-full flex items-center gap-3 px-4 py-3 text-sm text-red-400 hover:bg-red-500/10"><Trash2 size={16} /> Excluir</button>
+                                                </div>
+                                            </>
+                                        )}
+                                    </div>
+                                )}
                             </div>
 
                             {/* --- Stats Line --- */}
@@ -401,28 +521,35 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
                             </div>
 
                             {/* --- Actions --- */}
-                            <div className="flex gap-3">
-                                <RippleButton
-                                    onClick={(e) => {
-                                        e.stopPropagation();
-                                        setSelectedWorkout(selectedWorkout === workout.id ? null : workout.id);
-                                    }}
-                                    className="flex-1 py-3 bg-slate-800 hover:bg-slate-700 rounded-xl text-white text-xs font-bold transition-colors"
-                                >
-                                    {selectedWorkout === workout.id ? 'Ocultar' : 'Ver Exercícios'}
-                                </RippleButton>
+                            {isOrganizing ? (
+                                <div className="flex items-center justify-between rounded-xl border border-slate-800 bg-slate-950/45 px-4 py-3">
+                                    <span className="text-xs font-bold uppercase tracking-widest text-slate-500">Posição</span>
+                                    <span className="text-sm font-bold text-cyan-300">{idx + 1}</span>
+                                </div>
+                            ) : (
+                                <div className="flex gap-3">
+                                    <RippleButton
+                                        onClick={(e) => {
+                                            e.stopPropagation();
+                                            setSelectedWorkout(selectedWorkout === workout.id ? null : workout.id);
+                                        }}
+                                        className="flex-1 py-3 bg-slate-800 hover:bg-slate-700 rounded-xl text-white text-xs font-bold transition-colors"
+                                    >
+                                        {selectedWorkout === workout.id ? 'Ocultar' : 'Ver Exercícios'}
+                                    </RippleButton>
 
-                                <RippleButton
-                                    onClick={() => handleCardClick(workout.id, workout.name)}
-                                    className="flex-1 py-3 bg-linear-to-r from-cyan-500 to-blue-600 hover:to-blue-500 rounded-xl text-white text-xs font-bold shadow-lg shadow-cyan-500/20 flex items-center justify-center gap-2"
-                                >
-                                    <Play size={14} fill="currentColor" /> INICIAR
-                                </RippleButton>
-                            </div>
+                                    <RippleButton
+                                        onClick={() => handleCardClick(workout.id, workout.name)}
+                                        className="flex-1 py-3 bg-linear-to-r from-cyan-500 to-blue-600 hover:to-blue-500 rounded-xl text-white text-xs font-bold shadow-lg shadow-cyan-500/20 flex items-center justify-center gap-2"
+                                    >
+                                        <Play size={14} fill="currentColor" /> INICIAR
+                                    </RippleButton>
+                                </div>
+                            )}
 
                             {/* --- Expandable List (Accordion) --- */}
                             <AnimatePresence>
-                                {selectedWorkout === workout.id && (
+                                {!isOrganizing && selectedWorkout === workout.id && (
                                     <motion.div
                                         initial={{ height: 0, opacity: 0 }}
                                         animate={{ height: 'auto', opacity: 1 }}

--- a/src/pages/WorkoutsPage.test.jsx
+++ b/src/pages/WorkoutsPage.test.jsx
@@ -6,7 +6,8 @@ import { workoutService } from '../services/workoutService';
 
 vi.mock('../services/workoutService', () => ({
     workoutService: {
-        getTemplates: vi.fn()
+        getTemplates: vi.fn(),
+        saveTemplateOrder: vi.fn()
     }
 }));
 
@@ -51,7 +52,8 @@ describe('WorkoutsPage', () => {
             muscleGroups: ['Peito'],
             lastPerformed: { toDate: () => new Date('2024-01-02') },
             createdBy: 'user123',
-            assignedByTrainer: false
+            assignedByTrainer: false,
+            displayOrder: 0
         },
         {
             id: 'w2',
@@ -60,7 +62,8 @@ describe('WorkoutsPage', () => {
             muscleGroups: ['Costas'],
             lastPerformed: { toDate: () => new Date('2024-01-01') },
             createdBy: 'trainer-1',
-            assignedByTrainer: true
+            assignedByTrainer: true,
+            displayOrder: 1
         }
     ];
 
@@ -127,7 +130,22 @@ describe('WorkoutsPage', () => {
     it('calls onNavigateToCreate when clicking Novo Treino', async () => {
         const { onNavigateToCreate } = await renderPage();
 
-        fireEvent.click(screen.getByText('Novo Treino'));
+        fireEvent.click(screen.getByText('Novo'));
         expect(onNavigateToCreate).toHaveBeenCalledWith(null, { targetUserId: 'user123' });
+    });
+
+    it('lets the user move an active workout and persists the new order', async () => {
+        workoutService.saveTemplateOrder.mockResolvedValue(undefined);
+        await renderPage();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Ordem' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Mover Treino Peito para baixo' }));
+
+        await waitFor(() => {
+            expect(workoutService.saveTemplateOrder).toHaveBeenCalledWith([
+                expect.objectContaining({ id: 'w2', displayOrder: 0 }),
+                expect.objectContaining({ id: 'w1', displayOrder: 1 })
+            ]);
+        });
     });
 });

--- a/src/services/workoutService.js
+++ b/src/services/workoutService.js
@@ -1,4 +1,5 @@
 import { getFirestoreDeps } from '../firebaseDb';
+import { sortWorkoutTemplates } from '../utils/workoutTemplateOrder';
 
 const TEMPLATES_COLLECTION = 'workout_templates';
 const SESSIONS_COLLECTION = 'workout_sessions';
@@ -94,17 +95,16 @@ export const workoutService = {
                 ...doc.data()
             }));
 
-            // Client-side sort
-            list.sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+            const sorted = sortWorkoutTemplates(list);
 
             // Atualizar Cache
             templatesCache = {
                 userId,
-                data: list,
+                data: sorted,
                 timestamp: now
             };
 
-            return list;
+            return sorted;
         } catch (error) {
             console.error("Error fetching templates:", error);
             await showToastError("Erro ao carregar treinos. Verifique sua conexão.");
@@ -148,7 +148,7 @@ export const workoutService = {
                 ...doc.data()
             }));
 
-            const sorted = list.sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+            const sorted = sortWorkoutTemplates(list);
 
             // Também atualizar cache silenciosamente para mantê-lo fresco
             templatesCache = {
@@ -167,6 +167,21 @@ export const workoutService = {
      * Limpar Cache de Templates (ex: após criar novo treino)
      */
     clearCache() {
+        templatesCache = { userId: null, data: null, timestamp: 0 };
+    },
+
+    async saveTemplateOrder(templates) {
+        const orderedTemplates = templates.filter(template => template?.id);
+        if (orderedTemplates.length === 0) return;
+
+        const { db, doc, writeBatch } = await getFirestoreDeps();
+        const batch = writeBatch(db);
+
+        orderedTemplates.forEach((template, displayOrder) => {
+            batch.update(doc(db, TEMPLATES_COLLECTION, template.id), { displayOrder });
+        });
+
+        await batch.commit();
         templatesCache = { userId: null, data: null, timestamp: 0 };
     },
 

--- a/src/services/workoutService.test.js
+++ b/src/services/workoutService.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { workoutService } from './workoutService';
-import { collection, getDocs, onSnapshot, query, where, startAfter, orderBy, limit, doc, getDoc } from 'firebase/firestore';
+import { collection, getDocs, onSnapshot, query, where, startAfter, orderBy, limit, doc, getDoc, writeBatch } from 'firebase/firestore';
 import { toast } from 'sonner';
 
 vi.mock('sonner', () => ({
@@ -22,6 +22,9 @@ vi.mock('firebase/firestore', async (importOriginal) => {
         limit: vi.fn(),
         getDocs: vi.fn(),
         onSnapshot: vi.fn(),
+        doc: vi.fn(),
+        getDoc: vi.fn(),
+        writeBatch: vi.fn(),
     };
 });
 
@@ -39,6 +42,7 @@ vi.mock('../firebaseDb', () => ({
         onSnapshot,
         doc,
         getDoc,
+        writeBatch,
     })
 }));
 
@@ -82,6 +86,19 @@ describe('workoutService', () => {
             expect(result[0].name).toBe('A Workout');
             expect(result[1].name).toBe('Z Workout');
             expect(result.length).toBe(2);
+        });
+
+        it('prioritizes persisted display order over workout name', async () => {
+            getDocs.mockResolvedValue({
+                docs: [
+                    { id: 'a', data: () => ({ name: 'Treino A', displayOrder: 1 }) },
+                    { id: 'b', data: () => ({ name: 'Treino B', displayOrder: 0 }) }
+                ]
+            });
+
+            const result = await workoutService.getTemplates(mockUserId);
+
+            expect(result.map(template => template.id)).toEqual(['b', 'a']);
         });
 
         it('should return cached data on subsequent calls within duration', async () => {
@@ -128,6 +145,24 @@ describe('workoutService', () => {
             } finally {
                 consoleSpy.mockRestore();
             }
+        });
+    });
+
+    describe('saveTemplateOrder', () => {
+        it('persists contiguous positions in a single batch', async () => {
+            const update = vi.fn();
+            const commit = vi.fn().mockResolvedValue(undefined);
+            doc.mockImplementation((_db, collectionName, documentId) => ({ collectionName, documentId }));
+            writeBatch.mockReturnValue({ update, commit });
+
+            await workoutService.saveTemplateOrder([
+                { id: 'workout-b' },
+                { id: 'workout-a' }
+            ]);
+
+            expect(update).toHaveBeenNthCalledWith(1, expect.anything(), { displayOrder: 0 });
+            expect(update).toHaveBeenNthCalledWith(2, expect.anything(), { displayOrder: 1 });
+            expect(commit).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/src/utils/workoutTemplateOrder.js
+++ b/src/utils/workoutTemplateOrder.js
@@ -1,0 +1,36 @@
+const workoutNameCollator = new Intl.Collator('pt-BR', {
+    numeric: true,
+    sensitivity: 'base'
+});
+
+function getDisplayOrder(template) {
+    return Number.isInteger(template?.displayOrder) && template.displayOrder >= 0
+        ? template.displayOrder
+        : null;
+}
+
+export function compareWorkoutTemplates(a, b) {
+    if (Boolean(a?.isArchived) !== Boolean(b?.isArchived)) {
+        return a?.isArchived ? 1 : -1;
+    }
+
+    const aOrder = getDisplayOrder(a);
+    const bOrder = getDisplayOrder(b);
+
+    if (aOrder !== null && bOrder !== null && aOrder !== bOrder) {
+        return aOrder - bOrder;
+    }
+    if (aOrder !== null) return -1;
+    if (bOrder !== null) return 1;
+
+    return workoutNameCollator.compare(a?.name || '', b?.name || '');
+}
+
+export function sortWorkoutTemplates(templates = []) {
+    return [...templates].sort(compareWorkoutTemplates);
+}
+
+export function normalizeActiveWorkoutOrder(templates = []) {
+    return sortWorkoutTemplates(templates.filter(template => !template.isArchived))
+        .map((template, displayOrder) => ({ ...template, displayOrder }));
+}

--- a/src/utils/workoutTemplateOrder.test.js
+++ b/src/utils/workoutTemplateOrder.test.js
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeActiveWorkoutOrder, sortWorkoutTemplates } from './workoutTemplateOrder';
+
+describe('workoutTemplateOrder', () => {
+    it('uses natural name order for legacy templates without displayOrder', () => {
+        const result = sortWorkoutTemplates([
+            { id: 'c', name: 'Treino C' },
+            { id: 'a', name: 'Treino A' },
+            { id: 'b', name: 'Treino B' }
+        ]);
+
+        expect(result.map(template => template.id)).toEqual(['a', 'b', 'c']);
+    });
+
+    it('prioritizes saved order and keeps archived templates after active templates', () => {
+        const result = sortWorkoutTemplates([
+            { id: 'archived', name: 'Treino 1', displayOrder: 0, isArchived: true },
+            { id: 'b', name: 'Treino B', displayOrder: 1 },
+            { id: 'a', name: 'Treino A', displayOrder: 0 }
+        ]);
+
+        expect(result.map(template => template.id)).toEqual(['a', 'b', 'archived']);
+    });
+
+    it('normalizes only active templates into contiguous positions', () => {
+        const result = normalizeActiveWorkoutOrder([
+            { id: 'b', name: 'Treino B', displayOrder: 8 },
+            { id: 'archived', name: 'Treino Arquivado', isArchived: true },
+            { id: 'a', name: 'Treino A', displayOrder: 3 }
+        ]);
+
+        expect(result).toMatchObject([
+            { id: 'a', displayOrder: 0 },
+            { id: 'b', displayOrder: 1 }
+        ]);
+    });
+});

--- a/tests/security/firestore.rules.test.js
+++ b/tests/security/firestore.rules.test.js
@@ -164,6 +164,14 @@ describe('firestore.rules', () => {
             updatedAt: Timestamp.now()
         }));
 
+        await assertSucceeds(updateDoc(doc(authedDb('student-1'), 'workout_templates/template-1'), {
+            displayOrder: 0
+        }));
+
+        await assertFails(updateDoc(doc(authedDb('student-1'), 'workout_templates/template-1'), {
+            displayOrder: -1
+        }));
+
         await assertFails(updateDoc(doc(authedDb('student-1'), 'workout_templates/template-1'), {
             userId: 'other-user'
         }));


### PR DESCRIPTION
## O que foi alterado
- Ordena treinos ativos de forma previsível, com fallback natural A, B, C.
- Adiciona modo **Ordem** para persistir a sequência escolhida pelo usuário.
- Faz o Histórico iniciar no primeiro treino ativo, mantendo arquivados disponíveis apenas para seleção.
- Ajusta as abas mobile para evitar corte de "Arquivados".
- Permite o campo opcional `displayOrder` nas regras do Firestore.

## Como foi testado
- `npm run lint`
- `npm test -- --run`: 111 testes
- `npm run test:rules`: 12 testes de segurança
- `npm run build`
- QA autenticado no Chrome em 400x844 e desktop, sem overflow horizontal

## Impacto
- **Segurança:** schema das rules ampliado somente para inteiro não negativo opcional.
- **Dados:** nenhuma migração obrigatória; documentos legados usam ordenação natural.
- **UX:** o treino A passa a ser o padrão quando não existe ordem salva, e o usuário pode reorganizar A/B/C.