### PR TITLE
fix: tighten focus mode and profile actions

### DIFF
--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -20,6 +20,7 @@ import {
     Share2,
     Zap,
     Crown,
+    PencilLine,
     FileText,
     ShieldCheck,
     FileDown
@@ -319,16 +320,16 @@ export default function ProfilePage({ user, onLogout, onNavigateToHistory, onNav
         <div className="min-h-screen bg-slate-950 pb-48 px-4 pt-2 w-full max-w-3xl mx-auto lg:pb-32 lg:pt-6">
 
             {/* --- CARTÃO DE CABEÇALHO DO PERFIL --- */}
-            <div className="bg-slate-900/50 rounded-3xl p-6 mb-6 border border-slate-800 relative overflow-hidden">
+            <div className="bg-slate-900/50 rounded-3xl p-5 sm:p-6 mb-6 border border-slate-800 relative overflow-hidden">
                 {/* Brilho de Fundo */}
                 <div className="absolute top-0 right-0 w-64 h-64 bg-blue-500/10 rounded-full blur-3xl -translate-y-1/2 translate-x-1/2 pointer-events-none" />
 
 
 
-                <div className="flex gap-6 items-center relative z-10">
+                <div className="flex gap-4 sm:gap-6 items-center relative z-10">
                     {/* Grupo de Avatar (Esquerda) */}
                     <div className="relative shrink-0">
-                        <div className="w-24 h-24 rounded-full bg-linear-to-br from-[#2998FF] to-[#1E6BFF] flex items-center justify-center text-3xl shadow-xl shadow-blue-500/20 ring-4 ring-slate-900 z-10 relative">
+                        <div className="w-20 h-20 sm:w-24 sm:h-24 rounded-full bg-linear-to-br from-[#2998FF] to-[#1E6BFF] flex items-center justify-center text-2xl sm:text-3xl shadow-xl shadow-blue-500/20 ring-4 ring-slate-900 z-10 relative">
                             {profile.displayName && profile.displayName.length > 0
                                 ? <span className="font-bold text-white">{profile.displayName.substring(0, 2).toUpperCase()}</span>
                                 : <User size={32} className="text-white" />
@@ -346,39 +347,41 @@ export default function ProfilePage({ user, onLogout, onNavigateToHistory, onNav
                     <div className="flex-1 min-w-0">
                         {/* Linha de Nome */}
                         <div className="flex items-center gap-3 mb-1">
-                            <h1 className="text-2xl font-bold text-white tracking-tight break-words leading-tight">{profile.displayName || 'Atleta'}</h1>
+                            <h1 className="text-xl sm:text-2xl font-bold text-white tracking-tight break-words leading-tight">{profile.displayName || 'Atleta'}</h1>
                         </div>
 
 
 
                         {/* Join Date */}
-                        <div className="flex items-center gap-2 text-slate-500 mb-4">
+                        <div className="flex items-center gap-2 text-slate-500">
                             <CalendarDays size={14} strokeWidth={2.5} />
                             <span className="text-xs">Membro desde {formattedJoinDate}</span>
                         </div>
-
-                        {/* Botões de Ação (Abaixo do info) */}
-                        {/* Botões de Ação (Abaixo do info) */}
-                        <div className="flex items-center gap-2">
-                            <Button
-                                variant="secondary"
-                                size="xs"
-                                onClick={() => setShowEditModal(true)}
-                                className="rounded-lg"
-                            >
-                                Editar Perfil
-                            </Button>
-                            <Button
-                                variant="outline-primary"
-                                size="xs"
-                                onClick={() => setShowLinkTrainer(true)}
-                                className="rounded-lg"
-                                leftIcon={<Users size={12} />}
-                            >
-                                Personal
-                            </Button>
-                        </div>
                     </div>
+                </div>
+
+                <div
+                    data-testid="profile-primary-actions"
+                    className="relative z-10 mt-5 grid grid-cols-2 gap-2"
+                >
+                    <Button
+                        variant="secondary"
+                        size="sm"
+                        onClick={() => setShowEditModal(true)}
+                        className="w-full rounded-xl px-3 text-[0.68rem] tracking-normal whitespace-nowrap"
+                        leftIcon={<PencilLine size={14} />}
+                    >
+                        Editar perfil
+                    </Button>
+                    <Button
+                        variant="outline-primary"
+                        size="sm"
+                        onClick={() => setShowLinkTrainer(true)}
+                        className="w-full rounded-xl px-3 text-[0.68rem] tracking-normal whitespace-nowrap"
+                        leftIcon={<Users size={14} />}
+                    >
+                        Personal
+                    </Button>
                 </div>
 
                 {/* Experience Bar */}

--- a/src/pages/ProfilePage.test.jsx
+++ b/src/pages/ProfilePage.test.jsx
@@ -135,6 +135,18 @@ describe('ProfilePage Integration', () => {
         expect(screen.getByDisplayValue('Test User')).toBeInTheDocument();
     });
 
+    it('keeps the primary profile actions readable in a two-column row', async () => {
+        await renderProfile();
+
+        const actions = screen.getByTestId('profile-primary-actions');
+        const editButton = screen.getByRole('button', { name: /editar perfil/i });
+        const personalButton = screen.getByRole('button', { name: /^personal$/i });
+
+        expect(actions).toHaveClass('grid-cols-2');
+        expect(editButton).toHaveClass('w-full', 'whitespace-nowrap');
+        expect(personalButton).toHaveClass('w-full', 'whitespace-nowrap');
+    });
+
     it('updates profile data when form is submitted', async () => {
         await renderProfile();
         fireEvent.click(screen.getByRole('button', { name: /editar perfil/i }));

--- a/src/pages/WorkoutExecutionPage.jsx
+++ b/src/pages/WorkoutExecutionPage.jsx
@@ -554,7 +554,14 @@ export function WorkoutExecutionPage({ user }) {
     };
 
     return (
-        <div className={`min-h-screen bg-[#020617] text-slate-100 p-4 pb-40 font-sans selection:bg-cyan-500/30`}>
+        <div
+            data-testid="workout-execution-page"
+            data-focus-mode={focusMode ? 'true' : 'false'}
+            className={`min-h-screen bg-[#020617] text-slate-100 p-4 font-sans selection:bg-cyan-500/30 ${focusMode
+                ? 'pb-[calc(1rem+env(safe-area-inset-bottom))]'
+                : 'pb-40'
+                }`}
+        >
             {/* LOADER DE FINALIZAÇÃO DA SESSÃO */}
             {isFinishingSession && (
                 <div className="fixed inset-0 z-[300] flex flex-col items-center justify-center p-4 bg-[#020617]/95 backdrop-blur-xl animate-in fade-in duration-300 text-white">
@@ -906,7 +913,13 @@ export function WorkoutExecutionPage({ user }) {
 
                 {/* Footer Fim de Treino - Apenas mostra se o modal de finalização NÃO estiver visível */}
                 {!showFinishModal && (
-                    <div className="w-full mt-8 pb-[calc(6rem+env(safe-area-inset-bottom))] lg:pb-[calc(2rem+env(safe-area-inset-bottom))]">
+                    <div
+                        data-testid="workout-finish-footer"
+                        className={`w-full ${focusMode
+                            ? 'mt-5 pb-[calc(1rem+env(safe-area-inset-bottom))]'
+                            : 'mt-8 pb-[calc(6rem+env(safe-area-inset-bottom))] lg:pb-[calc(2rem+env(safe-area-inset-bottom))]'
+                            }`}
+                    >
                         <div className="max-w-2xl mx-auto flex justify-center">
                             <div className="space-y-4 w-full flex flex-col items-center px-4">
                                 <Button

--- a/src/pages/WorkoutExecutionPage.test.jsx
+++ b/src/pages/WorkoutExecutionPage.test.jsx
@@ -168,4 +168,19 @@ describe('WorkoutExecutionPage', () => {
 
         expect(await screen.findByText('Compartilhar Resultado', {}, { timeout: 2000 })).toBeInTheDocument();
     });
+
+    it('removes the large bottom reserve in focus mode', () => {
+        render(<WorkoutExecutionPage user={{ uid: 'u1' }} />);
+
+        const page = screen.getByTestId('workout-execution-page');
+        const footer = screen.getByTestId('workout-finish-footer');
+        expect(page).toHaveAttribute('data-focus-mode', 'false');
+        expect(page).toHaveClass('pb-40');
+
+        fireEvent.click(screen.getByRole('button', { name: 'FOCO' }));
+
+        expect(page).toHaveAttribute('data-focus-mode', 'true');
+        expect(page).not.toHaveClass('pb-40');
+        expect(footer.className).not.toContain('6rem');
+    });
 });


### PR DESCRIPTION
## O que foi alterado
- Remove a reserva inferior acumulada no modo foco, eliminando a rolagem vazia depois de **Finalizar treino**.
- Mantém a margem segura do iPhone sem aplicar os `pb-40` e `6rem` usados no fluxo normal.
- Reorganiza o cabeçalho do perfil para preservar nome e data.
- Move **Editar perfil** e **Personal** para uma linha de ações 50/50, com ícones e texto sem quebra.

## Como foi testado
- `npm run lint`
- `npm test -- --run`: 113 testes
- `npm run build`
- QA autenticado no Chrome em viewport `400x844`
- Sem overflow horizontal; botões medidos com 143 px cada e texto em uma linha

## Impacto
- Apenas layout responsivo e testes.
- Sem alterações em Firebase, regras ou modelo de dados.