### PR TITLE
feat: web push do timer de descanso (tela bloqueada)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ output/pdf/*.pdf
 output/
 *.trace.json
 *.devtoolslog.json
+
+.env*.local

--- a/api/cancel-rest-push.js
+++ b/api/cancel-rest-push.js
@@ -1,0 +1,38 @@
+/**
+ * /api/cancel-rest-push
+ * Cancela uma entrega agendada no QStash (timer pausado, ajustado ou
+ * concluído em primeiro plano). Corpo: { messageId }.
+ */
+const QSTASH_MESSAGES_URL = 'https://qstash.upstash.io/v2/messages/';
+
+export default async function handler(req, res) {
+    if (req.method !== 'POST') {
+        return res.status(405).json({ error: 'method_not_allowed' });
+    }
+
+    const token = process.env.QSTASH_TOKEN;
+    if (!token) {
+        return res.status(503).json({ error: 'push_not_configured' });
+    }
+
+    const { messageId } = req.body ?? {};
+    if (typeof messageId !== 'string' || !/^[\w-]{1,128}$/.test(messageId)) {
+        return res.status(400).json({ error: 'invalid_message_id' });
+    }
+
+    try {
+        const response = await fetch(QSTASH_MESSAGES_URL + encodeURIComponent(messageId), {
+            method: 'DELETE',
+            headers: { Authorization: `Bearer ${token}` }
+        });
+
+        // 404 = já entregue ou já cancelada — nada a fazer.
+        if (!response.ok && response.status !== 404) {
+            return res.status(502).json({ error: 'qstash_cancel_failed' });
+        }
+
+        return res.status(200).json({ ok: true });
+    } catch {
+        return res.status(502).json({ error: 'qstash_unreachable' });
+    }
+}

--- a/api/schedule-rest-push.js
+++ b/api/schedule-rest-push.js
@@ -1,0 +1,68 @@
+/**
+ * /api/schedule-rest-push
+ * Agenda no QStash a entrega do push de fim de descanso.
+ * Corpo: { subscription: PushSubscriptionJSON, delaySeconds: number }
+ * Resposta: { messageId } — usado para cancelar se o timer for pausado/ajustado.
+ */
+const QSTASH_PUBLISH_URL = 'https://qstash.upstash.io/v2/publish/';
+
+const MIN_DELAY_SECONDS = 5;
+const MAX_DELAY_SECONDS = 3600;
+
+function isValidSubscription(subscription) {
+    return Boolean(
+        subscription
+        && typeof subscription.endpoint === 'string'
+        && subscription.endpoint.startsWith('https://')
+        && subscription.keys
+        && typeof subscription.keys.p256dh === 'string'
+        && typeof subscription.keys.auth === 'string'
+    );
+}
+
+export default async function handler(req, res) {
+    if (req.method !== 'POST') {
+        return res.status(405).json({ error: 'method_not_allowed' });
+    }
+
+    const token = process.env.QSTASH_TOKEN;
+    const baseUrl = process.env.VITALITA_BASE_URL;
+    const internalSecret = process.env.PUSH_INTERNAL_SECRET;
+    if (!token || !baseUrl || !internalSecret) {
+        return res.status(503).json({ error: 'push_not_configured' });
+    }
+
+    const { subscription, delaySeconds } = req.body ?? {};
+    const delay = Math.round(Number(delaySeconds));
+
+    if (!isValidSubscription(subscription)) {
+        return res.status(400).json({ error: 'invalid_subscription' });
+    }
+    if (!Number.isFinite(delay) || delay < MIN_DELAY_SECONDS || delay > MAX_DELAY_SECONDS) {
+        return res.status(400).json({ error: 'invalid_delay' });
+    }
+
+    const target = `${baseUrl.replace(/\/+$/, '')}/api/send-rest-push`;
+
+    try {
+        const response = await fetch(QSTASH_PUBLISH_URL + target, {
+            method: 'POST',
+            headers: {
+                Authorization: `Bearer ${token}`,
+                'Content-Type': 'application/json',
+                'Upstash-Delay': `${delay}s`,
+                'Upstash-Retries': '2'
+            },
+            body: JSON.stringify({ subscription, secret: internalSecret })
+        });
+
+        const data = await response.json().catch(() => ({}));
+        if (!response.ok || !data.messageId) {
+            return res.status(502).json({ error: 'qstash_publish_failed' });
+        }
+
+        return res.status(200).json({ messageId: data.messageId });
+    } catch {
+        return res.status(502).json({ error: 'qstash_unreachable' });
+    }
+}

--- a/api/schedule-rest-push.test.js
+++ b/api/schedule-rest-push.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import handler from './schedule-rest-push';
+
+function makeRes() {
+    const res = {
+        statusCode: null,
+        body: null,
+        status(code) {
+            this.statusCode = code;
+            return this;
+        },
+        json(payload) {
+            this.body = payload;
+            return this;
+        }
+    };
+    return res;
+}
+
+const validSubscription = {
+    endpoint: 'https://push.example.com/sub/abc',
+    keys: { p256dh: 'chave', auth: 'auth' }
+};
+
+describe('/api/schedule-rest-push', () => {
+    beforeEach(() => {
+        process.env.QSTASH_TOKEN = 'token-teste';
+        process.env.VITALITA_BASE_URL = 'https://vitalita.vercel.app';
+        process.env.PUSH_INTERNAL_SECRET = 'segredo-teste';
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({ messageId: 'msg_123' })
+        }));
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        delete process.env.QSTASH_TOKEN;
+        delete process.env.VITALITA_BASE_URL;
+        delete process.env.PUSH_INTERNAL_SECRET;
+    });
+
+    it('rejeita métodos diferentes de POST', async () => {
+        const res = makeRes();
+        await handler({ method: 'GET' }, res);
+        expect(res.statusCode).toBe(405);
+    });
+
+    it('responde 503 sem configuração', async () => {
+        delete process.env.QSTASH_TOKEN;
+        const res = makeRes();
+        await handler({ method: 'POST', body: { subscription: validSubscription, delaySeconds: 90 } }, res);
+        expect(res.statusCode).toBe(503);
+    });
+
+    it('rejeita assinatura inválida', async () => {
+        const res = makeRes();
+        await handler({ method: 'POST', body: { subscription: { endpoint: 'http://inseguro' }, delaySeconds: 90 } }, res);
+        expect(res.statusCode).toBe(400);
+        expect(res.body.error).toBe('invalid_subscription');
+    });
+
+    it('rejeita delay fora dos limites', async () => {
+        const res = makeRes();
+        await handler({ method: 'POST', body: { subscription: validSubscription, delaySeconds: 99999 } }, res);
+        expect(res.statusCode).toBe(400);
+        expect(res.body.error).toBe('invalid_delay');
+    });
+
+    it('agenda no QStash com delay, alvo e segredo corretos', async () => {
+        const res = makeRes();
+        await handler({ method: 'POST', body: { subscription: validSubscription, delaySeconds: 92 } }, res);
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body.messageId).toBe('msg_123');
+
+        const [url, options] = fetch.mock.calls[0];
+        expect(url).toBe('https://qstash.upstash.io/v2/publish/https://vitalita.vercel.app/api/send-rest-push');
+        expect(options.headers['Upstash-Delay']).toBe('92s');
+        expect(JSON.parse(options.body)).toEqual({ subscription: validSubscription, secret: 'segredo-teste' });
+    });
+
+    it('responde 502 quando o QStash falha', async () => {
+        fetch.mockResolvedValueOnce({ ok: false, json: async () => ({}) });
+        const res = makeRes();
+        await handler({ method: 'POST', body: { subscription: validSubscription, delaySeconds: 90 } }, res);
+        expect(res.statusCode).toBe(502);
+    });
+});

--- a/api/send-rest-push.js
+++ b/api/send-rest-push.js
@@ -1,0 +1,61 @@
+/**
+ * /api/send-rest-push
+ * Chamado pelo QStash na hora agendada; envia o Web Push da notificação
+ * de descanso concluído. Autenticado pelo segredo interno incluído no corpo
+ * ao agendar (somente /api/schedule-rest-push o conhece).
+ */
+import crypto from 'node:crypto';
+import webpush from 'web-push';
+
+function secretMatches(provided, expected) {
+    if (typeof provided !== 'string' || typeof expected !== 'string') return false;
+    const providedBuffer = Buffer.from(provided);
+    const expectedBuffer = Buffer.from(expected);
+    if (providedBuffer.length !== expectedBuffer.length) return false;
+    return crypto.timingSafeEqual(providedBuffer, expectedBuffer);
+}
+
+export default async function handler(req, res) {
+    if (req.method !== 'POST') {
+        return res.status(405).json({ error: 'method_not_allowed' });
+    }
+
+    const {
+        VAPID_PUBLIC_KEY: publicKey,
+        VAPID_PRIVATE_KEY: privateKey,
+        VAPID_SUBJECT: subject,
+        PUSH_INTERNAL_SECRET: internalSecret
+    } = process.env;
+
+    if (!publicKey || !privateKey || !internalSecret) {
+        return res.status(503).json({ error: 'push_not_configured' });
+    }
+
+    const { subscription, secret } = req.body ?? {};
+    if (!secretMatches(secret, internalSecret)) {
+        return res.status(401).json({ error: 'unauthorized' });
+    }
+    if (!subscription?.endpoint) {
+        return res.status(400).json({ error: 'invalid_subscription' });
+    }
+
+    webpush.setVapidDetails(subject || 'mailto:contato@vitalita.app', publicKey, privateKey);
+
+    const payload = JSON.stringify({
+        title: 'Vitalità',
+        body: 'Descanso concluído. Hora da próxima série! 💪',
+        url: '/'
+    });
+
+    try {
+        await webpush.sendNotification(subscription, payload, { TTL: 120, urgency: 'high' });
+        return res.status(200).json({ ok: true });
+    } catch (err) {
+        // 404/410: assinatura expirou/foi revogada — sucesso do ponto de vista
+        // do QStash (não adianta reentregar).
+        if (err?.statusCode === 404 || err?.statusCode === 410) {
+            return res.status(200).json({ ok: false, expired: true });
+        }
+        return res.status(502).json({ error: 'push_send_failed' });
+    }
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -39,9 +39,15 @@ export default defineConfig([
     },
   },
   {
-    files: ['functions/**/*.js'],
+    files: ['functions/**/*.js', 'api/**/*.js'],
     languageOptions: {
       globals: globals.node,
+    },
+  },
+  {
+    files: ['public/push-sw.js'],
+    languageOptions: {
+      globals: globals.serviceworker,
     },
   },
 ])

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.12.0",
         "recharts": "^3.6.0",
-        "sonner": "^2.0.7"
+        "sonner": "^2.0.7",
+        "web-push": "^3.6.7"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -7055,7 +7056,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -7560,6 +7560,18 @@
         "safer-buffer": "~2.1.0"
       }
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -7978,6 +7990,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "1.20.5",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
@@ -8172,7 +8190,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
@@ -9638,7 +9655,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -9952,7 +9968,6 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -12932,6 +12947,15 @@
       "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
       "license": "MIT"
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -13002,7 +13026,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -13157,7 +13180,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -14358,7 +14380,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
       "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
@@ -14370,7 +14391,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
       "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "jwa": "^2.0.1",
@@ -15616,6 +15636,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -15633,7 +15659,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -15750,7 +15775,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mute-stream": {
@@ -17018,26 +17042,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/proxy-agent-negotiate": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent-negotiate/-/proxy-agent-negotiate-1.1.0.tgz",
-      "integrity": "sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "kerberos": "^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "kerberos": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/proxy-agent/node_modules/lru-cache": {
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
@@ -17143,18 +17147,6 @@
         }
       }
     },
-    "node_modules/puppeteer-core/node_modules/agent-base": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
-      "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20"
-      }
-    },
     "node_modules/puppeteer-core/node_modules/ansi-regex": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
@@ -17196,38 +17188,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/puppeteer-core/node_modules/data-uri-to-buffer": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-8.0.0.tgz",
-      "integrity": "sha512-6UHfyCux51b8PTGDgveqtz1tvphBku5DrMKKJbFAZAJOI2zsjDpDoYE1+QGj7FOMS4BdTFNJsJiR3zEB0xH0yQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/degenerator": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-7.0.1.tgz",
-      "integrity": "sha512-ABErK0IefDSyHjlPH7WUEenIAX2rPPnrDcDM+TS3z3+zu9TfyKKi07BQM+8rmxpdE2y1v5fjjdoAS/x4D2U60w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "ast-types": "^0.13.4",
-        "escodegen": "^2.1.0",
-        "esprima": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "quickjs-wasi": "^2.2.0"
-      }
-    },
     "node_modules/puppeteer-core/node_modules/devtools-protocol": {
       "version": "0.0.1638949",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1638949.tgz",
@@ -17241,161 +17201,6 @@
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/puppeteer-core/node_modules/get-uri": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-8.0.1.tgz",
-      "integrity": "sha512-/5N/P4Lrh0p/mDwlDRi7Y1+P2o/OyzZI3l6Iz1Ov6XXwwm1y3RlZLuo3gVgML99djrEDtV980bBxSuOeHLk8ww==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "basic-ftp": "^5.3.1",
-        "data-uri-to-buffer": "8.0.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/http-proxy-agent": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-9.1.0.tgz",
-      "integrity": "sha512-2NxoveTT58mjYT4n3RPTEfCZGLMbidoO8XEieXfpSYxu+PQJ1qpx4ypwH6N+uF9twBPIvRRgvkvW5HUTYWENig==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "9.0.0",
-        "debug": "^4.3.4",
-        "proxy-agent-negotiate": "1.1.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/https-proxy-agent": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.1.0.tgz",
-      "integrity": "sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "9.0.0",
-        "debug": "^4.3.4",
-        "proxy-agent-negotiate": "1.1.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/pac-proxy-agent": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-9.1.0.tgz",
-      "integrity": "sha512-1aU+1mpj3DrQPfo3gh+3Gap3G5x+axnMx1P/y0ZF2ch7kb2meyOCAH8K2k9d27ROsTE7TnAerzxqF9aon2jqnA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "9.0.0",
-        "debug": "^4.3.4",
-        "get-uri": "8.0.1",
-        "http-proxy-agent": "9.1.0",
-        "https-proxy-agent": "9.1.0",
-        "pac-resolver": "9.0.1",
-        "quickjs-wasi": "^2.2.0",
-        "socks-proxy-agent": "10.1.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/pac-resolver": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-9.0.1.tgz",
-      "integrity": "sha512-lJbS008tmkj08VhoM8Hzuv/VE5tK9MS0OIQ/7+s0lIF+BYhiQWFYzkSpML7lXs9iBu2jfmzBTLzhe9n6BX+dYw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "degenerator": "7.0.1",
-        "netmask": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "quickjs-wasi": "^2.2.0"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/proxy-agent": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-8.0.2.tgz",
-      "integrity": "sha512-idLLRewuemWd7GH/BDJzGiB0dWGfT2SQs3jy6NtZtGWU9uPTTSdeC1/cdbqLwgzhfv027daGFuXX426e2Eg20A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "9.0.0",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "9.1.0",
-        "https-proxy-agent": "9.1.0",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "9.1.0",
-        "proxy-from-env": "^2.0.0",
-        "socks-proxy-agent": "10.1.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/socks-proxy-agent": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-10.1.0.tgz",
-      "integrity": "sha512-WlMj/67cEJ6MDI1OcsnjuYKDNDoyPCCYZ249kuuXPiMDw9F8PXkVaQ7YWu3siTydfQ/4BEZcvGzu+aYvz7dDCQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "9.0.0",
-        "debug": "^4.3.4",
-        "socks": "^2.8.3"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
     },
     "node_modules/puppeteer-core/node_modules/string-width": {
       "version": "7.2.0",
@@ -17493,15 +17298,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/quickjs-wasi": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/quickjs-wasi/-/quickjs-wasi-2.2.0.tgz",
-      "integrity": "sha512-zQxXmQMrEoD3S+jQdYsloq4qAuaxKFHZj6hHqOYGwB2iQZH+q9e/lf5zQPXCKOk0WJuAjzRFbO4KwHIp2D05Iw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/railroad-diagrams": {
       "version": "1.0.0",
@@ -18450,7 +18246,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/saxes": {
@@ -20746,6 +20541,25 @@
       "integrity": "sha512-PQBbTofqV8FtMP65oT9tLPjbN4FSB2dRdNxLM0A9j4bNifVpFhEP/ATXSMMJAqPPWb/pgUOh6B+98yzfNEVbNw==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.12.0",
     "recharts": "^3.6.0",
-    "sonner": "^2.0.7"
+    "sonner": "^2.0.7",
+    "web-push": "^3.6.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/public/push-sw.js
+++ b/public/push-sw.js
@@ -1,0 +1,42 @@
+/**
+ * push-sw.js
+ * Handlers de Web Push injetados no service worker gerado (workbox importScripts).
+ * Recebe o push agendado do fim do descanso e mostra a notificação — funciona
+ * com o app fechado e a tela bloqueada.
+ */
+self.addEventListener('push', (event) => {
+    let data = {};
+    try {
+        data = event.data ? event.data.json() : {};
+    } catch {
+        // Payload não-JSON: usa os textos padrão abaixo.
+    }
+
+    const title = data.title || 'Vitalità';
+    const options = {
+        body: data.body || 'Descanso concluído. Hora da próxima série! 💪',
+        tag: 'vitalita-rest-timer',
+        renotify: true,
+        icon: '/pwa-192x192.png',
+        badge: '/pwa-192x192.png',
+        vibrate: [200, 100, 200, 100, 200],
+        data: { url: data.url || '/' }
+    };
+
+    event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', (event) => {
+    event.notification.close();
+    const targetUrl = event.notification.data?.url || '/';
+
+    event.waitUntil(
+        self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((windowClients) => {
+            const existing = windowClients.find((client) => 'focus' in client);
+            if (existing) {
+                return existing.focus();
+            }
+            return self.clients.openWindow(targetUrl);
+        })
+    );
+});

--- a/src/components/execution/RestTimer.jsx
+++ b/src/components/execution/RestTimer.jsx
@@ -12,6 +12,7 @@ import {
     ensureNotificationPermission,
     notifyRestComplete
 } from '../../utils/restTimerAlerts';
+import { scheduleRestPush, cancelRestPush } from '../../services/restPushService';
 
 export function RestTimer({ initialTime = 90, onComplete, isOpen, onClose, onDurationChange, autoStartTimer, onAutoStartChange }) {
     const [status, setStatus] = useState('idle'); // ocioso, rodando, pausado, completo
@@ -20,6 +21,33 @@ export function RestTimer({ initialTime = 90, onComplete, isOpen, onClose, onDur
     // Refs para temporização precisa
     const endTimeRef = useRef(null);
     const intervalRef = useRef(null);
+
+    // Push agendado no servidor (notifica mesmo com o app fechado/tela bloqueada)
+    const pushMessageIdRef = useRef(null);
+
+    const cancelScheduledPush = () => {
+        if (pushMessageIdRef.current) {
+            cancelRestPush(pushMessageIdRef.current);
+            pushMessageIdRef.current = null;
+        }
+    };
+
+    const scheduleBackgroundPush = (seconds) => {
+        cancelScheduledPush();
+        if (!seconds || seconds < 3) return;
+        // +2s de folga: concluindo em primeiro plano, dá tempo de cancelar
+        // antes da entrega; em segundo plano a notificação chega ~2s depois.
+        scheduleRestPush(seconds + 2).then((messageId) => {
+            pushMessageIdRef.current = messageId;
+        });
+    };
+
+    // Cancela push pendente ao desmontar (troca de página, fim do treino).
+    useEffect(() => () => {
+        if (pushMessageIdRef.current) {
+            cancelRestPush(pushMessageIdRef.current);
+        }
+    }, []);
 
     // Aumentei o raio de 52 para 80
     const radius = 80;
@@ -68,6 +96,9 @@ export function RestTimer({ initialTime = 90, onComplete, isOpen, onClose, onDur
     // Lógica do Cronômetro com Correção de Drift
     useEffect(() => {
         if (status === 'running') {
+            // Agenda o alerta de segundo plano para o fim do descanso.
+            scheduleBackgroundPush(timeLeft);
+
             if (!endTimeRef.current) {
                 endTimeRef.current = Date.now() + (timeLeft * 1000);
             } else {
@@ -99,6 +130,9 @@ export function RestTimer({ initialTime = 90, onComplete, isOpen, onClose, onDur
         } else {
             clearInterval(intervalRef.current);
             endTimeRef.current = null;
+            // Pausado, fechado ou concluído em primeiro plano: o alerta local
+            // já cobre; cancela a entrega em segundo plano.
+            cancelScheduledPush();
         }
 
         return () => clearInterval(intervalRef.current);
@@ -121,6 +155,11 @@ export function RestTimer({ initialTime = 90, onComplete, isOpen, onClose, onDur
         setStatus('running'); // Auto-start
         setTimeLeft(initialTime);
         endTimeRef.current = null; // Will be recalculated in useEffect
+        // Se já estava rodando, o efeito de status não reexecuta: reagenda aqui.
+        if (status === 'running') {
+            endTimeRef.current = Date.now() + (initialTime * 1000);
+            scheduleBackgroundPush(initialTime);
+        }
     };
 
     const adjustTime = (amount) => {
@@ -139,6 +178,11 @@ export function RestTimer({ initialTime = 90, onComplete, isOpen, onClose, onDur
             }
             return newVal;
         });
+
+        // Reagenda o alerta de segundo plano com o novo tempo restante.
+        if (status === 'running') {
+            scheduleBackgroundPush(Math.max(0, timeLeft + amount));
+        }
 
         if (status === 'complete' && timeLeft + amount > 0) {
             setStatus('idle');

--- a/src/services/restPushService.js
+++ b/src/services/restPushService.js
@@ -1,0 +1,79 @@
+/**
+ * restPushService.js
+ * Agenda/cancela o push de fim de descanso via backend (/api + QStash).
+ * Tudo é melhor esforço: sem suporte, sem permissão ou sem backend
+ * (ex.: dev local), as funções retornam null e o timer segue com os
+ * alertas locais de restTimerAlerts.js.
+ *
+ * iOS: push só funciona com o app instalado na tela de início (iOS 16.4+).
+ */
+
+// Chave pública VAPID (par gerado para o projeto; a privada fica só na Vercel).
+const VAPID_PUBLIC_KEY = 'BKWPJhj3txwL6uTei-NeO6IgJYD-9NvRvhvnnhBXgTko8z2xqfr2DXvTfkNhNAc5fDmV0jkFKhyPPyMktslDiRg';
+
+function urlBase64ToUint8Array(base64String) {
+    const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+    const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+    const rawData = atob(base64);
+    return Uint8Array.from(rawData, (char) => char.charCodeAt(0));
+}
+
+export function isPushSupported() {
+    return typeof window !== 'undefined'
+        && 'serviceWorker' in navigator
+        && 'PushManager' in window
+        && 'Notification' in window;
+}
+
+async function getPushSubscription() {
+    const registration = await navigator.serviceWorker.ready;
+    const existing = await registration.pushManager.getSubscription();
+    if (existing) return existing;
+
+    return registration.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC_KEY)
+    });
+}
+
+/**
+ * Agenda o push para daqui a `delaySeconds`. Retorna o messageId (para
+ * cancelamento) ou null quando indisponível.
+ */
+export async function scheduleRestPush(delaySeconds) {
+    if (!isPushSupported() || Notification.permission !== 'granted') return null;
+
+    try {
+        const subscription = await getPushSubscription();
+        const response = await fetch('/api/schedule-rest-push', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                subscription: subscription.toJSON(),
+                delaySeconds: Math.round(delaySeconds)
+            })
+        });
+        if (!response.ok) return null;
+        const data = await response.json().catch(() => null);
+        return data?.messageId || null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Cancela um push agendado. Silencioso: se já foi entregue/cancelado, ok.
+ */
+export async function cancelRestPush(messageId) {
+    if (!messageId) return;
+    try {
+        await fetch('/api/cancel-rest-push', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ messageId }),
+            keepalive: true
+        });
+    } catch {
+        // Melhor esforço.
+    }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -22,7 +22,8 @@ export default defineConfig(({ mode }) => {
     VitePWA({
       registerType: 'prompt',
       workbox: {
-        mode: pwaWorkboxMode
+        mode: pwaWorkboxMode,
+        importScripts: ['push-sw.js']
       },
       devOptions: {
         enabled: mode === 'development'

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -8,7 +8,10 @@ export default defineConfig({
         globals: true,
         environment: 'jsdom',
         setupFiles: './src/test/setup.js',
-        include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+        include: [
+            'src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
+            'api/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts}'
+        ],
     },
     resolve: {
         alias: {


### PR DESCRIPTION
## O que faz

Entrega a notificação de fim de descanso por **Web Push** — funciona com o app fechado e a tela bloqueada, porque quem acorda o aparelho é o serviço de push do sistema, não a página.

## Arquitetura (custo zero)

```
Timer inicia → /api/schedule-rest-push → QStash (Upstash-Delay: Xs)
QStash na hora certa → /api/send-rest-push → web-push (VAPID) → notificação
Pausar/ajustar/concluir em 1º plano → /api/cancel-rest-push
```

- `public/push-sw.js` injetado no SW gerado (workbox `importScripts`) com handlers de `push` e `notificationclick`
- `restPushService` (cliente): assinatura VAPID + agendar/cancelar, tudo melhor-esforço (sem suporte/permissão/backend → alertas locais continuam como antes)
- `send` autenticado por segredo interno incluído no corpo ao agendar; validações de assinatura/delay no `schedule`
- Teste de validação da rota de agendamento (6 casos); ESLint/Vitest configurados para `api/`

## Ativação (necessário antes de funcionar)

Adicionar na Vercel (Production): `QSTASH_TOKEN`, `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_SUBJECT`, `PUSH_INTERNAL_SECRET`, `VITALITA_BASE_URL`. Sem elas, as rotas respondem 503 e o app degrada para o comportamento atual.

## Limitações

- iPhone: push só com o app **instalado na tela de início** (iOS 16.4+).
- Concluir a série em primeiro plano cancela o push; há 2s de folga para o cancelamento chegar antes da entrega.

🤖 Generated with [Claude Code](https://claude.com/claude-code)