### PR TITLE
fix: contain history filters on mobile

### DIFF
--- a/src/components/history/HistoryAnalyticsSection.jsx
+++ b/src/components/history/HistoryAnalyticsSection.jsx
@@ -37,7 +37,10 @@ export function HistoryAnalyticsSection({
     }, [allUserExercises, globalSearchTerm]);
 
     return (
-        <div className="space-y-6 animate-in fade-in slide-in-from-bottom-4 duration-500">
+        <div
+            data-testid="history-analytics-section"
+            className="w-full min-w-0 max-w-full space-y-6 overflow-x-clip animate-in fade-in slide-in-from-bottom-4 duration-500"
+        >
             {loadingTemplates ? (
                 <div className="py-20 text-center">
                     <Activity className="animate-spin w-8 h-8 text-cyan-500 mx-auto mb-4" />
@@ -46,7 +49,7 @@ export function HistoryAnalyticsSection({
             ) : (
                 <>
                     {/* Filtros */}
-                    <div className="space-y-4 bg-slate-900/50 p-4 rounded-2xl border border-slate-800/50">
+                    <div className="w-full min-w-0 max-w-full space-y-4 overflow-hidden rounded-2xl border border-slate-800/50 bg-slate-900/50 p-4">
                         {/* Toggle de Modo de Busca */}
                         <div className="flex bg-slate-950 rounded-xl p-1 border border-slate-800/80">
                             <button
@@ -72,43 +75,47 @@ export function HistoryAnalyticsSection({
                         </div>
 
                         {searchMode === 'template' ? (
-                            <div className="space-y-3 animate-in fade-in zoom-in-95 duration-300">
+                            <div className="min-w-0 max-w-full space-y-3 animate-in fade-in zoom-in-95 duration-300">
                                 <div className="flex flex-col gap-1.5">
                                     <label className="text-xs font-bold text-slate-400 uppercase ml-1">Rotina</label>
-                                    <select
-                                        value={selectedTemplate}
-                                        onChange={(e) => onTemplateChange(e.target.value)}
-                                        className="w-full bg-slate-950 text-white border border-slate-800 rounded-xl px-4 py-3 appearance-none focus:border-cyan-500 outline-none transition-colors"
-                                    >
-                                        <option value="" disabled>Selecione um treino...</option>
-                                        <optgroup label="Treinos Ativos">
-                                            {templates.filter(t => !t.isArchived).map(t => (
-                                                <option key={t.id} value={t.name}>{t.name}</option>
-                                            ))}
-                                        </optgroup>
-                                        {templates.some(t => t.isArchived) && (
-                                            <optgroup label="Treinos Arquivados">
-                                                {templates.filter(t => t.isArchived).map(t => (
+                                    <div className="min-w-0 max-w-full overflow-hidden rounded-xl [contain:inline-size]">
+                                        <select
+                                            value={selectedTemplate}
+                                            onChange={(e) => onTemplateChange(e.target.value)}
+                                            className="block w-full min-w-0 max-w-full truncate overflow-hidden rounded-xl border border-slate-800 bg-slate-950 px-4 py-3 text-base text-white outline-none transition-colors focus:border-cyan-500"
+                                        >
+                                            <option value="" disabled>Selecione um treino...</option>
+                                            <optgroup label="Treinos Ativos">
+                                                {templates.filter(t => !t.isArchived).map(t => (
                                                     <option key={t.id} value={t.name}>{t.name}</option>
                                                 ))}
                                             </optgroup>
-                                        )}
-                                    </select>
+                                            {templates.some(t => t.isArchived) && (
+                                                <optgroup label="Treinos Arquivados">
+                                                    {templates.filter(t => t.isArchived).map(t => (
+                                                        <option key={t.id} value={t.name}>{t.name}</option>
+                                                    ))}
+                                                </optgroup>
+                                            )}
+                                        </select>
+                                    </div>
                                 </div>
 
                                 <div className="flex flex-col gap-1.5">
                                     <label className="text-xs font-bold text-slate-400 uppercase ml-1">Exercício</label>
-                                    <select
-                                        value={selectedExercise}
-                                        onChange={(e) => onExerciseChange(e.target.value)}
-                                        disabled={!selectedTemplate}
-                                        className="w-full bg-slate-950 text-white border border-slate-800 rounded-xl px-4 py-3 appearance-none focus:border-cyan-500 outline-none transition-colors disabled:opacity-50"
-                                    >
-                                        <option value="" disabled>Selecione...</option>
-                                        {exerciseOptions.map(opt => (
-                                            <option key={opt} value={opt}>{opt}</option>
-                                        ))}
-                                    </select>
+                                    <div className="min-w-0 max-w-full overflow-hidden rounded-xl [contain:inline-size]">
+                                        <select
+                                            value={selectedExercise}
+                                            onChange={(e) => onExerciseChange(e.target.value)}
+                                            disabled={!selectedTemplate}
+                                            className="block w-full min-w-0 max-w-full truncate overflow-hidden rounded-xl border border-slate-800 bg-slate-950 px-4 py-3 text-base text-white outline-none transition-colors focus:border-cyan-500 disabled:opacity-50"
+                                        >
+                                            <option value="" disabled>Selecione...</option>
+                                            {exerciseOptions.map(opt => (
+                                                <option key={opt} value={opt}>{opt}</option>
+                                            ))}
+                                        </select>
+                                    </div>
                                 </div>
                             </div>
                         ) : (
@@ -168,9 +175,9 @@ export function HistoryAnalyticsSection({
                     {((searchMode === 'template' && selectedTemplate && selectedExercise) || 
                       (searchMode === 'global' && selectedGlobalExercises.length > 0)) && (
                         <div className="space-y-3">
-                            <div className="flex justify-between items-center px-1">
+                            <div className="flex min-w-0 flex-wrap items-center justify-between gap-2 px-1">
                                 <h3 className="font-bold text-slate-400 uppercase tracking-wide text-xs">Evolução de Carga</h3>
-                                <div className="flex gap-1 bg-slate-900/50 p-1 rounded-lg border border-slate-800">
+                                <div className="flex max-w-full shrink-0 gap-1 rounded-lg border border-slate-800 bg-slate-900/50 p-1">
                                     {['1M', '3M', '6M', '1Y', 'ALL'].map(range => (
                                         <button
                                             key={range}

--- a/src/pages/HistoryPage.jsx
+++ b/src/pages/HistoryPage.jsx
@@ -526,7 +526,10 @@ function HistoryPage({ user, isEmbedded = false }) {
     }, [selectedTemplate, selectedExercise, user, activeTab, chartRange, searchMode, globalSearchTerm, selectedGlobalExercises, globalSessionsCache]);
 
     return (
-        <div className="min-h-screen bg-[#020617] pb-48 lg:pb-32">
+        <div
+            data-testid="history-page"
+            className="min-h-screen w-full min-w-0 max-w-full overflow-x-clip bg-[#020617] pb-48 lg:pb-32"
+        >
             {/* --- CABEÇALHO --- */}
             <div className="sticky top-0 z-40 bg-[#020617]/95 backdrop-blur-md pt-2 pb-4 lg:pt-[calc(1.5rem+env(safe-area-inset-top))]">
                 <div className="w-full max-w-5xl mx-auto px-4 space-y-4">
@@ -565,7 +568,7 @@ function HistoryPage({ user, isEmbedded = false }) {
                 </div>
             </div>
 
-            <div className="px-4 py-6 w-full max-w-5xl mx-auto">
+            <div className="mx-auto w-full min-w-0 max-w-5xl px-4 py-6">
                 {/* === VISÃO DE DIÁRIO === */}
                 {activeTab === 'journal' && (
                     <div className="space-y-6 animate-in fade-in slide-in-from-bottom-4 duration-500">

--- a/src/pages/HistoryPage.test.jsx
+++ b/src/pages/HistoryPage.test.jsx
@@ -71,6 +71,38 @@ describe('HistoryPage', () => {
         expect(screen.getByText('Evolução')).toBeInTheDocument();
     });
 
+    it('contains long mobile filters without expanding the page width', async () => {
+        workoutService.getTemplates.mockResolvedValue([
+            {
+                id: 'long-template',
+                name: 'Treino A (Costas, Bíceps e Abdômen)',
+                exercises: [{ name: 'Puxada pela frente pronada + puxada pegada supinada (Bi-set)' }]
+            }
+        ]);
+
+        render(<HistoryPage user={mockUser} />);
+
+        await waitFor(() => {
+            expect(screen.getAllByRole('combobox')).toHaveLength(2);
+        });
+
+        expect(screen.getByTestId('history-page')).toHaveClass(
+            'w-full',
+            'min-w-0',
+            'max-w-full',
+            'overflow-x-clip'
+        );
+        expect(screen.getByTestId('history-analytics-section')).toHaveClass(
+            'min-w-0',
+            'max-w-full',
+            'overflow-x-clip'
+        );
+
+        screen.getAllByRole('combobox').forEach((select) => {
+            expect(select).toHaveClass('w-full', 'min-w-0', 'max-w-full', 'overflow-hidden');
+        });
+    });
+
     it('selects the first ordered active workout instead of an archived workout', async () => {
         workoutService.getTemplates.mockResolvedValue([
             { id: 'archived', name: 'Treino 1 Antigo', isArchived: true, displayOrder: 0, exercises: [] },


### PR DESCRIPTION
## O que foi alterado
- Impede que nomes longos de treinos e exercícios ampliem a largura interna dos selects no Histórico.
- Isola os filtros com contenção de largura e corta qualquer overflow horizontal da página.
- Mantém fonte de 16 px nos selects para evitar zoom automático do Safari ao tocar no campo.
- Permite que o cabeçalho do gráfico reorganize os períodos em telas estreitas.

## Como foi testado
- `npm run lint`
- `npm test -- --run`: 114 testes
- `npm run build`
- QA autenticado no Chrome em 390 x 844 e 360 x 800
- `scrollWidth` do documento igual à viewport
- Conteúdo interno dos selects reduzido de 496 px para a largura disponível

## Impacto
- Apenas responsividade da tela de Histórico e teste de regressão.
- Sem alterações em Firebase, regras ou modelo de dados.