### PR TITLE
fix: push do descanso robusto em timers curtos e saída imediata

### DIFF
--- a/src/components/execution/RestTimer.jsx
+++ b/src/components/execution/RestTimer.jsx
@@ -12,7 +12,7 @@ import {
     ensureNotificationPermission,
     notifyRestComplete
 } from '../../utils/restTimerAlerts';
-import { scheduleRestPush, cancelRestPush } from '../../services/restPushService';
+import { scheduleRestPush, cancelRestPush, warmRestPushSubscription } from '../../services/restPushService';
 
 export function RestTimer({ initialTime = 90, onComplete, isOpen, onClose, onDurationChange, autoStartTimer, onAutoStartChange }) {
     const [status, setStatus] = useState('idle'); // ocioso, rodando, pausado, completo
@@ -22,38 +22,76 @@ export function RestTimer({ initialTime = 90, onComplete, isOpen, onClose, onDur
     const endTimeRef = useRef(null);
     const intervalRef = useRef(null);
 
-    // Push agendado no servidor (notifica mesmo com o app fechado/tela bloqueada)
-    const pushMessageIdRef = useRef(null);
-
-    const cancelScheduledPush = () => {
-        if (pushMessageIdRef.current) {
-            cancelRestPush(pushMessageIdRef.current);
-            pushMessageIdRef.current = null;
-        }
-    };
-
     /*
      * Estratégia do push (a prova de suspensão do iOS): o agendamento no
      * servidor acontece SEMPRE com o app ativo — ao iniciar/retomar/ajustar o
      * timer — nunca no evento de ir para segundo plano (o iOS congela o JS
      * antes de o pedido completar). Se o usuário sair do app, o push já está
      * agendado e o sistema entrega na hora certa. Se ficar no app, o push é
-     * cancelado 5s antes do fim (folga confortável), e os alertas locais
+     * cancelado 5s antes do fim (em descansos >= 30s), e os alertas locais
      * cuidam do aviso — sem notificação duplicada.
+     *
+     * A contabilidade inclui pedidos em voo: se um agendamento resolver
+     * depois de um cancelamento (ex.: requisição congelada pelo iOS que
+     * resume ao voltar ao app), ele se cancela na hora — nunca fica órfão.
      */
+    const pushStateRef = useRef({ messageId: null, pending: null, canceled: false });
+    const lastScheduledSecondsRef = useRef(0);
+
+    const cancelScheduledPush = () => {
+        const state = pushStateRef.current;
+        state.canceled = true;
+        if (state.messageId) {
+            cancelRestPush(state.messageId);
+            state.messageId = null;
+        }
+        if (state.pending) {
+            const pending = state.pending;
+            state.pending = null;
+            pending.then((messageId) => {
+                if (messageId) cancelRestPush(messageId);
+            });
+        }
+    };
+
     const scheduleBackgroundPush = (seconds) => {
         cancelScheduledPush();
         if (!seconds || seconds < 3) return;
-        scheduleRestPush(seconds).then((messageId) => {
-            pushMessageIdRef.current = messageId;
+
+        const state = pushStateRef.current;
+        state.canceled = false;
+        lastScheduledSecondsRef.current = seconds;
+
+        const request = scheduleRestPush(seconds);
+        state.pending = request;
+        request.then((messageId) => {
+            if (state.pending === request) {
+                state.pending = null;
+            }
+            if (!messageId) return;
+            if (state.canceled) {
+                cancelRestPush(messageId);
+                return;
+            }
+            state.messageId = messageId;
         });
     };
 
-    // Cancela push pendente ao desmontar (fechar timer, trocar de página).
-    useEffect(() => () => {
-        if (pushMessageIdRef.current) {
-            cancelRestPush(pushMessageIdRef.current);
-        }
+    // Cancela push pendente (inclusive em voo) ao desmontar.
+    useEffect(() => {
+        const state = pushStateRef.current;
+        return () => {
+            state.canceled = true;
+            if (state.messageId) {
+                cancelRestPush(state.messageId);
+                state.messageId = null;
+            }
+            if (state.pending) {
+                state.pending.then((messageId) => {
+                    if (messageId) cancelRestPush(messageId);
+                });
+            }
+        };
     }, []);
 
     // Aumentei o raio de 52 para 80
@@ -77,10 +115,13 @@ export function RestTimer({ initialTime = 90, onComplete, isOpen, onClose, onDur
     // Inicializar e Início Automático
     useEffect(() => {
         if (isOpen) {
-            // Abrir o timer é um gesto do usuário: prepara áudio e permissão de
-            // notificação para alertar mesmo com o app em segundo plano.
+            // Abrir o timer é um gesto do usuário: prepara áudio, permissão de
+            // notificação e a assinatura de push (a primeira pode levar
+            // segundos; aquecida aqui, o agendamento vira uma requisição só).
             primeRestAudio();
-            ensureNotificationPermission().catch(() => undefined);
+            ensureNotificationPermission()
+                .then((granted) => { if (granted) warmRestPushSubscription(); })
+                .catch(() => undefined);
 
             // Only start if explicitly idle (prevents restart on re-renders)
             if (status === 'idle') {
@@ -122,7 +163,11 @@ export function RestTimer({ initialTime = 90, onComplete, isOpen, onClose, onDur
 
                 // Com o app visível, o alerta local cobre o fim: cancela o
                 // push com 5s de antecedência (folga que não perde corrida).
-                if (remaining <= 5 && remaining > 0 && pushMessageIdRef.current
+                // Só em descansos >= 30s — em timers curtos a janela comeria
+                // boa parte do tempo útil de sair do app.
+                if (remaining <= 5 && remaining > 0
+                    && lastScheduledSecondsRef.current >= 30
+                    && (pushStateRef.current.messageId || pushStateRef.current.pending)
                     && document.visibilityState === 'visible') {
                     cancelScheduledPush();
                 }

--- a/src/services/restPushService.js
+++ b/src/services/restPushService.js
@@ -25,15 +25,39 @@ export function isPushSupported() {
         && 'Notification' in window;
 }
 
+// A primeira assinatura envolve registro no serviço de push do sistema e pode
+// levar segundos; o cache permite agendar com uma única requisição depois.
+let cachedSubscription = null;
+
 async function getPushSubscription() {
+    if (cachedSubscription) return cachedSubscription;
+
     const registration = await navigator.serviceWorker.ready;
     const existing = await registration.pushManager.getSubscription();
-    if (existing) return existing;
+    if (existing) {
+        cachedSubscription = existing;
+        return existing;
+    }
 
-    return registration.pushManager.subscribe({
+    cachedSubscription = await registration.pushManager.subscribe({
         userVisibleOnly: true,
         applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC_KEY)
     });
+    return cachedSubscription;
+}
+
+/**
+ * Pré-aquece a assinatura (chamar ao abrir o timer, com o app ativo), para
+ * que o agendamento em si seja uma única requisição rápida.
+ */
+export async function warmRestPushSubscription() {
+    if (!isPushSupported() || Notification.permission !== 'granted') return false;
+    try {
+        await getPushSubscription();
+        return true;
+    } catch {
+        return false;
+    }
 }
 
 /**
@@ -51,7 +75,10 @@ export async function scheduleRestPush(delaySeconds) {
             body: JSON.stringify({
                 subscription: subscription.toJSON(),
                 delaySeconds: Math.round(delaySeconds)
-            })
+            }),
+            // keepalive: o navegador completa o envio mesmo se o app for
+            // suspenso logo depois (usuário bloqueando a tela em seguida).
+            keepalive: true
         });
         if (!response.ok) return null;
         const data = await response.json().catch(() => null);


### PR DESCRIPTION
Teste real no iPhone (timer de 10s) expôs dois defeitos:

1. **Assinatura lenta + saída rápida**: a primeira assinatura de push leva segundos; saindo do app logo após iniciar o timer, o agendamento congelava no meio, resumia ao voltar e agendava atrasado — notificação fantasma ao fechar o timer.
2. **Cancelamento antecipado de 5s** consumia metade de um timer de 10s — sair do app na segunda metade já não notificava.

Correções:
- `warmRestPushSubscription()` ao abrir o timer + cache da assinatura → agendar vira uma única requisição rápida; POST com `keepalive` completa mesmo com suspensão logo em seguida.
- Contabilidade de pedidos em voo no RestTimer: um agendamento que resolver depois de um cancelamento (requisição descongelada) é cancelado imediatamente — órfão impossível.
- Cancelamento antecipado (5s antes do fim, app visível) restrito a descansos ≥ 30s; em timers curtos o push permanece e pode chegar junto do alerta local se o usuário ficar no app (mesma tag, o sistema agrupa).

🤖 Generated with [Claude Code](https://claude.com/claude-code)