### PR TITLE
fix: completar merge do PR #25 (bi-set toast, modo claro e densidade)

### DIFF
--- a/src/AppAuthed.jsx
+++ b/src/AppAuthed.jsx
@@ -346,7 +346,7 @@ function AppAuthedContent() {
             )}
 
             <div className={`w-full min-h-screen transition-all duration-300 relative flex flex-col ${user && !location.pathname.startsWith('/execute') && location.pathname !== '/login'
-                ? 'pt-[calc(1rem+env(safe-area-inset-top))] pb-44 lg:pb-8 lg:pt-8 lg:pl-64'
+                ? 'pt-[calc(1rem+env(safe-area-inset-top))] pb-24 lg:pb-8 lg:pt-8 lg:pl-64'
                 : ''
                 }`}>
                 <div className="w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex-1">

--- a/src/BottomNavEnhanced.jsx
+++ b/src/BottomNavEnhanced.jsx
@@ -62,7 +62,7 @@ export function BottomNavEnhanced({ activeTab, onTabChange }) {
             <div
                 className="flex items-center gap-1 p-1.5 rounded-[28px] border border-white/10 relative overflow-hidden backdrop-blur-3xl"
                 style={{
-                    background: 'rgba(12, 12, 14, 0.45)', // Base dark glass
+                    background: 'var(--vit-nav-glass)',
                     boxShadow: '0 20px 40px -10px rgba(0,0,0,0.5), 0 0 0 1px rgba(255,255,255,0.05) inset',
                     WebkitBackdropFilter: 'blur(40px) saturate(180%)'
                 }}

--- a/src/DesktopSidebar.jsx
+++ b/src/DesktopSidebar.jsx
@@ -40,9 +40,9 @@ export function DesktopSidebar({ activeTab, onTabChange, user, isTrainer }) {
         <aside
             className="hidden lg:flex flex-col fixed left-0 top-0 bottom-0 w-64 z-50 py-6 px-4 gap-8 font-sans"
             style={{
-                background: '#050B16', // Fundo azul marinho mais escuro
-                borderRight: '1px solid rgba(30, 41, 59, 0.4)',
-                boxShadow: '4px 0 24px rgba(0,0,0,0.4)'
+                background: 'var(--vit-sidebar)',
+                borderRight: '1px solid var(--vit-sidebar-border)',
+                boxShadow: 'var(--vit-sidebar-shadow)'
             }}
         >
             {/* Seção do Logo */}

--- a/src/components/achievements/VitalitaGlassCard.jsx
+++ b/src/components/achievements/VitalitaGlassCard.jsx
@@ -71,7 +71,7 @@ export const VitalitaGlassCard = forwardRef(({ achievement, className = '' }, re
         // CONTAINER PRINCIPAL: Define tamanho, borda e efeito de vidro
         <div
             ref={ref}
-            className={`relative flex h-[500px] w-[340px] flex-col overflow-hidden rounded-[30px] border border-slate-800/50 bg-[#020617]/70 p-8 shadow-2xl backdrop-blur-[24px] transition-transform duration-500 hover:scale-[1.02] ${className}`}
+            className={`theme-dark-locked relative flex h-[500px] w-[340px] flex-col overflow-hidden rounded-[30px] border border-slate-800/50 bg-[#020617]/70 p-8 shadow-2xl backdrop-blur-[24px] transition-transform duration-500 hover:scale-[1.02] ${className}`}
         >
 
             {/* CAMADA 0: Ambient Glows (Luzes de fundo) */}

--- a/src/components/design-system/Button.jsx
+++ b/src/components/design-system/Button.jsx
@@ -52,7 +52,7 @@ export const Button = ({
     // Estilos de variante combinando com "Variantes" e "Design Tokens"
     const variantStyles = {
         // PRIMÁRIO: Gradiente ciano + brilho + borda (reservado à ação principal da tela)
-        primary: 'bg-[radial-gradient(circle_at_top_left,#3abff8_0%,#0ea5e9_42%,#1d4ed8_100%)] border border-sky-400/80 text-white shadow-[0_8px_20px_rgba(37,99,235,0.4)] hover:shadow-[0_12px_30px_rgba(37,99,235,0.5)]',
+        primary: 'bg-[radial-gradient(circle_at_top_left,#3abff8_0%,#0ea5e9_42%,#1d4ed8_100%)] border border-sky-400/80 text-[#fff] shadow-[0_8px_20px_rgba(37,99,235,0.4)] hover:shadow-[0_12px_30px_rgba(37,99,235,0.5)]',
 
         // SECUNDÁRIO: Contorno transparente em slate neutro
         secondary: 'bg-transparent border border-slate-400/30 text-slate-400 hover:border-slate-400/70 hover:text-slate-200',
@@ -64,13 +64,13 @@ export const Button = ({
         ghost: 'bg-transparent border-transparent text-slate-400 hover:bg-slate-700/10 hover:text-slate-300',
 
         // PERIGO: Gradiente vermelho + brilho + borda
-        danger: 'bg-[radial-gradient(circle_at_top_left,#ef4444_0%,#dc2626_42%,#991b1b_100%)] border border-red-500/80 text-white shadow-[0_8px_20px_rgba(220,38,38,0.4)] hover:shadow-[0_12px_30px_rgba(220,38,38,0.5)]',
+        danger: 'bg-[radial-gradient(circle_at_top_left,#ef4444_0%,#dc2626_42%,#991b1b_100%)] border border-red-500/80 text-[#fff] shadow-[0_8px_20px_rgba(220,38,38,0.4)] hover:shadow-[0_12px_30px_rgba(220,38,38,0.5)]',
 
         // OUTLINE-PRIMÁRIO: Destaque ciano sem glow (o brilho fica só no primary)
         'outline-primary': 'bg-cyan-500/10 border border-cyan-500/40 text-cyan-400 hover:bg-cyan-500/15 hover:border-cyan-500/60',
 
         // SUCESSO: Gradiente esmeralda — celebração/conclusão (finalizar treino, PR)
-        success: 'bg-[radial-gradient(circle_at_top_left,#34d399_0%,#10b981_42%,#059669_100%)] border border-emerald-500/80 text-white shadow-[0_8px_20px_rgba(16,185,129,0.4)] hover:shadow-[0_12px_30px_rgba(16,185,129,0.5)]',
+        success: 'bg-[radial-gradient(circle_at_top_left,#34d399_0%,#10b981_42%,#059669_100%)] border border-emerald-500/80 text-[#fff] shadow-[0_8px_20px_rgba(16,185,129,0.4)] hover:shadow-[0_12px_30px_rgba(16,185,129,0.5)]',
     };
 
     // Combinar classes
@@ -166,7 +166,7 @@ export const Button = ({
             <span className="flex items-center gap-1.5">
                 {children}
                 {badge !== undefined && (
-                    <span className="bg-red-500 text-white px-1.5 rounded-full text-[10px] min-w-[18px] h-[18px] flex items-center justify-center font-bold ml-1">
+                    <span className="bg-red-500 text-[#fff] px-1.5 rounded-full text-[10px] min-w-[18px] h-[18px] flex items-center justify-center font-bold ml-1">
                         {badge}
                     </span>
                 )}

--- a/src/index.css
+++ b/src/index.css
@@ -92,6 +92,11 @@
     --vit-shadow-card: 0 20px 45px rgba(2, 6, 23, 0.35);
     --vit-shadow-glow: 0 0 24px rgba(6, 182, 212, 0.28);
 
+    --vit-sidebar: #050b16;
+    --vit-sidebar-border: rgba(30, 41, 59, 0.4);
+    --vit-sidebar-shadow: 4px 0 24px rgba(0, 0, 0, 0.4);
+    --vit-nav-glass: rgba(12, 12, 14, 0.45);
+
     color-scheme: dark;
 }
 
@@ -140,23 +145,95 @@
     /* Ciano de destaque um tom mais escuro para contraste em fundo claro */
     --color-cyan-400: #0891b2;
     --color-cyan-300: #0e7490;
+
+    --vit-sidebar: #ffffff;
+    --vit-sidebar-border: rgba(100, 116, 139, 0.25);
+    --vit-sidebar-shadow: 4px 0 24px rgba(15, 23, 42, 0.08);
+    --vit-nav-glass: rgba(255, 255, 255, 0.72);
+}
+
+/*
+ * Subárvores travadas no tema escuro (cards de compartilhamento, que viram
+ * imagem para redes sociais): re-fixa a paleta escura dentro do elemento.
+ */
+:root[data-theme="light"] .theme-dark-locked {
+    color-scheme: dark;
+    --color-slate-950: #020617;
+    --color-slate-900: #0f172a;
+    --color-slate-800: #1e293b;
+    --color-slate-700: #334155;
+    --color-slate-600: #475569;
+    --color-slate-500: #64748b;
+    --color-slate-400: #94a3b8;
+    --color-slate-300: #cbd5e1;
+    --color-slate-200: #e2e8f0;
+    --color-slate-100: #f1f5f9;
+    --color-slate-50: #f8fafc;
+    --color-gray-100: #f3f4f6;
+    --color-gray-200: #e5e7eb;
+    --color-gray-300: #d1d5db;
+    --color-gray-400: #9ca3af;
+    --color-white: #ffffff;
+    --color-cyan-400: #22d3ee;
+    --color-cyan-300: #67e8f9;
 }
 
 /* Superfícies com hex hardcoded (fora da paleta de variáveis) */
-:root[data-theme="light"] [class*="bg-[#020617]"] {
+:root[data-theme="light"] [class*="bg-[#020617]"]:not(.theme-dark-locked, .theme-dark-locked *) {
     background-color: #f1f5f9;
 }
 
-:root[data-theme="light"] [class*="bg-[#0f172a]"] {
+:root[data-theme="light"] [class*="bg-[#0f172a]"]:not(.theme-dark-locked, .theme-dark-locked *) {
     background-color: #ffffff;
 }
 
-:root[data-theme="light"] [class*="bg-[#1e293b]"] {
+:root[data-theme="light"] [class*="bg-[#1e293b]"]:not(.theme-dark-locked, .theme-dark-locked *) {
     background-color: #e2e8f0;
 }
 
-:root[data-theme="light"] [class*="text-[#e2e8f0]"] {
+:root[data-theme="light"] [class*="bg-[#334155]"]:not(.theme-dark-locked, .theme-dark-locked *) {
+    background-color: #cbd5e1;
+}
+
+:root[data-theme="light"] [class*="bg-[#02061740]"]:not(.theme-dark-locked, .theme-dark-locked *) {
+    background-color: rgba(15, 23, 42, 0.05);
+}
+
+:root[data-theme="light"] [class*="bg-[#083344]"]:not(.theme-dark-locked, .theme-dark-locked *) {
+    background-color: #cffafe;
+}
+
+:root[data-theme="light"] [class*="text-[#e2e8f0]"]:not(.theme-dark-locked, .theme-dark-locked *) {
     color: #1e293b;
+}
+
+:root[data-theme="light"] [class*="text-[#94a3b8]"]:not(.theme-dark-locked, .theme-dark-locked *) {
+    color: #64748b;
+}
+
+:root[data-theme="light"] [class*="border-[#1e293b]"]:not(.theme-dark-locked, .theme-dark-locked *) {
+    border-color: #cbd5e1;
+}
+
+:root[data-theme="light"] [class*="border-[#020617]"]:not(.theme-dark-locked, .theme-dark-locked *) {
+    border-color: #e2e8f0;
+}
+
+/* Gradientes com stops em hex escuro (ex.: card "Próximo Treino Sugerido") */
+:root[data-theme="light"] [class*="from-[#0f172a]"]:not(.theme-dark-locked, .theme-dark-locked *) {
+    --tw-gradient-from: #ffffff;
+}
+
+:root[data-theme="light"] [class*="from-[#020617]"]:not(.theme-dark-locked, .theme-dark-locked *) {
+    --tw-gradient-from: #f1f5f9;
+}
+
+:root[data-theme="light"] [class*="to-[#020617]"]:not(.theme-dark-locked, .theme-dark-locked *) {
+    --tw-gradient-to: #f8fafc;
+}
+
+:root[data-theme="light"] [class*="to-[#0f172a]"]:not(.theme-dark-locked, .theme-dark-locked *) {
+    --tw-gradient-to: #ffffff;
 }
 
 @layer base {

--- a/src/index.css
+++ b/src/index.css
@@ -6,6 +6,7 @@
  */
 @import "tailwindcss";
 @import "./fonts.css";
+@import "./theme-light-compat.css";
 
 @theme {
     /* Cores - Vitalità Palette */
@@ -80,6 +81,7 @@
     --vit-border: rgba(148, 163, 184, 0.24);
     --vit-text: #e2e8f0;
     --vit-text-strong: #f8fafc;
+    --vit-text-soft: #cbd5e1;
     --vit-muted: #94a3b8;
     --vit-primary: #06b6d4;
     --vit-primary-strong: #0891b2;
@@ -89,6 +91,72 @@
 
     --vit-shadow-card: 0 20px 45px rgba(2, 6, 23, 0.35);
     --vit-shadow-glow: 0 0 24px rgba(6, 182, 212, 0.28);
+
+    color-scheme: dark;
+}
+
+/*
+ * Tema claro: ativado com data-theme="light" no <html> (ver src/utils/theme.js).
+ * As utilities do Tailwind v4 referenciam var(--color-*), então remapear a
+ * paleta aqui inverte as superfícies do app inteiro sem tocar nos componentes.
+ */
+:root[data-theme="light"] {
+    color-scheme: light;
+
+    --vit-surface: #f1f5f9;
+    --vit-panel: #ffffff;
+    --vit-panel-raised: #e2e8f0;
+    --vit-border: rgba(71, 85, 105, 0.22);
+    --vit-text: #1e293b;
+    --vit-text-strong: #0f172a;
+    --vit-text-soft: #334155;
+    --vit-muted: #64748b;
+    --vit-shadow-card: 0 20px 45px rgba(15, 23, 42, 0.12);
+    --vit-shadow-glow: 0 0 24px rgba(6, 182, 212, 0.2);
+
+    /* Escala slate invertida (superfícies escuras -> claras e vice-versa) */
+    --color-slate-950: #f8fafc;
+    --color-slate-900: #ffffff;
+    --color-slate-800: #e2e8f0;
+    --color-slate-700: #cbd5e1;
+    --color-slate-600: #94a3b8;
+    --color-slate-500: #64748b;
+    --color-slate-400: #475569;
+    --color-slate-300: #334155;
+    --color-slate-200: #1e293b;
+    --color-slate-100: #0f172a;
+    --color-slate-50: #020617;
+
+    /* Cinzas usados em textos de cards */
+    --color-gray-100: #0f172a;
+    --color-gray-200: #1e293b;
+    --color-gray-300: #334155;
+    --color-gray-400: #475569;
+
+    /* Texto "branco" vira tinta escura em superfícies claras. Botões com
+       gradiente saturado usam text-[#fff] literal e não são afetados. */
+    --color-white: #0f172a;
+
+    /* Ciano de destaque um tom mais escuro para contraste em fundo claro */
+    --color-cyan-400: #0891b2;
+    --color-cyan-300: #0e7490;
+}
+
+/* Superfícies com hex hardcoded (fora da paleta de variáveis) */
+:root[data-theme="light"] [class*="bg-[#020617]"] {
+    background-color: #f1f5f9;
+}
+
+:root[data-theme="light"] [class*="bg-[#0f172a]"] {
+    background-color: #ffffff;
+}
+
+:root[data-theme="light"] [class*="bg-[#1e293b]"] {
+    background-color: #e2e8f0;
+}
+
+:root[data-theme="light"] [class*="text-[#e2e8f0]"] {
+    color: #1e293b;
 }
 
 @layer base {
@@ -138,7 +206,7 @@
         /* ~20px → 24px */
         font-weight: 700;
         line-height: 1.3;
-        color: #f1f5f9;
+        color: var(--vit-text-strong);
         letter-spacing: 0.3px;
     }
 
@@ -155,7 +223,7 @@
         font-size: 0.875rem;
         font-weight: 400;
         line-height: 1.6;
-        color: #cbd5e1;
+        color: var(--vit-text-soft);
     }
 
     small {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -10,12 +10,15 @@ import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import { AuthProvider } from './AuthContext';
 import './index.css';
+import { initTheme } from './utils/theme';
 import { SpeedInsightsLoader } from './components/SpeedInsightsLoader';
 import { ObservabilityTracker } from './components/ObservabilityTracker';
 import {
     initializeAppCheckMonitoring,
     isAppCheckMonitoringEnabled
 } from './services/appCheckService';
+
+initTheme();
 
 function renderApplication() {
     ReactDOM.createRoot(document.getElementById('root')).render(

--- a/src/pages/CreateWorkoutPage.jsx
+++ b/src/pages/CreateWorkoutPage.jsx
@@ -350,7 +350,7 @@ export default function CreateWorkoutPage({ user }) {
     }
 
     return (
-        <div className="w-full max-w-3xl mx-auto px-4 pt-2 pb-48 lg:pt-[calc(1.5rem+env(safe-area-inset-top))] lg:pb-32">
+        <div className="w-full max-w-3xl mx-auto px-4 pt-2 pb-8 lg:pt-[calc(1.5rem+env(safe-area-inset-top))] lg:pb-12">
             <PageHeader
                 title={initialData ? 'Editar Treino' : 'Criar Novo Treino'}
                 description="Monte a ficha com exercícios, séries, repetições e método de execução."

--- a/src/pages/CreateWorkoutPage.jsx
+++ b/src/pages/CreateWorkoutPage.jsx
@@ -221,7 +221,9 @@ export default function CreateWorkoutPage({ user }) {
 
         if (editingExerciseId) {
             // Editar existente (merge preserva campos fora do formulário, como groupId)
-            setExercises(exercises.map(ex => ex.id === editingExerciseId ? { ...ex, ...finalExercise, id: editingExerciseId } : ex));
+            const updated = exercises.map(ex => ex.id === editingExerciseId ? { ...ex, ...finalExercise, id: editingExerciseId } : ex);
+            setExercises(updated);
+            suggestGroupingForBiSet(updated, editingExerciseId);
             setEditingExerciseId(null);
             setShowAddExercise(false);
         } else {
@@ -230,7 +232,9 @@ export default function CreateWorkoutPage({ user }) {
                 id: Date.now().toString(),
                 ...finalExercise
             };
-            setExercises([...exercises, exercise]);
+            const updated = [...exercises, exercise];
+            setExercises(updated);
+            suggestGroupingForBiSet(updated, exercise.id);
             setShowAddExercise(false);
         }
 
@@ -276,6 +280,26 @@ export default function CreateWorkoutPage({ user }) {
 
     function handleToggleLink(id) {
         setExercises(prev => toggleGroupWithPrevious(prev, prev.findIndex(ex => ex.id === id)));
+    }
+
+    // Método "Bi-set" sozinho é só informativo; o que muda a execução é o
+    // agrupamento. Ao salvar com esse método, oferece agrupar com o anterior.
+    function suggestGroupingForBiSet(list, exerciseId) {
+        const idx = list.findIndex(ex => ex.id === exerciseId);
+        if (idx <= 0) return;
+        const current = list[idx];
+        if (current.method !== 'Bi-set') return;
+        const previous = list[idx - 1];
+        if (current.groupId && current.groupId === previous.groupId) return;
+
+        toast('Bi-set é executado em dupla', {
+            description: `Agrupar com "${previous.name}" para alternar as séries na execução?`,
+            action: {
+                label: 'Agrupar',
+                onClick: () => handleToggleLink(exerciseId)
+            },
+            duration: 8000
+        });
     }
 
     async function handleSave() {
@@ -544,6 +568,13 @@ export default function CreateWorkoutPage({ user }) {
                                     />
                                 </label>
                             </div>
+
+                            {newExercise.method === 'Bi-set' && (
+                                <p className="flex items-start gap-1.5 text-[11px] leading-snug text-cyan-300/90 bg-cyan-500/10 border border-cyan-500/30 rounded-lg px-3 py-2">
+                                    <Link2 size={12} className="mt-0.5 shrink-0" />
+                                    <span>Para alternar as séries na execução, agrupe este exercício com o anterior usando o botão de corrente na lista.</span>
+                                </p>
+                            )}
 
                             <label className="flex flex-col gap-2 text-xs font-bold text-slate-400 uppercase tracking-wider">
                                 Observação

--- a/src/pages/HistoryPage.jsx
+++ b/src/pages/HistoryPage.jsx
@@ -528,7 +528,7 @@ function HistoryPage({ user, isEmbedded = false }) {
     return (
         <div
             data-testid="history-page"
-            className="min-h-screen w-full min-w-0 max-w-full overflow-x-clip bg-[#020617] pb-48 lg:pb-32"
+            className="min-h-screen w-full min-w-0 max-w-full overflow-x-clip bg-[#020617] pb-8 lg:pb-12"
         >
             {/* --- CABEÇALHO --- */}
             <div className="sticky top-0 z-40 bg-[#020617]/95 backdrop-blur-md pt-2 pb-4 lg:pt-[calc(1.5rem+env(safe-area-inset-top))]">

--- a/src/pages/HomeDashboard.jsx
+++ b/src/pages/HomeDashboard.jsx
@@ -533,7 +533,7 @@ export function HomeDashboard({
 
 
     return (
-        <div className="pb-44 lg:pb-8 max-w-3xl mx-auto w-full">
+        <div className="pb-4 lg:pb-8 max-w-3xl mx-auto w-full">
             <div className="w-full px-4 lg:px-8 flex flex-col">
 
                 {/* 1. SAUDAÇÃO */}

--- a/src/pages/MethodsPage.jsx
+++ b/src/pages/MethodsPage.jsx
@@ -26,7 +26,7 @@ export default function MethodsPage() {
     const navigate = useNavigate();
     const onBack = () => navigate(-1);
     return (
-        <div className="w-full max-w-3xl mx-auto px-4 pt-8 pb-32">
+        <div className="w-full max-w-3xl mx-auto px-4 pt-8 pb-8">
             {/* Cabeçalho */}
             <div className="mb-8">
                 <Button

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -23,8 +23,11 @@ import {
     PencilLine,
     FileText,
     ShieldCheck,
-    FileDown
+    FileDown,
+    Sun,
+    Moon
 } from 'lucide-react';
+import { getStoredTheme, setTheme, THEMES } from '../utils/theme';
 import { achievementsCatalog } from '../data/achievementsCatalog';
 import { evaluateAchievements, calculateStats, evaluateHistory } from '../utils/evaluateAchievements';
 import { calculateWeeklyStats } from '../utils/workoutStats';
@@ -45,6 +48,11 @@ export default function ProfilePage({ user, onLogout, onNavigateToHistory, onNav
     const [loading, setLoading] = useState(true);
     const [saving, setSaving] = useState(false);
     const [exportingData, setExportingData] = useState(false);
+    const [appTheme, setAppTheme] = useState(getStoredTheme);
+
+    const handleThemeChange = (nextTheme) => {
+        setAppTheme(setTheme(nextTheme));
+    };
 
     // --- VINCULAÇÃO DE PERSONAL TRAINER ---
     const [showLinkTrainer, setShowLinkTrainer] = useState(false);
@@ -317,7 +325,7 @@ export default function ProfilePage({ user, onLogout, onNavigateToHistory, onNav
     }
 
     return (
-        <div className="min-h-screen bg-slate-950 pb-48 px-4 pt-2 w-full max-w-3xl mx-auto lg:pb-32 lg:pt-6">
+        <div className="min-h-screen bg-slate-950 pb-8 px-4 pt-2 w-full max-w-3xl mx-auto lg:pb-12 lg:pt-6">
 
             {/* --- CARTÃO DE CABEÇALHO DO PERFIL --- */}
             <div className="bg-slate-900/50 rounded-3xl p-5 sm:p-6 mb-6 border border-slate-800 relative overflow-hidden">
@@ -725,6 +733,40 @@ export default function ProfilePage({ user, onLogout, onNavigateToHistory, onNav
                         )}
                     </>
                 )}
+            </div>
+
+            {/* --- APARÊNCIA --- */}
+            <div className="mb-6 rounded-3xl border border-slate-800 bg-slate-900/50 p-5">
+                <SectionHeader icon={<Sun size={18} className="text-cyan-300" />} title="Aparência" />
+                <p className="mb-4 text-sm leading-relaxed text-slate-400">
+                    Escolha o tema do aplicativo. A preferência fica salva neste dispositivo.
+                </p>
+                <div className="grid grid-cols-2 gap-3" role="radiogroup" aria-label="Tema do aplicativo">
+                    <Button
+                        variant="unstyled"
+                        role="radio"
+                        aria-checked={appTheme === THEMES.dark}
+                        onClick={() => handleThemeChange(THEMES.dark)}
+                        className={`inline-flex items-center justify-center gap-2 rounded-2xl border px-4 py-3 text-xs font-bold uppercase tracking-widest transition-colors ${appTheme === THEMES.dark
+                            ? 'border-cyan-400/50 bg-cyan-400/10 text-cyan-300'
+                            : 'border-slate-700 bg-slate-950/40 text-slate-400 hover:border-slate-500 hover:text-slate-200'}`}
+                    >
+                        <Moon size={16} />
+                        Escuro
+                    </Button>
+                    <Button
+                        variant="unstyled"
+                        role="radio"
+                        aria-checked={appTheme === THEMES.light}
+                        onClick={() => handleThemeChange(THEMES.light)}
+                        className={`inline-flex items-center justify-center gap-2 rounded-2xl border px-4 py-3 text-xs font-bold uppercase tracking-widest transition-colors ${appTheme === THEMES.light
+                            ? 'border-cyan-400/50 bg-cyan-400/10 text-cyan-300'
+                            : 'border-slate-700 bg-slate-950/40 text-slate-400 hover:border-slate-500 hover:text-slate-200'}`}
+                    >
+                        <Sun size={16} />
+                        Claro
+                    </Button>
+                </div>
             </div>
 
             {/* --- PRIVACIDADE E TERMOS --- */}

--- a/src/pages/TrainerDashboard.jsx
+++ b/src/pages/TrainerDashboard.jsx
@@ -269,7 +269,7 @@ export function TrainerDashboard({ user, onBack, onNavigateToCreateWorkout }) {
 
     // --- VISÃO PRINCIPAL DO DASHBOARD ---
     return (
-        <div className="min-h-screen bg-[#020617] pb-48 pt-2 px-4 lg:px-8 max-w-5xl mx-auto lg:pb-24 lg:pt-0">
+        <div className="min-h-screen bg-[#020617] pb-8 pt-2 px-4 lg:px-8 max-w-5xl mx-auto lg:pb-12 lg:pt-0">
 
             <PageHeader
                 title="Área do Personal"

--- a/src/pages/WorkoutExecutionPage.jsx
+++ b/src/pages/WorkoutExecutionPage.jsx
@@ -77,16 +77,17 @@ function preloadImage(src) {
     return preloadPromise;
 }
 
-const TopBarButton = ({ icon, label, variant = 'default', onClick, active, isBack = false, prominence = 'compact' }) => {
-    // Estilos base: "Voltar" recebe tamanho padrão; ações podem ser compactas ou destacadas.
-    const sizeStyles = isBack
-        ? "px-3 py-2 text-xs"
+const TopBarButton = ({ icon, label, variant = 'default', onClick, active, iconOnly = false, prominence = 'compact' }) => {
+    // Ações principais mantêm rótulo; ações de navegação/destrutivas podem ser
+    // icon-only (rótulo vai para aria-label) para a barra caber sem rolagem.
+    const sizeStyles = iconOnly
+        ? "p-2.5 min-w-10 min-h-10 justify-center"
         : prominence === 'large'
             ? "px-3.5 py-2 text-[11px] tracking-wide min-h-9"
-            : "px-2 py-1.5 text-[9px] tracking-tight";
+            : "px-2.5 py-2 text-[10px] tracking-tight min-h-9";
 
     const baseStyles = `flex items-center gap-1 rounded-lg font-bold uppercase transition-all duration-300 border backdrop-blur-md whitespace-nowrap ${sizeStyles}`;
-    const iconSize = isBack ? 16 : prominence === 'large' ? 15 : 13;
+    const iconSize = iconOnly ? 18 : prominence === 'large' ? 15 : 14;
 
     const variants = {
         primary: "bg-cyan-500/10 text-cyan-400 border-cyan-500/50 hover:bg-cyan-500/20",
@@ -99,10 +100,12 @@ const TopBarButton = ({ icon, label, variant = 'default', onClick, active, isBac
     return (
         <button
             onClick={onClick}
+            aria-label={label}
+            title={iconOnly ? label : undefined}
             className={`${baseStyles} ${variants[variant]}`}
         >
             {React.cloneElement(icon, { size: iconSize, strokeWidth: 2.5 })}
-            <span>{label}</span>
+            {!iconOnly && <span>{label}</span>}
         </button>
     );
 };
@@ -110,7 +113,7 @@ const TopBarButton = ({ icon, label, variant = 'default', onClick, active, isBac
 // --- SUBCOMPONENTE: Card de Progresso (Mantido inline por simplicidade ou mover para arquivo separado depois) ---
 function ProgressCard({ completedCount, totalCount }) {
     return (
-        <div className="bg-slate-900/40 backdrop-blur-md rounded-3xl p-5 border border-slate-700/50 mb-6 shadow-xl shadow-black/20">
+        <div className="bg-slate-900/40 backdrop-blur-md rounded-3xl p-4 border border-slate-700/50 mb-4 shadow-xl shadow-black/20">
             <div className="flex items-center justify-between mb-4">
                 <div className="flex items-center gap-2">
                     <div className="w-4 h-4 rounded-full border border-cyan-500/50 flex items-center justify-center bg-cyan-500/10">
@@ -589,7 +592,7 @@ export function WorkoutExecutionPage({ user }) {
             data-focus-mode={focusMode ? 'true' : 'false'}
             className={`min-h-screen bg-[#020617] text-slate-100 p-4 font-sans selection:bg-cyan-500/30 ${focusMode
                 ? 'pb-[calc(1rem+env(safe-area-inset-bottom))]'
-                : 'pb-40'
+                : 'pb-4'
                 }`}
         >
             {/* LOADER DE FINALIZAÇÃO DA SESSÃO */}
@@ -698,25 +701,27 @@ export function WorkoutExecutionPage({ user }) {
                             {/* Left side - Back button */}
                             <TopBarButton
                                 icon={<ArrowLeft />}
-                                label="VOLTAR"
+                                label="Voltar"
                                 variant="primary"
                                 onClick={() => onFinish()}
-                                isBack={true}
+                                iconOnly
                             />
 
                             {/* Right side - Action buttons */}
-                            <div className="flex items-center gap-1 overflow-x-auto no-scrollbar py-1 mask-linear-fade flex-1 justify-end min-w-0 pl-2">
+                            <div className="flex items-center gap-1.5 py-1 flex-1 justify-end min-w-0 pl-2">
                                 <TopBarButton
                                     icon={<Trash2 />}
-                                    label="CANCELAR"
+                                    label="Cancelar treino"
                                     variant="danger"
                                     onClick={handleDiscard}
+                                    iconOnly
                                 />
 
                                 <TopBarButton
                                     icon={<Calculator />}
                                     label="CALC"
                                     active={showGymTools}
+                                    prominence="large"
                                     onClick={() => setShowGymTools(true)}
                                 />
 
@@ -891,10 +896,10 @@ export function WorkoutExecutionPage({ user }) {
                                     className="rounded-[28px] border border-cyan-500/25 bg-cyan-500/[0.04] p-2 pt-3 space-y-4"
                                 >
                                     <div className="flex items-center gap-2 px-3">
-                                        <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-cyan-500/15 border border-cyan-500/40 text-cyan-300 text-[10px] font-bold uppercase tracking-widest">
+                                        <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-cyan-500/15 border border-cyan-500/40 text-cyan-300 text-[10px] font-bold uppercase tracking-widest whitespace-nowrap shrink-0">
                                             <Link2 size={11} /> {groupLabel(segment.indices.length)}
                                         </span>
-                                        <span className="text-[11px] text-slate-500 font-medium">
+                                        <span className="text-[11px] text-slate-500 font-medium leading-tight">
                                             Alterne as séries • descanso ao fim da volta
                                         </span>
                                     </div>
@@ -998,7 +1003,7 @@ export function WorkoutExecutionPage({ user }) {
                         data-testid="workout-finish-footer"
                         className={`w-full ${focusMode
                             ? 'mt-5 pb-[calc(1rem+env(safe-area-inset-bottom))]'
-                            : 'mt-8 pb-[calc(6rem+env(safe-area-inset-bottom))] lg:pb-[calc(2rem+env(safe-area-inset-bottom))]'
+                            : 'mt-6 pb-[calc(1.25rem+env(safe-area-inset-bottom))]'
                             }`}
                     >
                         <div className="max-w-2xl mx-auto flex justify-center">

--- a/src/pages/WorkoutExecutionPage.test.jsx
+++ b/src/pages/WorkoutExecutionPage.test.jsx
@@ -131,7 +131,7 @@ describe('WorkoutExecutionPage', () => {
     it('opens cancel modal and confirms discard', async () => {
         render(<WorkoutExecutionPage user={{ uid: 'u1' }} />);
 
-        fireEvent.click(screen.getByRole('button', { name: 'CANCELAR' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Cancelar treino' }));
         expect(screen.getByText('Cancelar Treino?')).toBeInTheDocument();
 
         const confirmButton = screen.getByRole('button', { name: 'Confirmar' });
@@ -162,18 +162,18 @@ describe('WorkoutExecutionPage', () => {
         expect(await screen.findByText('Compartilhar Resultado', {}, { timeout: 2000 })).toBeInTheDocument();
     });
 
-    it('removes the large bottom reserve in focus mode', () => {
+    it('keeps the bottom padding compact in both modes', () => {
         render(<WorkoutExecutionPage user={{ uid: 'u1' }} />);
 
         const page = screen.getByTestId('workout-execution-page');
         const footer = screen.getByTestId('workout-finish-footer');
         expect(page).toHaveAttribute('data-focus-mode', 'false');
-        expect(page).toHaveClass('pb-40');
+        expect(page).toHaveClass('pb-4');
+        expect(footer.className).not.toContain('6rem');
 
         fireEvent.click(screen.getByRole('button', { name: 'FOCO' }));
 
         expect(page).toHaveAttribute('data-focus-mode', 'true');
-        expect(page).not.toHaveClass('pb-40');
-        expect(footer.className).not.toContain('6rem');
+        expect(page).not.toHaveClass('pb-4');
     });
 });

--- a/src/pages/WorkoutsPage.jsx
+++ b/src/pages/WorkoutsPage.jsx
@@ -301,7 +301,7 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
 
     // --- RENDER ---
     return (
-        <div className="min-h-screen pb-48 pt-2 px-4 lg:px-8 w-full max-w-5xl mx-auto lg:pt-[calc(1.5rem+env(safe-area-inset-top))] lg:pb-32">
+        <div className="min-h-screen pb-8 pt-2 px-4 lg:px-8 w-full max-w-5xl mx-auto lg:pt-[calc(1.5rem+env(safe-area-inset-top))] lg:pb-12">
 
             {/* 1. HEADER & SEARCH */}
             <div className="space-y-6 pt-2 mb-8 lg:space-y-8 lg:pt-6">

--- a/src/theme-light-compat.css
+++ b/src/theme-light-compat.css
@@ -1,0 +1,194 @@
+/**
+ * theme-light-compat.css
+ * GERADO para o tema claro: classes slate com modificador de opacidade
+ * compilam para hex literal (não var()), então precisam de override explícito.
+ * Regenerar se novas classes slate-*/opacidade forem adicionadas ao código.
+ */
+
+:root[data-theme="light"] [class~="bg-slate-400/20"] {
+    background-color: color-mix(in srgb, #475569 20%, transparent);
+}
+
+:root[data-theme="light"] [class~="bg-slate-400/25"] {
+    background-color: color-mix(in srgb, #475569 25%, transparent);
+}
+
+:root[data-theme="light"] [class~="bg-slate-700/10"] {
+    background-color: color-mix(in srgb, #cbd5e1 10%, transparent);
+}
+
+:root[data-theme="light"] [class~="bg-slate-800/20"] {
+    background-color: color-mix(in srgb, #e2e8f0 20%, transparent);
+}
+
+:root[data-theme="light"] [class~="bg-slate-800/40"] {
+    background-color: color-mix(in srgb, #e2e8f0 40%, transparent);
+}
+
+:root[data-theme="light"] [class~="bg-slate-800/50"] {
+    background-color: color-mix(in srgb, #e2e8f0 50%, transparent);
+}
+
+:root[data-theme="light"] [class~="bg-slate-800/60"] {
+    background-color: color-mix(in srgb, #e2e8f0 60%, transparent);
+}
+
+:root[data-theme="light"] [class~="bg-slate-800/70"] {
+    background-color: color-mix(in srgb, #e2e8f0 70%, transparent);
+}
+
+:root[data-theme="light"] [class~="bg-slate-800/80"] {
+    background-color: color-mix(in srgb, #e2e8f0 80%, transparent);
+}
+
+:root[data-theme="light"] [class~="bg-slate-800/90"] {
+    background-color: color-mix(in srgb, #e2e8f0 90%, transparent);
+}
+
+:root[data-theme="light"] [class~="bg-slate-900/20"] {
+    background-color: color-mix(in srgb, #ffffff 20%, transparent);
+}
+
+:root[data-theme="light"] [class~="bg-slate-900/30"] {
+    background-color: color-mix(in srgb, #ffffff 30%, transparent);
+}
+
+:root[data-theme="light"] [class~="bg-slate-900/35"] {
+    background-color: color-mix(in srgb, #ffffff 35%, transparent);
+}
+
+:root[data-theme="light"] [class~="bg-slate-900/40"] {
+    background-color: color-mix(in srgb, #ffffff 40%, transparent);
+}
+
+:root[data-theme="light"] [class~="bg-slate-900/50"] {
+    background-color: color-mix(in srgb, #ffffff 50%, transparent);
+}
+
+:root[data-theme="light"] [class~="bg-slate-900/55"] {
+    background-color: color-mix(in srgb, #ffffff 55%, transparent);
+}
+
+:root[data-theme="light"] [class~="bg-slate-900/60"] {
+    background-color: color-mix(in srgb, #ffffff 60%, transparent);
+}
+
+:root[data-theme="light"] [class~="bg-slate-900/70"] {
+    background-color: color-mix(in srgb, #ffffff 70%, transparent);
+}
+
+:root[data-theme="light"] [class~="bg-slate-900/80"] {
+    background-color: color-mix(in srgb, #ffffff 80%, transparent);
+}
+
+:root[data-theme="light"] [class~="bg-slate-900/95"] {
+    background-color: color-mix(in srgb, #ffffff 95%, transparent);
+}
+
+:root[data-theme="light"] [class~="bg-slate-950/40"] {
+    background-color: color-mix(in srgb, #f8fafc 40%, transparent);
+}
+
+:root[data-theme="light"] [class~="bg-slate-950/45"] {
+    background-color: color-mix(in srgb, #f8fafc 45%, transparent);
+}
+
+:root[data-theme="light"] [class~="bg-slate-950/50"] {
+    background-color: color-mix(in srgb, #f8fafc 50%, transparent);
+}
+
+:root[data-theme="light"] [class~="bg-slate-950/60"] {
+    background-color: color-mix(in srgb, #f8fafc 60%, transparent);
+}
+
+:root[data-theme="light"] [class~="bg-slate-950/80"] {
+    background-color: color-mix(in srgb, #f8fafc 80%, transparent);
+}
+
+:root[data-theme="light"] [class~="border-slate-400/20"] {
+    border-color: color-mix(in srgb, #475569 20%, transparent);
+}
+
+:root[data-theme="light"] [class~="border-slate-400/30"] {
+    border-color: color-mix(in srgb, #475569 30%, transparent);
+}
+
+:root[data-theme="light"] [class~="border-slate-400/35"] {
+    border-color: color-mix(in srgb, #475569 35%, transparent);
+}
+
+:root[data-theme="light"] [class~="border-slate-400/45"] {
+    border-color: color-mix(in srgb, #475569 45%, transparent);
+}
+
+:root[data-theme="light"] [class~="border-slate-400/70"] {
+    border-color: color-mix(in srgb, #475569 70%, transparent);
+}
+
+:root[data-theme="light"] [class~="border-slate-600/40"] {
+    border-color: color-mix(in srgb, #94a3b8 40%, transparent);
+}
+
+:root[data-theme="light"] [class~="border-slate-600/50"] {
+    border-color: color-mix(in srgb, #94a3b8 50%, transparent);
+}
+
+:root[data-theme="light"] [class~="border-slate-700/50"] {
+    border-color: color-mix(in srgb, #cbd5e1 50%, transparent);
+}
+
+:root[data-theme="light"] [class~="border-slate-700/60"] {
+    border-color: color-mix(in srgb, #cbd5e1 60%, transparent);
+}
+
+:root[data-theme="light"] [class~="border-slate-700/70"] {
+    border-color: color-mix(in srgb, #cbd5e1 70%, transparent);
+}
+
+:root[data-theme="light"] [class~="border-slate-800/30"] {
+    border-color: color-mix(in srgb, #e2e8f0 30%, transparent);
+}
+
+:root[data-theme="light"] [class~="border-slate-800/50"] {
+    border-color: color-mix(in srgb, #e2e8f0 50%, transparent);
+}
+
+:root[data-theme="light"] [class~="border-slate-800/60"] {
+    border-color: color-mix(in srgb, #e2e8f0 60%, transparent);
+}
+
+:root[data-theme="light"] [class~="border-slate-800/80"] {
+    border-color: color-mix(in srgb, #e2e8f0 80%, transparent);
+}
+
+:root[data-theme="light"] [class~="border-slate-900/90"] {
+    border-color: color-mix(in srgb, #ffffff 90%, transparent);
+}
+
+:root[data-theme="light"] [class~="from-slate-900/90"] {
+    --tw-gradient-from: color-mix(in srgb, #ffffff 90%, transparent);
+}
+
+:root[data-theme="light"] [class~="text-slate-200/40"] {
+    color: color-mix(in srgb, #1e293b 40%, transparent);
+}
+
+:root[data-theme="light"] [class~="text-slate-200/75"] {
+    color: color-mix(in srgb, #1e293b 75%, transparent);
+}
+
+:root[data-theme="light"] [class~="text-slate-200/80"] {
+    color: color-mix(in srgb, #1e293b 80%, transparent);
+}
+
+:root[data-theme="light"] [class~="text-slate-200/95"] {
+    color: color-mix(in srgb, #1e293b 95%, transparent);
+}
+
+:root[data-theme="light"] [class~="text-slate-400/70"] {
+    color: color-mix(in srgb, #475569 70%, transparent);
+}
+
+:root[data-theme="light"] [class~="to-slate-950/95"] {
+    --tw-gradient-to: color-mix(in srgb, #f8fafc 95%, transparent);
+}

--- a/src/theme-light-compat.css
+++ b/src/theme-light-compat.css
@@ -2,193 +2,207 @@
  * theme-light-compat.css
  * GERADO para o tema claro: classes slate com modificador de opacidade
  * compilam para hex literal (não var()), então precisam de override explícito.
+ * Usa color-mix com var(--color-slate-*) para que .theme-dark-locked possa
+ * re-fixar a paleta escura em subárvores (cards de compartilhamento).
  * Regenerar se novas classes slate-*/opacidade forem adicionadas ao código.
  */
 
 :root[data-theme="light"] [class~="bg-slate-400/20"] {
-    background-color: color-mix(in srgb, #475569 20%, transparent);
+    background-color: color-mix(in srgb, var(--color-slate-400) 20%, transparent);
 }
 
 :root[data-theme="light"] [class~="bg-slate-400/25"] {
-    background-color: color-mix(in srgb, #475569 25%, transparent);
-}
-
-:root[data-theme="light"] [class~="bg-slate-700/10"] {
-    background-color: color-mix(in srgb, #cbd5e1 10%, transparent);
+    background-color: color-mix(in srgb, var(--color-slate-400) 25%, transparent);
 }
 
 :root[data-theme="light"] [class~="bg-slate-800/20"] {
-    background-color: color-mix(in srgb, #e2e8f0 20%, transparent);
+    background-color: color-mix(in srgb, var(--color-slate-800) 20%, transparent);
 }
 
 :root[data-theme="light"] [class~="bg-slate-800/40"] {
-    background-color: color-mix(in srgb, #e2e8f0 40%, transparent);
+    background-color: color-mix(in srgb, var(--color-slate-800) 40%, transparent);
 }
 
 :root[data-theme="light"] [class~="bg-slate-800/50"] {
-    background-color: color-mix(in srgb, #e2e8f0 50%, transparent);
+    background-color: color-mix(in srgb, var(--color-slate-800) 50%, transparent);
 }
 
 :root[data-theme="light"] [class~="bg-slate-800/60"] {
-    background-color: color-mix(in srgb, #e2e8f0 60%, transparent);
+    background-color: color-mix(in srgb, var(--color-slate-800) 60%, transparent);
 }
 
 :root[data-theme="light"] [class~="bg-slate-800/70"] {
-    background-color: color-mix(in srgb, #e2e8f0 70%, transparent);
+    background-color: color-mix(in srgb, var(--color-slate-800) 70%, transparent);
 }
 
 :root[data-theme="light"] [class~="bg-slate-800/80"] {
-    background-color: color-mix(in srgb, #e2e8f0 80%, transparent);
+    background-color: color-mix(in srgb, var(--color-slate-800) 80%, transparent);
 }
 
 :root[data-theme="light"] [class~="bg-slate-800/90"] {
-    background-color: color-mix(in srgb, #e2e8f0 90%, transparent);
+    background-color: color-mix(in srgb, var(--color-slate-800) 90%, transparent);
 }
 
 :root[data-theme="light"] [class~="bg-slate-900/20"] {
-    background-color: color-mix(in srgb, #ffffff 20%, transparent);
+    background-color: color-mix(in srgb, var(--color-slate-900) 20%, transparent);
 }
 
 :root[data-theme="light"] [class~="bg-slate-900/30"] {
-    background-color: color-mix(in srgb, #ffffff 30%, transparent);
+    background-color: color-mix(in srgb, var(--color-slate-900) 30%, transparent);
 }
 
 :root[data-theme="light"] [class~="bg-slate-900/35"] {
-    background-color: color-mix(in srgb, #ffffff 35%, transparent);
+    background-color: color-mix(in srgb, var(--color-slate-900) 35%, transparent);
 }
 
 :root[data-theme="light"] [class~="bg-slate-900/40"] {
-    background-color: color-mix(in srgb, #ffffff 40%, transparent);
+    background-color: color-mix(in srgb, var(--color-slate-900) 40%, transparent);
 }
 
 :root[data-theme="light"] [class~="bg-slate-900/50"] {
-    background-color: color-mix(in srgb, #ffffff 50%, transparent);
+    background-color: color-mix(in srgb, var(--color-slate-900) 50%, transparent);
 }
 
 :root[data-theme="light"] [class~="bg-slate-900/55"] {
-    background-color: color-mix(in srgb, #ffffff 55%, transparent);
+    background-color: color-mix(in srgb, var(--color-slate-900) 55%, transparent);
 }
 
 :root[data-theme="light"] [class~="bg-slate-900/60"] {
-    background-color: color-mix(in srgb, #ffffff 60%, transparent);
+    background-color: color-mix(in srgb, var(--color-slate-900) 60%, transparent);
 }
 
 :root[data-theme="light"] [class~="bg-slate-900/70"] {
-    background-color: color-mix(in srgb, #ffffff 70%, transparent);
+    background-color: color-mix(in srgb, var(--color-slate-900) 70%, transparent);
 }
 
 :root[data-theme="light"] [class~="bg-slate-900/80"] {
-    background-color: color-mix(in srgb, #ffffff 80%, transparent);
+    background-color: color-mix(in srgb, var(--color-slate-900) 80%, transparent);
 }
 
 :root[data-theme="light"] [class~="bg-slate-900/95"] {
-    background-color: color-mix(in srgb, #ffffff 95%, transparent);
+    background-color: color-mix(in srgb, var(--color-slate-900) 95%, transparent);
 }
 
 :root[data-theme="light"] [class~="bg-slate-950/40"] {
-    background-color: color-mix(in srgb, #f8fafc 40%, transparent);
+    background-color: color-mix(in srgb, var(--color-slate-950) 40%, transparent);
 }
 
 :root[data-theme="light"] [class~="bg-slate-950/45"] {
-    background-color: color-mix(in srgb, #f8fafc 45%, transparent);
+    background-color: color-mix(in srgb, var(--color-slate-950) 45%, transparent);
 }
 
 :root[data-theme="light"] [class~="bg-slate-950/50"] {
-    background-color: color-mix(in srgb, #f8fafc 50%, transparent);
+    background-color: color-mix(in srgb, var(--color-slate-950) 50%, transparent);
 }
 
 :root[data-theme="light"] [class~="bg-slate-950/60"] {
-    background-color: color-mix(in srgb, #f8fafc 60%, transparent);
+    background-color: color-mix(in srgb, var(--color-slate-950) 60%, transparent);
 }
 
 :root[data-theme="light"] [class~="bg-slate-950/80"] {
-    background-color: color-mix(in srgb, #f8fafc 80%, transparent);
+    background-color: color-mix(in srgb, var(--color-slate-950) 80%, transparent);
 }
 
 :root[data-theme="light"] [class~="border-slate-400/20"] {
-    border-color: color-mix(in srgb, #475569 20%, transparent);
+    border-color: color-mix(in srgb, var(--color-slate-400) 20%, transparent);
 }
 
 :root[data-theme="light"] [class~="border-slate-400/30"] {
-    border-color: color-mix(in srgb, #475569 30%, transparent);
+    border-color: color-mix(in srgb, var(--color-slate-400) 30%, transparent);
 }
 
 :root[data-theme="light"] [class~="border-slate-400/35"] {
-    border-color: color-mix(in srgb, #475569 35%, transparent);
+    border-color: color-mix(in srgb, var(--color-slate-400) 35%, transparent);
 }
 
 :root[data-theme="light"] [class~="border-slate-400/45"] {
-    border-color: color-mix(in srgb, #475569 45%, transparent);
-}
-
-:root[data-theme="light"] [class~="border-slate-400/70"] {
-    border-color: color-mix(in srgb, #475569 70%, transparent);
+    border-color: color-mix(in srgb, var(--color-slate-400) 45%, transparent);
 }
 
 :root[data-theme="light"] [class~="border-slate-600/40"] {
-    border-color: color-mix(in srgb, #94a3b8 40%, transparent);
+    border-color: color-mix(in srgb, var(--color-slate-600) 40%, transparent);
 }
 
 :root[data-theme="light"] [class~="border-slate-600/50"] {
-    border-color: color-mix(in srgb, #94a3b8 50%, transparent);
+    border-color: color-mix(in srgb, var(--color-slate-600) 50%, transparent);
 }
 
 :root[data-theme="light"] [class~="border-slate-700/50"] {
-    border-color: color-mix(in srgb, #cbd5e1 50%, transparent);
+    border-color: color-mix(in srgb, var(--color-slate-700) 50%, transparent);
 }
 
 :root[data-theme="light"] [class~="border-slate-700/60"] {
-    border-color: color-mix(in srgb, #cbd5e1 60%, transparent);
+    border-color: color-mix(in srgb, var(--color-slate-700) 60%, transparent);
 }
 
 :root[data-theme="light"] [class~="border-slate-700/70"] {
-    border-color: color-mix(in srgb, #cbd5e1 70%, transparent);
+    border-color: color-mix(in srgb, var(--color-slate-700) 70%, transparent);
 }
 
 :root[data-theme="light"] [class~="border-slate-800/30"] {
-    border-color: color-mix(in srgb, #e2e8f0 30%, transparent);
+    border-color: color-mix(in srgb, var(--color-slate-800) 30%, transparent);
 }
 
 :root[data-theme="light"] [class~="border-slate-800/50"] {
-    border-color: color-mix(in srgb, #e2e8f0 50%, transparent);
+    border-color: color-mix(in srgb, var(--color-slate-800) 50%, transparent);
 }
 
 :root[data-theme="light"] [class~="border-slate-800/60"] {
-    border-color: color-mix(in srgb, #e2e8f0 60%, transparent);
+    border-color: color-mix(in srgb, var(--color-slate-800) 60%, transparent);
 }
 
 :root[data-theme="light"] [class~="border-slate-800/80"] {
-    border-color: color-mix(in srgb, #e2e8f0 80%, transparent);
+    border-color: color-mix(in srgb, var(--color-slate-800) 80%, transparent);
 }
 
 :root[data-theme="light"] [class~="border-slate-900/90"] {
-    border-color: color-mix(in srgb, #ffffff 90%, transparent);
+    border-color: color-mix(in srgb, var(--color-slate-900) 90%, transparent);
 }
 
 :root[data-theme="light"] [class~="from-slate-900/90"] {
-    --tw-gradient-from: color-mix(in srgb, #ffffff 90%, transparent);
+    --tw-gradient-from: color-mix(in srgb, var(--color-slate-900) 90%, transparent);
+}
+
+:root[data-theme="light"] [class~="hover:bg-slate-700/10"]:hover {
+    background-color: color-mix(in srgb, var(--color-slate-700) 10%, transparent);
+}
+
+:root[data-theme="light"] [class~="hover:bg-slate-800/40"]:hover {
+    background-color: color-mix(in srgb, var(--color-slate-800) 40%, transparent);
+}
+
+:root[data-theme="light"] [class~="hover:bg-slate-800/50"]:hover {
+    background-color: color-mix(in srgb, var(--color-slate-800) 50%, transparent);
+}
+
+:root[data-theme="light"] [class~="hover:bg-slate-800/80"]:hover {
+    background-color: color-mix(in srgb, var(--color-slate-800) 80%, transparent);
+}
+
+:root[data-theme="light"] [class~="hover:border-slate-400/70"]:hover {
+    border-color: color-mix(in srgb, var(--color-slate-400) 70%, transparent);
 }
 
 :root[data-theme="light"] [class~="text-slate-200/40"] {
-    color: color-mix(in srgb, #1e293b 40%, transparent);
+    color: color-mix(in srgb, var(--color-slate-200) 40%, transparent);
 }
 
 :root[data-theme="light"] [class~="text-slate-200/75"] {
-    color: color-mix(in srgb, #1e293b 75%, transparent);
+    color: color-mix(in srgb, var(--color-slate-200) 75%, transparent);
 }
 
 :root[data-theme="light"] [class~="text-slate-200/80"] {
-    color: color-mix(in srgb, #1e293b 80%, transparent);
+    color: color-mix(in srgb, var(--color-slate-200) 80%, transparent);
 }
 
 :root[data-theme="light"] [class~="text-slate-200/95"] {
-    color: color-mix(in srgb, #1e293b 95%, transparent);
+    color: color-mix(in srgb, var(--color-slate-200) 95%, transparent);
 }
 
 :root[data-theme="light"] [class~="text-slate-400/70"] {
-    color: color-mix(in srgb, #475569 70%, transparent);
+    color: color-mix(in srgb, var(--color-slate-400) 70%, transparent);
 }
 
 :root[data-theme="light"] [class~="to-slate-950/95"] {
-    --tw-gradient-to: color-mix(in srgb, #f8fafc 95%, transparent);
+    --tw-gradient-to: color-mix(in srgb, var(--color-slate-950) 95%, transparent);
 }

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -1,0 +1,43 @@
+/**
+ * theme.js
+ * Tema claro/escuro do Vitalità.
+ * O tema é aplicado via atributo data-theme no <html>; o CSS em index.css
+ * remapeia as variáveis de paleta. Escuro é o padrão (sem atributo).
+ */
+import { safeGetItem, safeSetItem } from './storage';
+
+const THEME_STORAGE_KEY = 'vitalita_theme_v1';
+
+export const THEMES = {
+    dark: 'dark',
+    light: 'light'
+};
+
+export function getStoredTheme() {
+    const stored = safeGetItem(THEME_STORAGE_KEY);
+    return stored === THEMES.light ? THEMES.light : THEMES.dark;
+}
+
+export function applyTheme(theme) {
+    if (typeof document === 'undefined') return;
+    const root = document.documentElement;
+    if (theme === THEMES.light) {
+        root.dataset.theme = THEMES.light;
+    } else {
+        delete root.dataset.theme;
+    }
+}
+
+export function setTheme(theme) {
+    const normalized = theme === THEMES.light ? THEMES.light : THEMES.dark;
+    safeSetItem(THEME_STORAGE_KEY, normalized);
+    applyTheme(normalized);
+    return normalized;
+}
+
+/**
+ * Aplica o tema salvo antes do primeiro render (evita flash do tema errado).
+ */
+export function initTheme() {
+    applyTheme(getStoredTheme());
+}


### PR DESCRIPTION
## Contexto

O squash do PR #25 levou apenas o primeiro commit do branch — o head do PR ficou preso em `6afd48d` e os três commits seguintes (validados nos previews) ficaram fora da main. Este PR recupera-os via cherry-pick:

- `be87264` — sugestão de agrupamento ao selecionar método Bi-set (toast com ação + dica no formulário)
- `01b0122` — modo claro (toggle em Perfil > Aparência), densidade das telas (remoção de padding duplicado) e barra da execução com botões icon-only
- `7c90bbd` — cobertura completa do modo claro (sidebar desktop, nav mobile, gradientes hex, cards de compartilhamento travados no escuro)

## Testes

173 testes, lint e build de produção passando no estado final.

🤖 Generated with [Claude Code](https://claude.com/claude-code)