### PR TITLE
feat: compactar Conquistas em grade, corrigir marcas duplicadas e uni…

### DIFF
--- a/src/components/profile/AchievementsSection.jsx
+++ b/src/components/profile/AchievementsSection.jsx
@@ -1,136 +1,112 @@
-import { Loader2, Lock, Share2, Trophy } from 'lucide-react';
+import { Loader2, Lock, Trophy } from 'lucide-react';
 import { EmptyState } from '../design-system/EmptyState';
-import { SectionHeader } from '../design-system/SectionHeader';
+import { ProfileSection } from './ProfileSection';
 import { getAchievementTheme } from './achievementTheme';
 
 /**
- * Seção de conquistas: desbloqueadas (com tema por categoria e ação de
- * compartilhar) e bloqueadas (estilo minimalista). O split unlocked/locked
- * é feito aqui a partir da lista completa.
+ * Conquistas em grade de medalhas: compacta o suficiente para exibir o
+ * catálogo inteiro (35+) sem dominar a página — a lista de cards anterior
+ * crescia ~88px por conquista e piorava conforme o usuário evoluía.
+ *
+ * O rótulo é obrigatório: o ícone vem da CATEGORIA (só 4 temas em
+ * `getAchievementTheme`), então uma grade só de ícones repetiria o mesmo
+ * símbolo dezenas de vezes sem diferenciar nada.
  */
-export function AchievementsSection({ achievements, loading, onSelect }) {
-    const unlockedAchievements = achievements.filter(a => a.isUnlocked);
-    const lockedAchievements = achievements.filter(a => !a.isUnlocked);
+
+/** Medalha individual. Desbloqueada usa o tema da categoria; bloqueada fica esmaecida. */
+function AchievementMedal({ achievement, onSelect }) {
+    const isUnlocked = achievement.isUnlocked;
+    const theme = getAchievementTheme(achievement.category);
+    const IconComponent = isUnlocked ? (theme.Icon || Trophy) : Lock;
+
+    const unlockedAt = achievement.unlockedAt
+        ? new Date(achievement.unlockedAt).toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit' })
+        : null;
+
+    const title = isUnlocked
+        ? `${achievement.title}${unlockedAt ? ` — desbloqueada em ${unlockedAt}` : ''}`
+        : `${achievement.title} — ${achievement.description}`;
 
     return (
-        <div className="mb-24">
-            <SectionHeader icon={<Trophy className="text-yellow-500" size={20} />} title="Conquistas" />
+        <button
+            type="button"
+            onClick={() => isUnlocked && onSelect(achievement)}
+            disabled={!isUnlocked}
+            title={title}
+            className={`group flex flex-col items-center gap-1.5 text-center ${isUnlocked ? 'cursor-pointer' : 'cursor-default'}`}
+        >
+            <span
+                className={`
+                    relative flex h-14 w-14 items-center justify-center rounded-2xl border transition-transform duration-300
+                    ${isUnlocked
+                        ? `${theme.bg} ${theme.border} ${theme.text} ${theme.glow} group-hover:scale-110`
+                        : 'border-slate-800 bg-slate-900 text-slate-600'}
+                `}
+            >
+                <IconComponent size={24} strokeWidth={1.5} />
+            </span>
 
+            <span
+                className={`line-clamp-2 text-[10px] font-semibold leading-tight ${isUnlocked ? 'text-slate-300' : 'text-slate-600'}`}
+            >
+                {achievement.title}
+            </span>
+        </button>
+    );
+}
+
+export function AchievementsSection({ achievements, loading, onSelect }) {
+    const unlockedCount = achievements.filter(a => a.isUnlocked).length;
+    const total = achievements.length;
+    const progress = total > 0 ? (unlockedCount / total) * 100 : 0;
+
+    // Desbloqueadas primeiro, preservando a ordem do catálogo dentro de cada grupo.
+    const ordered = [
+        ...achievements.filter(a => a.isUnlocked),
+        ...achievements.filter(a => !a.isUnlocked)
+    ];
+
+    return (
+        <ProfileSection icon={<Trophy className="text-yellow-500" size={20} />} title="Conquistas">
             {loading ? (
-                <div className="text-center py-8">
-                    <Loader2 className="animate-spin mx-auto text-cyan-500 mb-2" size={24} />
+                <div className="py-8 text-center">
+                    <Loader2 className="mx-auto animate-spin text-cyan-500" size={24} />
                 </div>
+            ) : total === 0 ? (
+                <EmptyState
+                    icon={<Trophy size={26} />}
+                    title="Nenhuma conquista desbloqueada"
+                    description="Conclua treinos e mantenha consistência para desbloquear suas primeiras conquistas."
+                />
             ) : (
                 <>
-                    {/* DESBLOQUEADAS */}
-                    <div className="grid gap-3">
-                        {unlockedAchievements.length === 0 && (
-                            <EmptyState
-                                icon={<Trophy size={26} />}
-                                title="Nenhuma conquista desbloqueada"
-                                description="Conclua treinos e mantenha consistência para desbloquear suas primeiras conquistas."
+                    {/* Progresso — espelha a barra de XP do cabeçalho do perfil. */}
+                    <div className="mb-5">
+                        <div className="mb-1.5 flex items-baseline justify-between">
+                            <span className="text-xs font-medium text-slate-500">
+                                <span className="font-bold text-white">{unlockedCount}</span> de {total} conquistas
+                            </span>
+                            <span className="text-xs font-bold text-yellow-500">{Math.round(progress)}%</span>
+                        </div>
+                        <div className="h-2 w-full overflow-hidden rounded-full bg-slate-800">
+                            <div
+                                className="h-full rounded-full bg-yellow-500 shadow-[0_0_10px_rgba(234,179,8,0.5)] transition-all duration-1000"
+                                style={{ width: `${progress}%` }}
                             />
-                        )}
-                        {unlockedAchievements.map(achievement => {
-                            // Cor + ícone dinâmicos baseados na categoria.
-                            const theme = getAchievementTheme(achievement.category);
-                            const IconComponent = theme.Icon || Trophy;
-
-                            return (
-                                <div
-                                    key={achievement.id}
-                                    onClick={() => onSelect(achievement)}
-                                    className={`
-                                        relative flex items-center gap-5 p-5 rounded-[24px]
-                                        bg-[#0f172a] border border-[#1e293b]
-                                        hover:border-opacity-50 hover:bg-[#1e293b]
-                                        transition-all duration-300 cursor-pointer active:scale-[0.98]
-                                        group overflow-hidden
-                                    `}
-                                >
-                                    {/* Background Glow Effect on Hover */}
-                                    <div className={`absolute inset-0 bg-gradient-to-r ${theme.gradient} opacity-0 group-hover:opacity-100 transition-opacity duration-500`} />
-
-                                    {/* Share Icon Hint */}
-                                    <div className="absolute top-4 right-4 text-[#64748b] opacity-0 group-hover:opacity-100 transition-opacity -translate-y-1 group-hover:translate-y-0 duration-300">
-                                        <Share2 size={16} />
-                                    </div>
-
-                                    {/* Ícone */}
-                                    <div className={`
-                                        relative w-14 h-14 rounded-2xl flex items-center justify-center
-                                        ${theme.bg} ${theme.border} border
-                                        ${theme.text} ${theme.glow}
-                                        shrink-0 group-hover:scale-110 transition-transform duration-300
-                                    `}>
-                                        {/* Inner Glow */}
-                                        <div className={`absolute inset-0 rounded-2xl opacity-20 bg-current blur-md`} />
-                                        <IconComponent size={28} strokeWidth={1.5} className="relative z-10 drop-shadow-sm" />
-                                    </div>
-
-                                    {/* Conteúdo */}
-                                    <div className="flex-1 min-w-0 relative z-10 ">
-                                        <h4 className="text-lg font-bold text-white mb-1 tracking-tight truncate pr-6">
-                                            {achievement.title}
-                                        </h4>
-
-                                        <div className="flex items-center gap-2">
-                                            <p className="text-[#94a3b8] text-xs font-medium leading-relaxed truncate">
-                                                {achievement.description}
-                                            </p>
-
-                                            <span className="w-1 h-1 rounded-full bg-[#334155] shrink-0" />
-
-                                            <div className={`inline-flex items-center gap-1 shrink-0 ${theme.bg} px-1.5 py-0.5 rounded-md border ${theme.border} border-opacity-50`}>
-                                                <Trophy size={9} className={theme.text} />
-                                                <span className={`${theme.text} text-[9px] font-bold uppercase tracking-wider`}>
-                                                    Desbloqueada em {achievement.unlockedAt
-                                                        ? new Date(achievement.unlockedAt).toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit' })
-                                                        : 'Hoje'}
-                                                </span>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            );
-                        })}
+                        </div>
                     </div>
 
-                    {/* BLOQUEADAS - Estilo Minimalista */}
-                    {lockedAchievements.length > 0 && (
-                        <div className="mt-8 pt-8 border-t border-[#1e293b]">
-                            <div className="flex items-center gap-3 mb-6 opacity-60">
-                                <Lock size={16} className="text-[#64748b]" />
-                                <h4 className="text-xs font-black text-[#64748b] uppercase tracking-widest">
-                                    Bloqueadas ({lockedAchievements.length})
-                                </h4>
-                            </div>
-
-                            <div className="grid gap-3 opacity-50 hover:opacity-100 transition-opacity duration-500">
-                                {lockedAchievements.slice(0, 3).map(achievement => (
-                                    <div
-                                        key={achievement.id}
-                                        className="flex items-center gap-4 p-4 rounded-2xl bg-[#0f172a] border border-[#1e293b] grayscale"
-                                    >
-                                        <div className="w-12 h-12 rounded-2xl bg-[#1e293b] flex items-center justify-center text-[#475569] shrink-0">
-                                            <Lock size={20} />
-                                        </div>
-                                        <div className="min-w-0">
-                                            <h4 className="text-sm font-bold text-[#94a3b8] truncate">{achievement.title}</h4>
-                                            <p className="text-xs text-[#64748b] truncate">{achievement.description}</p>
-                                        </div>
-                                    </div>
-                                ))}
-                                {lockedAchievements.length > 3 && (
-                                    <p className="text-center text-[10px] text-[#475569] font-medium uppercase tracking-widest mt-2">
-                                        + {lockedAchievements.length - 3} conquistas ocultas
-                                    </p>
-                                )}
-                            </div>
-                        </div>
-                    )}
+                    <div className="grid grid-cols-4 gap-x-2 gap-y-4 sm:grid-cols-6">
+                        {ordered.map(achievement => (
+                            <AchievementMedal
+                                key={achievement.id}
+                                achievement={achievement}
+                                onSelect={onSelect}
+                            />
+                        ))}
+                    </div>
                 </>
             )}
-        </div>
+        </ProfileSection>
     );
 }

--- a/src/components/profile/BestMarksCard.jsx
+++ b/src/components/profile/BestMarksCard.jsx
@@ -1,58 +1,63 @@
 import { Trophy } from 'lucide-react';
-import { SectionHeader } from '../design-system/SectionHeader';
+import { ProfileSection } from './ProfileSection';
+import { aggregateExerciseMaxes } from '../../utils/exerciseName';
+
+const TOP_MARKS = 4;
+
+/** "LEG PRESS 45°" -> "Leg Press 45°" */
+function formatExerciseName(name) {
+    return name
+        .split(' ')
+        .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+        .join(' ');
+}
 
 /**
  * Melhores marcas (TOP 4 dos máximos por exercício), preenchendo com
  * placeholders quando há menos de 4 registros.
+ *
+ * Os máximos são agregados por nome normalizado: como `exerciseMaxes` é
+ * indexado pelo nome cru, grafias diferentes do mesmo exercício ("Leg Press
+ * 45°" e "leg press 45") ocupavam duas vagas do top 4 com a mesma marca.
  */
 export function BestMarksCard({ stats }) {
+    const topMarks = aggregateExerciseMaxes(stats?.exerciseMaxes)
+        .sort((a, b) => b.weight - a.weight)
+        .slice(0, TOP_MARKS);
+
+    const slots = [
+        ...topMarks,
+        ...Array(Math.max(0, TOP_MARKS - topMarks.length)).fill(null)
+    ];
+
     return (
-        <div className="bg-slate-900/50 border border-slate-800 rounded-3xl p-6 mt-6">
-            <SectionHeader icon={<Trophy size={18} className="text-amber-500" />} title="Melhores Marcas" />
-
+        <ProfileSection icon={<Trophy size={18} className="text-amber-500" />} title="Melhores Marcas">
             <div className="grid grid-cols-2 gap-3">
-                {(() => {
-                    // 1. Obter todos os máximos
-                    const allMaxes = stats?.exerciseMaxes ? Object.entries(stats.exerciseMaxes) : [];
-                    // 2. Ordenar por peso desc
-                    const sortedMaxes = allMaxes.sort(([, weightA], [, weightB]) => weightB - weightA);
-                    // 3. Pegar top 4
-                    const top4 = sortedMaxes.slice(0, 4);
-
-                    // 4. Preencher com placeholders se menos que 4
-                    const displayItems = [...top4];
-                    while (displayItems.length < 4) {
-                        displayItems.push(null);
-                    }
-
-                    return displayItems.map((item, index) => {
-                        if (!item) {
-                            // Placeholder
-                            return (
-                                <div key={`placeholder-${index}`}>
-                                    <p className="text-sm text-slate-500 mb-1">--</p>
-                                    <div className="flex items-baseline gap-1">
-                                        <span className="text-xl font-bold text-slate-700">--</span>
-                                    </div>
-                                </div>
-                            );
-                        }
-
-                        const [name, weight] = item;
-                        const displayName = name.split(' ').map(w => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase()).join(' ');
-
+                {slots.map((item, index) => {
+                    if (!item) {
                         return (
-                            <div key={name}>
-                                <p className="text-sm text-slate-500 mb-1 truncate" title={displayName}>{displayName}</p>
+                            <div key={`placeholder-${index}`}>
+                                <p className="text-sm text-slate-500 mb-1">--</p>
                                 <div className="flex items-baseline gap-1">
-                                    <span className="text-xl font-bold text-white">{weight}</span>
-                                    <span className="text-xs text-slate-500">kg</span>
+                                    <span className="text-xl font-bold text-slate-700">--</span>
                                 </div>
                             </div>
                         );
-                    });
-                })()}
+                    }
+
+                    const displayName = formatExerciseName(item.name);
+
+                    return (
+                        <div key={item.name}>
+                            <p className="text-sm text-slate-500 mb-1 truncate" title={displayName}>{displayName}</p>
+                            <div className="flex items-baseline gap-1">
+                                <span className="text-xl font-bold text-white">{item.weight}</span>
+                                <span className="text-xs text-slate-500">kg</span>
+                            </div>
+                        </div>
+                    );
+                })}
             </div>
-        </div>
+        </ProfileSection>
     );
 }

--- a/src/components/profile/BodyStatsCard.jsx
+++ b/src/components/profile/BodyStatsCard.jsx
@@ -1,5 +1,5 @@
 import { Activity } from 'lucide-react';
-import { SectionHeader } from '../design-system/SectionHeader';
+import { ProfileSection } from './ProfileSection';
 
 /**
  * Dados corporais: peso, altura, idade e IMC.
@@ -7,49 +7,45 @@ import { SectionHeader } from '../design-system/SectionHeader';
  */
 export function BodyStatsCard({ profile, bmi }) {
     return (
-        <div className="mb-6">
-            <div className="bg-slate-900/50 border border-slate-800 rounded-3xl p-5 relative overflow-hidden">
-                <SectionHeader icon={<Activity size={18} />} title="Dados Corporais" />
-
-                <div className="grid grid-cols-2 gap-x-6 gap-y-4 px-2">
-                    {/* Weight */}
-                    <div className="flex items-center gap-6">
-                        <p className="text-xs font-bold text-slate-500 uppercase tracking-wider min-w-[60px]">Peso</p>
-                        <div className="flex items-baseline gap-1">
-                            <span className="text-lg font-bold text-white">{profile.weight || '--'}</span>
-                            <span className="text-[10px] text-slate-500 font-bold">kg</span>
-                        </div>
+        <ProfileSection icon={<Activity size={18} />} title="Dados Corporais">
+            <div className="grid grid-cols-2 gap-x-6 gap-y-4 px-2">
+                {/* Weight */}
+                <div className="flex items-center gap-6">
+                    <p className="text-xs font-bold text-slate-500 uppercase tracking-wider min-w-[60px]">Peso</p>
+                    <div className="flex items-baseline gap-1">
+                        <span className="text-lg font-bold text-white">{profile.weight || '--'}</span>
+                        <span className="text-[10px] text-slate-500 font-bold">kg</span>
                     </div>
+                </div>
 
-                    {/* Height */}
-                    <div className="flex items-center gap-6">
-                        <p className="text-xs font-bold text-slate-500 uppercase tracking-wider min-w-[60px]">Altura</p>
-                        <div className="flex items-baseline gap-1">
-                            <span className="text-lg font-bold text-white">{profile.height || '--'}</span>
-                            <span className="text-[10px] text-slate-500 font-bold">cm</span>
-                        </div>
+                {/* Height */}
+                <div className="flex items-center gap-6">
+                    <p className="text-xs font-bold text-slate-500 uppercase tracking-wider min-w-[60px]">Altura</p>
+                    <div className="flex items-baseline gap-1">
+                        <span className="text-lg font-bold text-white">{profile.height || '--'}</span>
+                        <span className="text-[10px] text-slate-500 font-bold">cm</span>
                     </div>
+                </div>
 
-                    {/* Age */}
-                    <div className="flex items-center gap-6">
-                        <p className="text-xs font-bold text-slate-500 uppercase tracking-wider min-w-[60px]">Idade</p>
-                        <div className="flex items-baseline gap-1">
-                            <span className="text-lg font-bold text-white">{profile.age || '--'}</span>
-                            <span className="text-[10px] text-slate-500 font-bold">anos</span>
-                        </div>
+                {/* Age */}
+                <div className="flex items-center gap-6">
+                    <p className="text-xs font-bold text-slate-500 uppercase tracking-wider min-w-[60px]">Idade</p>
+                    <div className="flex items-baseline gap-1">
+                        <span className="text-lg font-bold text-white">{profile.age || '--'}</span>
+                        <span className="text-[10px] text-slate-500 font-bold">anos</span>
                     </div>
+                </div>
 
-                    {/* BMI */}
-                    <div className="flex items-center gap-6">
-                        <p className="text-xs font-bold text-slate-500 uppercase tracking-wider min-w-[60px]">IMC</p>
-                        <div className="flex items-baseline gap-1">
-                            <span className={`text-lg font-bold ${bmi ? 'text-white' : 'text-slate-600'}`}>
-                                {bmi || '--'}
-                            </span>
-                        </div>
+                {/* BMI */}
+                <div className="flex items-center gap-6">
+                    <p className="text-xs font-bold text-slate-500 uppercase tracking-wider min-w-[60px]">IMC</p>
+                    <div className="flex items-baseline gap-1">
+                        <span className={`text-lg font-bold ${bmi ? 'text-white' : 'text-slate-600'}`}>
+                            {bmi || '--'}
+                        </span>
                     </div>
                 </div>
             </div>
-        </div>
+        </ProfileSection>
     );
 }

--- a/src/components/profile/PrivacyTermsCard.jsx
+++ b/src/components/profile/PrivacyTermsCard.jsx
@@ -9,7 +9,7 @@ import { PRIVACY_POLICY_VERSION, TERMS_OF_USE_VERSION } from '../../constants/le
  */
 export function PrivacyTermsCard({ hasPrivacyConsent, privacyConsent, exportingData, onExportData }) {
     return (
-        <div className="mb-6 rounded-3xl border border-slate-800 bg-slate-900/50 p-5">
+        <div className="rounded-3xl border border-slate-800 bg-slate-900/50 p-5">
             <SectionHeader icon={<ShieldCheck size={18} className="text-cyan-300" />} title="Privacidade e termos" />
             <p className="mb-4 text-sm leading-relaxed text-slate-400">
                 {hasPrivacyConsent

--- a/src/components/profile/ProfileHeaderCard.jsx
+++ b/src/components/profile/ProfileHeaderCard.jsx
@@ -21,7 +21,7 @@ export function ProfileHeaderCard({
     onToggleTheme
 }) {
     return (
-        <div className="bg-slate-900/50 rounded-3xl p-5 sm:p-6 mb-6 border border-slate-800 relative overflow-hidden">
+        <div className="bg-slate-900/50 rounded-3xl p-5 sm:p-6 border border-slate-800 relative overflow-hidden">
             {/* Brilho de Fundo */}
             <div className="absolute top-0 right-0 w-64 h-64 bg-blue-500/10 rounded-full blur-3xl -translate-y-1/2 translate-x-1/2 pointer-events-none" />
 

--- a/src/components/profile/ProfileSection.jsx
+++ b/src/components/profile/ProfileSection.jsx
@@ -1,0 +1,15 @@
+import { SectionHeader } from '../design-system/SectionHeader';
+
+/**
+ * Contêiner padrão das seções do perfil — mesma superfície, raio e padding em
+ * todas. O espaçamento ENTRE seções fica no container da página (`space-y-6`),
+ * para não espalhar margens conflitantes pelos componentes.
+ */
+export function ProfileSection({ icon, title, action, children, className = '' }) {
+    return (
+        <section className={`rounded-3xl border border-slate-800 bg-slate-900/50 p-5 ${className}`}>
+            {title && <SectionHeader icon={icon} title={title} action={action} />}
+            {children}
+        </section>
+    );
+}

--- a/src/components/profile/StatsGrid.jsx
+++ b/src/components/profile/StatsGrid.jsx
@@ -6,7 +6,7 @@ import { Activity, BicepsFlexed, Dumbbell, Trophy } from 'lucide-react';
  */
 export function StatsGrid({ stats, onNavigateToHistory }) {
     return (
-        <div className="grid grid-cols-2 gap-4 mb-6 mt-6">
+        <div className="grid grid-cols-2 gap-4">
             {/* Treinos (Clickable) */}
             <button
                 onClick={onNavigateToHistory}

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -142,6 +142,10 @@ export default function ProfilePage({ user, onLogout, onNavigateToHistory, onNav
     return (
         <div className="min-h-screen bg-slate-950 pb-8 px-4 pt-2 w-full max-w-3xl mx-auto lg:pb-12 lg:pt-6">
 
+            {/* Espaçamento único entre as seções — os componentes não carregam
+                margens próprias, para o ritmo ficar consistente. */}
+            <div className="space-y-6">
+
             {/* --- CARTÃO DE CABEÇALHO DO PERFIL --- */}
             <ProfileHeaderCard
                 profile={profile}
@@ -162,7 +166,7 @@ export default function ProfilePage({ user, onLogout, onNavigateToHistory, onNav
                         variant="outline-primary"
                         size="sm"
                         onClick={onNavigateToTrainer}
-                        className="mb-6 w-full rounded-xl lg:hidden"
+                        className="w-full rounded-xl lg:hidden"
                         leftIcon={<Users size={14} />}
                     >
                         Área do Personal
@@ -193,6 +197,8 @@ export default function ProfilePage({ user, onLogout, onNavigateToHistory, onNav
                 exportingData={exportingData}
                 onExportData={handleExportData}
             />
+
+            </div>
 
             {/* ACHIEVEMENT SHARE MODAL */}
             {selectedAchievement && (

--- a/src/utils/exerciseName.js
+++ b/src/utils/exerciseName.js
@@ -1,0 +1,57 @@
+/**
+ * exerciseName.js
+ * Normalização de nomes de exercício.
+ *
+ * `exerciseMaxes` é indexado pelo nome cru digitado/gravado, sem normalizar
+ * (ver functions/src/userStatsCalculator.js e utils/evaluateAchievements.js).
+ * Variações de grafia do mesmo exercício ("Leg Press 45°", "leg press 45")
+ * viram chaves distintas e apareciam duplicadas nas Melhores Marcas — ocupando
+ * duas vagas do top 4 com a mesma marca.
+ */
+
+// Marcas de acento combinantes, expostas pelo normalize('NFD').
+const COMBINING_MARKS = new RegExp('[\\u0300-\\u036f]', 'g');
+
+/**
+ * Chave canônica de um exercício: sem acento, minúscula e sem pontuação
+ * (inclusive os símbolos de grau ° e º), com espaços colapsados.
+ */
+export function normalizeExerciseName(name) {
+    if (typeof name !== 'string') return '';
+    return name
+        .normalize('NFD')
+        .replace(COMBINING_MARKS, '')
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, ' ') // °, º, hífens e pontuação viram espaço
+        .trim();
+}
+
+/**
+ * Agrupa `exerciseMaxes` ({ nome: peso }) por nome normalizado, mantendo o
+ * maior peso de cada exercício. Retorna `[{ name, weight }]` — `name` é o
+ * rótulo mais completo encontrado (o mais longo costuma trazer acento/grau,
+ * ex.: "Leg Press 45°" em vez de "leg press 45").
+ */
+export function aggregateExerciseMaxes(exerciseMaxes) {
+    if (!exerciseMaxes || typeof exerciseMaxes !== 'object') return [];
+
+    const byKey = new Map();
+
+    for (const [rawName, rawWeight] of Object.entries(exerciseMaxes)) {
+        const key = normalizeExerciseName(rawName);
+        if (!key) continue;
+
+        const weight = Number(rawWeight) || 0;
+        const current = byKey.get(key);
+
+        if (!current) {
+            byKey.set(key, { name: rawName, weight });
+            continue;
+        }
+
+        if (weight > current.weight) current.weight = weight;
+        if (rawName.length > current.name.length) current.name = rawName;
+    }
+
+    return [...byKey.values()];
+}

--- a/src/utils/exerciseName.test.js
+++ b/src/utils/exerciseName.test.js
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeExerciseName, aggregateExerciseMaxes } from './exerciseName';
+
+describe('normalizeExerciseName', () => {
+    it('ignora caixa, acentos e o símbolo de grau', () => {
+        expect(normalizeExerciseName('Leg Press 45°')).toBe('leg press 45');
+        expect(normalizeExerciseName('leg press 45')).toBe('leg press 45');
+        expect(normalizeExerciseName('LEG PRESS 45º')).toBe('leg press 45');
+        expect(normalizeExerciseName('Agachamento Búlgaro')).toBe('agachamento bulgaro');
+    });
+
+    it('colapsa espaços e pontuação', () => {
+        expect(normalizeExerciseName('  Supino   Reto  ')).toBe('supino reto');
+        expect(normalizeExerciseName('Puxada-Alta')).toBe('puxada alta');
+    });
+
+    it('lida com entrada inválida', () => {
+        expect(normalizeExerciseName(null)).toBe('');
+        expect(normalizeExerciseName(undefined)).toBe('');
+        expect(normalizeExerciseName(42)).toBe('');
+    });
+});
+
+describe('aggregateExerciseMaxes', () => {
+    it('funde grafias diferentes do mesmo exercício mantendo o maior peso', () => {
+        const result = aggregateExerciseMaxes({
+            'Leg Press 45°': 130,
+            'leg press 45': 120
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result[0].weight).toBe(130);
+        // Mantém o rótulo mais completo (com o símbolo de grau).
+        expect(result[0].name).toBe('Leg Press 45°');
+    });
+
+    it('mantém o maior peso mesmo quando vem na segunda grafia', () => {
+        const result = aggregateExerciseMaxes({
+            'leg press 45': 150,
+            'Leg Press 45°': 130
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result[0].weight).toBe(150);
+    });
+
+    it('preserva exercícios distintos', () => {
+        const result = aggregateExerciseMaxes({
+            'Leg Press 45°': 130,
+            'Agachamento Smith': 110,
+            'Agachamento No Hack': 100
+        });
+
+        expect(result).toHaveLength(3);
+        expect(result.map(r => r.weight).sort((a, b) => b - a)).toEqual([130, 110, 100]);
+    });
+
+    it('ignora entradas vazias ou inválidas', () => {
+        expect(aggregateExerciseMaxes(null)).toEqual([]);
+        expect(aggregateExerciseMaxes({})).toEqual([]);
+        expect(aggregateExerciseMaxes({ '   ': 100 })).toEqual([]);
+    });
+});


### PR DESCRIPTION
…ficar o perfil

A página de Perfil era dominada pelas Conquistas: cada uma era um card full-width de ~88px, somando ~2.100px de rolagem e exibindo só 24 das 35 — e piorava conforme o usuário evoluía.

- Conquistas viram grade de medalhas (4 col) com barra de progresso "X de 35": ~1.030px exibindo TODAS as 35. O rótulo é obrigatório porque o ícone vem da categoria (só 4 temas), então uma grade só de ícones não diferenciaria nada. Toque segue abrindo o AchievementUnlockedModal já existente.
- Melhores Marcas: exerciseMaxes é indexado pelo nome cru, então grafias diferentes do mesmo exercício ("Leg Press 45°" e "leg press 45") ocupavam duas vagas do top 4 com a mesma marca. Novo util exerciseName.js agrega por nome normalizado mantendo o maior peso (+ testes). Correção na exibição: a origem exigiria recalcular prsCount e os user_stats já gravados.
- Ritmo visual: novo ProfileSection padroniza superfície/raio/padding, e o espaçamento sai dos componentes para um space-y-6 na página.

## O que foi alterado

## Como foi testado

## Impacto em segurança

## Impacto em Firestore/rules/indexes

## Impacto visual

## Checklist

- [ ] Rodei `npm run lint`
- [ ] Rodei `npm test -- --run`
- [ ] Rodei `npm run test:rules`
- [ ] Rodei `npm run build`
- [ ] Revisei regras do Firestore, se aplicável
- [ ] Atualizei documentação, se aplicável
