### PR TITLE
feat: switch deslizante de tema no perfil

### DIFF
--- a/src/components/design-system/ThemeSwitch.jsx
+++ b/src/components/design-system/ThemeSwitch.jsx
@@ -1,0 +1,39 @@
+/**
+ * ThemeSwitch.jsx
+ * Switch deslizante de tema (claro/escuro) no estilo pílula neumórfica:
+ * trilho rebaixado + botão que desliza com o ícone do modo atual.
+ */
+import React from 'react';
+import { Sun, Moon } from 'lucide-react';
+
+export function ThemeSwitch({ isLight, onToggle }) {
+    return (
+        <button
+            type="button"
+            role="switch"
+            aria-checked={isLight}
+            aria-label={isLight ? 'Mudar para o modo escuro' : 'Mudar para o modo claro'}
+            onClick={onToggle}
+            className="relative w-16 h-8 shrink-0 rounded-full border border-slate-700/60 bg-slate-800/80 shadow-[inset_0_2px_6px_rgba(0,0,0,0.3)] transition-colors duration-300 cursor-pointer"
+        >
+            {/* Ícone da extremidade oposta (sugere o outro modo) */}
+            <Moon
+                size={13}
+                className={`absolute left-2 top-1/2 -translate-y-1/2 text-slate-400 transition-opacity duration-300 ${isLight ? 'opacity-50' : 'opacity-0'}`}
+            />
+            <Sun
+                size={13}
+                className={`absolute right-2 top-1/2 -translate-y-1/2 text-slate-400 transition-opacity duration-300 ${isLight ? 'opacity-0' : 'opacity-50'}`}
+            />
+
+            {/* Botão deslizante (branco em ambos os temas, como na referência) */}
+            <span
+                className={`absolute top-[3px] flex h-[26px] w-[26px] items-center justify-center rounded-full bg-[#f8fafc] shadow-[0_2px_6px_rgba(0,0,0,0.35)] transition-all duration-300 ${isLight ? 'left-[calc(100%-29px)]' : 'left-[3px]'}`}
+            >
+                {isLight
+                    ? <Sun size={14} className="text-amber-500" />
+                    : <Moon size={14} className="text-[#334155]" />}
+            </span>
+        </button>
+    );
+}

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -28,6 +28,7 @@ import {
     Moon
 } from 'lucide-react';
 import { getStoredTheme, setTheme, THEMES } from '../utils/theme';
+import { ThemeSwitch } from '../components/design-system/ThemeSwitch';
 import { achievementsCatalog } from '../data/achievementsCatalog';
 import { evaluateAchievements, calculateStats, evaluateHistory } from '../utils/evaluateAchievements';
 import { calculateWeeklyStats } from '../utils/workoutStats';
@@ -332,16 +333,6 @@ export default function ProfilePage({ user, onLogout, onNavigateToHistory, onNav
                 {/* Brilho de Fundo */}
                 <div className="absolute top-0 right-0 w-64 h-64 bg-blue-500/10 rounded-full blur-3xl -translate-y-1/2 translate-x-1/2 pointer-events-none" />
 
-                {/* Alternador de tema (claro/escuro) */}
-                <Button
-                    variant="unstyled"
-                    onClick={() => handleThemeChange(appTheme === THEMES.dark ? THEMES.light : THEMES.dark)}
-                    aria-label={appTheme === THEMES.dark ? 'Mudar para o tema claro' : 'Mudar para o tema escuro'}
-                    title={appTheme === THEMES.dark ? 'Tema claro' : 'Tema escuro'}
-                    className="absolute top-4 right-4 z-20 w-10 h-10 rounded-full bg-slate-800/60 border border-slate-700/60 text-slate-300 hover:text-cyan-400 hover:border-cyan-500/40 flex items-center justify-center transition-colors"
-                >
-                    {appTheme === THEMES.dark ? <Sun size={18} /> : <Moon size={18} />}
-                </Button>
 
 
 
@@ -401,6 +392,22 @@ export default function ProfilePage({ user, onLogout, onNavigateToHistory, onNav
                     >
                         Personal
                     </Button>
+                </div>
+
+                {/* Tema do aplicativo */}
+                <div className="relative z-10 mt-4 flex items-center justify-between rounded-2xl border border-slate-800/60 bg-slate-950/40 px-4 py-3">
+                    <div className="flex items-center gap-2 text-slate-400">
+                        {appTheme === THEMES.light
+                            ? <Sun size={15} className="text-amber-500" />
+                            : <Moon size={15} className="text-cyan-400" />}
+                        <span className="text-xs font-bold uppercase tracking-wider">
+                            {appTheme === THEMES.light ? 'Modo claro' : 'Modo escuro'}
+                        </span>
+                    </div>
+                    <ThemeSwitch
+                        isLight={appTheme === THEMES.light}
+                        onToggle={() => handleThemeChange(appTheme === THEMES.dark ? THEMES.light : THEMES.dark)}
+                    />
                 </div>
 
                 {/* Experience Bar */}


### PR DESCRIPTION
Substitui o ícone solto por um switch pílula (estilo neumórfico da referência) com rótulo em português ("Modo claro"/"Modo escuro"), em linha própria do cabeçalho do perfil — entre as ações e a experiência, sem sobrepor o avatar. Componente novo: ThemeSwitch no design system, com role=switch e aria-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)