### PR TITLE
Fix/normalizar nome exercicio nas stats

### DIFF
--- a/functions/scripts/backfillUserStats.js
+++ b/functions/scripts/backfillUserStats.js
@@ -1,7 +1,7 @@
 import { pathToFileURL } from "node:url";
 import { initializeApp, applicationDefault } from "firebase-admin/app";
 import { FieldPath, FieldValue, getFirestore } from "firebase-admin/firestore";
-import { buildUserStatsFromSessions } from "../src/userStatsCalculator.js";
+import { buildUserStatsFromSessions, mergeUnlockedAchievements } from "../src/userStatsCalculator.js";
 
 const DEFAULT_BATCH_SIZE = 50;
 const DEFAULT_MAX_SESSIONS = 2000;
@@ -156,8 +156,11 @@ async function processUser(db, userId, options, summary, log, startedAt, userDat
             return;
         }
 
+        const previousStats = (await db.doc(`user_stats/${userId}`).get()).data();
+
         await db.doc(`user_stats/${userId}`).set({
             ...stats,
+            achievements: mergeUnlockedAchievements(previousStats?.achievements, stats.achievements),
             source: "backfill_script",
             backfillLimit: options.maxSessions,
             backfillTruncated: sessionsSnap.size >= options.maxSessions,

--- a/functions/scripts/backfillUserStats.js
+++ b/functions/scripts/backfillUserStats.js
@@ -151,12 +151,14 @@ async function processUser(db, userId, options, summary, log, startedAt, userDat
 
         summary.processedUsers += 1;
 
+        const previousStats = (await db.doc(`user_stats/${userId}`).get()).data();
+
         if (!options.write) {
-            log.info(`[dry-run] ${userId}: ${stats.totalWorkouts} treinos, ${stats.totalTonnageKg}kg volume`);
+            log.info(`[dry-run] ${userId}: ${stats.totalWorkouts} treinos, ${stats.totalTonnageKg}kg volume`
+                + `, PRs ${formatDelta(previousStats?.prsCount, stats.prsCount)}`
+                + `, exercicios ${formatDelta(previousStats?.distinctExercises, stats.distinctExercises)}`);
             return;
         }
-
-        const previousStats = (await db.doc(`user_stats/${userId}`).get()).data();
 
         await db.doc(`user_stats/${userId}`).set({
             ...stats,
@@ -174,6 +176,15 @@ async function processUser(db, userId, options, summary, log, startedAt, userDat
         summary.failedUsers += 1;
         log.error(`[error] ${userId}: ${error.message}`);
     }
+}
+
+/**
+ * "47 (era 52)" — o dry-run existe para comparar com o que já está gravado,
+ * e a normalização de nomes derruba justamente PRs e exercícios distintos.
+ */
+function formatDelta(previous, next) {
+    if (!Number.isFinite(previous) || previous === next) return String(next);
+    return `${next} (era ${previous})`;
 }
 
 function requireValue(arg, value) {

--- a/functions/src/exerciseName.js
+++ b/functions/src/exerciseName.js
@@ -1,30 +1,28 @@
 /**
- * exerciseName.js
- * Normalização de nomes de exercício.
+ * exerciseName.js (functions)
+ * ESPELHO de src/utils/exerciseName.js — functions/ é um pacote separado e o
+ * deploy leva só esta pasta, então a normalização é duplicada de propósito
+ * (mesmo caso de achievementTargets.js). Alterou lá, altere aqui.
  *
- * Variações de grafia do mesmo exercício ("Leg Press 45°", "leg press 45")
- * viravam chaves distintas em `exerciseMaxes` — duplicando as Melhores Marcas
- * e inflando `distinctExercises` e `prsCount`.
- *
- * ESPELHO: functions/src/exerciseName.js repete `normalizeExerciseName` e
- * `createExerciseMaxTracker` porque functions/ é um pacote separado (o deploy
- * leva só aquela pasta). Alterou aqui, altere lá.
+ * Sem isto, grafias diferentes do mesmo exercício ("Leg Press 45°" e
+ * "leg press 45") viram chaves distintas em `exerciseMaxes` e inflam
+ * `distinctExercises` e `prsCount`.
  */
 
 // Marcas de acento combinantes, expostas pelo normalize('NFD').
-const COMBINING_MARKS = new RegExp('[\\u0300-\\u036f]', 'g');
+const COMBINING_MARKS = new RegExp("[\\u0300-\\u036f]", "g");
 
 /**
  * Chave canônica de um exercício: sem acento, minúscula e sem pontuação
  * (inclusive os símbolos de grau ° e º), com espaços colapsados.
  */
 export function normalizeExerciseName(name) {
-    if (typeof name !== 'string') return '';
+    if (typeof name !== "string") return "";
     return name
-        .normalize('NFD')
-        .replace(COMBINING_MARKS, '')
+        .normalize("NFD")
+        .replace(COMBINING_MARKS, "")
         .toLowerCase()
-        .replace(/[^a-z0-9]+/g, ' ') // °, º, hífens e pontuação viram espaço
+        .replace(/[^a-z0-9]+/g, " ") // °, º, hífens e pontuação viram espaço
         .trim();
 }
 
@@ -70,34 +68,4 @@ export function createExerciseMaxTracker() {
             return result;
         }
     };
-}
-
-/**
- * Agrupa `exerciseMaxes` ({ nome: peso }) por nome normalizado, mantendo o
- * maior peso de cada exercício. Retorna `[{ name, weight }]` — `name` é o
- * rótulo mais completo encontrado (o mais longo costuma trazer acento/grau,
- * ex.: "Leg Press 45°" em vez de "leg press 45").
- */
-export function aggregateExerciseMaxes(exerciseMaxes) {
-    if (!exerciseMaxes || typeof exerciseMaxes !== 'object') return [];
-
-    const byKey = new Map();
-
-    for (const [rawName, rawWeight] of Object.entries(exerciseMaxes)) {
-        const key = normalizeExerciseName(rawName);
-        if (!key) continue;
-
-        const weight = Number(rawWeight) || 0;
-        const current = byKey.get(key);
-
-        if (!current) {
-            byKey.set(key, { name: rawName, weight });
-            continue;
-        }
-
-        if (weight > current.weight) current.weight = weight;
-        if (rawName.length > current.name.length) current.name = rawName;
-    }
-
-    return [...byKey.values()];
 }

--- a/functions/src/index.js
+++ b/functions/src/index.js
@@ -2,7 +2,7 @@ import { initializeApp } from "firebase-admin/app";
 import { getFirestore, FieldValue } from "firebase-admin/firestore";
 import { onDocumentCreated } from "firebase-functions/v2/firestore";
 import * as logger from "firebase-functions/logger";
-import { buildUserStatsFromSessions } from "./userStatsCalculator.js";
+import { buildUserStatsFromSessions, mergeUnlockedAchievements } from "./userStatsCalculator.js";
 
 initializeApp();
 
@@ -27,8 +27,9 @@ export const rebuildUserStatsOnSessionCreated = onDocumentCreated(
 );
 
 async function rebuildUserStats(userId, sourceSessionId) {
-    const [userSnap, sessionsSnap] = await Promise.all([
+    const [userSnap, statsSnap, sessionsSnap] = await Promise.all([
         db.doc(`users/${userId}`).get(),
+        db.doc(`user_stats/${userId}`).get(),
         db.collection("workout_sessions")
             .where("userId", "==", userId)
             .orderBy("completedAt", "desc")
@@ -50,6 +51,7 @@ async function rebuildUserStats(userId, sourceSessionId) {
 
     await db.doc(`user_stats/${userId}`).set({
         ...stats,
+        achievements: mergeUnlockedAchievements(statsSnap.data()?.achievements, stats.achievements),
         rebuildLimit: MAX_REBUILD_SESSIONS,
         rebuildTruncated: sessionsSnap.size >= MAX_REBUILD_SESSIONS,
         sourceSessionId,

--- a/functions/src/userStatsCalculator.js
+++ b/functions/src/userStatsCalculator.js
@@ -1,4 +1,5 @@
 import { achievementTargets } from "./achievementTargets.js";
+import { createExerciseMaxTracker, normalizeExerciseName } from "./exerciseName.js";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const TRANSITION_DATE = new Date(2026, 4, 11);
@@ -15,7 +16,7 @@ export function buildUserStatsFromSessions(sessions = [], options = {}) {
         .sort((a, b) => a.__date - b.__date);
 
     const totals = createEmptyTotals();
-    const exerciseMaxes = {};
+    const exerciseMaxTracker = createExerciseMaxTracker();
     const distinctExercises = new Set();
     const last7DaysCutoff = new Date(now.getTime() - 7 * MS_PER_DAY);
     const startOfYear = new Date(now.getFullYear(), 0, 1);
@@ -62,7 +63,7 @@ export function buildUserStatsFromSessions(sessions = [], options = {}) {
         }
         workoutsInCurrentYear += 1;
 
-        collectExerciseStats(session, totals, exerciseMaxes, distinctExercises);
+        collectExerciseStats(session, totals, exerciseMaxTracker, distinctExercises);
 
         const runningStats = {
             totalWorkouts: totals.totalWorkouts,
@@ -79,6 +80,7 @@ export function buildUserStatsFromSessions(sessions = [], options = {}) {
         unlockAchievements(achievementHistory, runningStats, sessionDate);
     });
 
+    const exerciseMaxes = exerciseMaxTracker.toObject();
     const weekly = calculateWeeklyAggregates(validSessions, weeklyGoal, now);
     const uniqueCurrentWeekDays = weekly.currentWeekActiveDays;
 
@@ -129,6 +131,33 @@ export function buildUserStatsFromSessions(sessions = [], options = {}) {
     };
 }
 
+/**
+ * União do histórico de conquistas já gravado com o recém-calculado, mantendo
+ * a data mais antiga. Conquista desbloqueada nunca volta a bloquear: o rebuild
+ * sobrescreve o doc inteiro ({ merge: false }) e a normalização de nomes pode
+ * derrubar `prsCount`/`distinctExercises` abaixo do alvo que já foi batido.
+ */
+export function mergeUnlockedAchievements(previous = {}, computed = {}) {
+    const merged = { ...(previous || {}) };
+
+    Object.entries(computed || {}).forEach(([id, entry]) => {
+        const existing = merged[id];
+        if (!existing) {
+            merged[id] = entry;
+            return;
+        }
+
+        const existingAt = Date.parse(existing.unlockedAt);
+        const computedAt = Date.parse(entry.unlockedAt);
+        const keepExisting = Number.isFinite(existingAt)
+            && (!Number.isFinite(computedAt) || existingAt <= computedAt);
+
+        merged[id] = keepExisting ? existing : entry;
+    });
+
+    return merged;
+}
+
 function createEmptyTotals() {
     return {
         totalWorkouts: 0,
@@ -145,7 +174,7 @@ function createEmptyTotals() {
     };
 }
 
-function collectExerciseStats(session, totals, exerciseMaxes, distinctExercises) {
+function collectExerciseStats(session, totals, exerciseMaxTracker, distinctExercises) {
     const exercises = session.results || session.exercises || [];
 
     const processSet = (set) => {
@@ -162,8 +191,11 @@ function collectExerciseStats(session, totals, exerciseMaxes, distinctExercises)
     };
 
     const processExercise = (name, data) => {
-        if (!name) return;
-        distinctExercises.add(name);
+        // Grafias diferentes do mesmo exercício compartilham a chave canônica:
+        // sem isto elas contariam como exercícios distintos e como PR extra.
+        const key = normalizeExerciseName(name);
+        if (!key) return;
+        distinctExercises.add(key);
 
         const sets = Array.isArray(data) ? data : [data];
         let sessionMaxWeight = 0;
@@ -180,9 +212,8 @@ function collectExerciseStats(session, totals, exerciseMaxes, distinctExercises)
             }
         });
 
-        if (sessionMaxWeight > (exerciseMaxes[name] || 0)) {
+        if (exerciseMaxTracker.record(name, sessionMaxWeight)) {
             totals.prsCount += 1;
-            exerciseMaxes[name] = sessionMaxWeight;
         }
     };
 
@@ -198,7 +229,7 @@ function collectExerciseStats(session, totals, exerciseMaxes, distinctExercises)
 
 function getSessionVolume(session) {
     const totals = createEmptyTotals();
-    collectExerciseStats(session, totals, {}, new Set());
+    collectExerciseStats(session, totals, createExerciseMaxTracker(), new Set());
     return totals.totalTonnageKg;
 }
 

--- a/functions/test/backfillUserStats.test.js
+++ b/functions/test/backfillUserStats.test.js
@@ -49,6 +49,27 @@ describe("backfillUserStats", () => {
         expect(set).not.toHaveBeenCalled();
     });
 
+    it("compares against the stored doc so the dry-run shows what will change", async () => {
+        const set = vi.fn();
+        const log = createFakeLog();
+        const db = createFakeDb({
+            set,
+            existingStats: { prsCount: 3, distinctExercises: 2 }
+        });
+
+        await backfillUserStats(db, {
+            userId: "user-1",
+            batchSize: 50,
+            maxSessions: 2000,
+            write: false
+        }, log);
+
+        const [message] = log.info.mock.calls[0];
+        expect(message).toContain("PRs 1 (era 3)");
+        expect(message).toContain("exercicios 1 (era 2)");
+        expect(set).not.toHaveBeenCalled();
+    });
+
     it("writes aggregate when --write is enabled", async () => {
         const set = vi.fn();
         const db = createFakeDb({ set });

--- a/functions/test/backfillUserStats.test.js
+++ b/functions/test/backfillUserStats.test.js
@@ -69,9 +69,35 @@ describe("backfillUserStats", () => {
             totalTonnageKg: 1000
         }), { merge: false });
     });
+
+    it("preserves achievements already unlocked in the stored doc", async () => {
+        const set = vi.fn();
+        const db = createFakeDb({
+            set,
+            existingStats: {
+                achievements: {
+                    pr_50: { unlockedAt: "2026-05-01T00:00:00.000Z", value: 50 }
+                }
+            }
+        });
+
+        await backfillUserStats(db, {
+            userId: "user-1",
+            batchSize: 50,
+            maxSessions: 2000,
+            write: true
+        }, createFakeLog());
+
+        const written = set.mock.calls[0][0];
+        expect(written.achievements.pr_50).toEqual({
+            unlockedAt: "2026-05-01T00:00:00.000Z",
+            value: 50
+        });
+        expect(written.achievements.w_1).toBeTruthy();
+    });
 });
 
-function createFakeDb({ set }) {
+function createFakeDb({ set, existingStats = null }) {
     const userDoc = {
         data: () => ({
             weeklyGoal: 4
@@ -101,7 +127,10 @@ function createFakeDb({ set }) {
             }
 
             if (path === "user_stats/user-1") {
-                return { set };
+                return {
+                    set,
+                    get: async () => ({ data: () => existingStats })
+                };
             }
 
             throw new Error(`unexpected doc path ${path}`);

--- a/functions/test/userStatsCalculator.test.js
+++ b/functions/test/userStatsCalculator.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildUserStatsFromSessions } from "../src/userStatsCalculator.js";
+import { buildUserStatsFromSessions, mergeUnlockedAchievements } from "../src/userStatsCalculator.js";
 
 function session(date, exercises = []) {
     return {
@@ -71,5 +71,60 @@ describe("buildUserStatsFromSessions", () => {
         expect(stats.strengthWorkouts).toBe(0);
         expect(stats.totalDurationSeconds).toBe(1800);
         expect(stats.totalTonnageKg).toBe(0);
+    });
+
+    it("treats spelling variants of an exercise as the same movement", () => {
+        const stats = buildUserStatsFromSessions([
+            session("2026-07-01T10:00:00.000Z", [
+                strengthExercise("Leg Press 45°", [
+                    { weight: "200", reps: "10", completed: true }
+                ])
+            ]),
+            session("2026-07-02T10:00:00.000Z", [
+                strengthExercise("leg press 45", [
+                    { weight: "180", reps: "10", completed: true }
+                ])
+            ])
+        ], {
+            weeklyGoal: 4,
+            now: new Date("2026-07-03T12:00:00.000Z")
+        });
+
+        // Um exercício só, um PR só — a segunda grafia não é recorde novo.
+        expect(stats.distinctExercises).toBe(1);
+        expect(stats.prsCount).toBe(1);
+        // Rótulo exibido: o mais completo, com o símbolo de grau.
+        expect(stats.exerciseMaxes).toEqual({ "Leg Press 45°": 200 });
+        expect(stats.achievementStats.exerciseMaxes).toEqual({ "Leg Press 45°": 200 });
+    });
+});
+
+describe("mergeUnlockedAchievements", () => {
+    it("keeps achievements that the new calculation no longer unlocks", () => {
+        const merged = mergeUnlockedAchievements(
+            { pr_50: { unlockedAt: "2026-05-01T00:00:00.000Z", value: 50 } },
+            { w_1: { unlockedAt: "2026-06-01T00:00:00.000Z", value: 1 } }
+        );
+
+        expect(merged.pr_50.unlockedAt).toBe("2026-05-01T00:00:00.000Z");
+        expect(merged.w_1).toBeTruthy();
+    });
+
+    it("keeps the earliest unlock date when both sides have the achievement", () => {
+        const merged = mergeUnlockedAchievements(
+            { w_1: { unlockedAt: "2026-01-01T00:00:00.000Z", value: 1 } },
+            { w_1: { unlockedAt: "2026-06-01T00:00:00.000Z", value: 1 } }
+        );
+
+        expect(merged.w_1.unlockedAt).toBe("2026-01-01T00:00:00.000Z");
+    });
+
+    it("falls back to the computed entry when the stored date is unusable", () => {
+        const merged = mergeUnlockedAchievements(
+            { w_1: { unlockedAt: null } },
+            { w_1: { unlockedAt: "2026-06-01T00:00:00.000Z", value: 1 } }
+        );
+
+        expect(merged.w_1.unlockedAt).toBe("2026-06-01T00:00:00.000Z");
     });
 });

--- a/src/utils/evaluateAchievements.js
+++ b/src/utils/evaluateAchievements.js
@@ -1,23 +1,34 @@
 
 // evaluateAchievements.js
 
+import { createExerciseMaxTracker, normalizeExerciseName } from './exerciseName';
+
+/**
+ * Conquista já registrada em `unlockedMap` continua desbloqueada mesmo que o
+ * valor atual fique abaixo do alvo — a normalização de nomes de exercício pode
+ * derrubar `prsCount`/`distinctExercises`, e o usuário não perde o que ganhou.
+ */
 export function evaluateAchievements(catalog, stats, unlockedMap = {}) {
     return catalog.map((a) => {
         const value = getValue(a.type, stats);
-        const isUnlocked = value >= a.target;
+        const wasUnlocked = Boolean(unlockedMap[a.id]);
+        const isUnlocked = value >= a.target || wasUnlocked;
 
         const unlockedAt =
             unlockedMap[a.id]?.unlockedAt ??
             (isUnlocked ? new Date().toISOString() : null);
+
+        // Desbloqueada => barra cheia, ainda que o valor recalculado tenha caído.
+        const progressValue = isUnlocked ? a.target : value;
 
         return {
             ...a,
             value,
             isUnlocked,
             unlockedAt,
-            progressValue: Math.min(value, a.target),
-            progressRatio: Math.min(1, value / a.target),
-            progressText: format(a, value)
+            progressValue,
+            progressRatio: Math.min(1, progressValue / a.target),
+            progressText: format(a, progressValue)
         };
     });
 }
@@ -89,8 +100,8 @@ export function calculateStats(sessions) {
     let prsCount = 0;
     let distinctExercisesSet = new Set();
 
-    // Mapas para rastrear PR: nomeExercício -> pesoMax
-    const exerciseMaxWeight = {};
+    // Máximos por exercício canônico (também é a fonte do prsCount).
+    const exerciseMaxTracker = createExerciseMaxTracker();
 
     const now = new Date();
     const oneWeekAgo = new Date();
@@ -149,7 +160,10 @@ export function calculateStats(sessions) {
 
         // Auxiliar para iterar exercícios
         const processExercise = (name, sets) => {
-            distinctExercisesSet.add(name);
+            // Grafias diferentes do mesmo exercício compartilham a chave canônica.
+            const key = normalizeExerciseName(name);
+            if (!key) return;
+            distinctExercisesSet.add(key);
             let sessionMaxWeight = 0;
 
             if (Array.isArray(sets)) {
@@ -178,23 +192,9 @@ export function calculateStats(sessions) {
                 }
             }
 
-            // Verificação de PR
-            if (sessionMaxWeight > 0) {
-                const currentMax = exerciseMaxWeight[name] || 0;
-                if (sessionMaxWeight > currentMax) {
-                    if (currentMax > 0) {
-                        // Contar apenas como PR se superar um recorde positivo anterior? 
-                        // Ou a primeira vez é um PR? Geralmente primeira vez é PR também (Novo PR!).
-                        // Catálogo do usuário diz "Primeiro PR", "10 PRs".
-                        // Se eu contar todo primeiro exercício como PR, usuários terão muitos PRs inicialmente.
-                        // Mas estritamente falando, um PB é um PB.
-                        prsCount++;
-                    } else {
-                        // Primeira vez fazendo exercício é tecnicamente um PR.
-                        prsCount++;
-                    }
-                    exerciseMaxWeight[name] = sessionMaxWeight;
-                }
+            // Verificação de PR (a primeira vez também conta como recorde).
+            if (exerciseMaxTracker.record(name, sessionMaxWeight)) {
+                prsCount++;
             }
         };
 
@@ -220,7 +220,7 @@ export function calculateStats(sessions) {
         prsCount,
 
         distinctExercises: distinctExercisesSet.size,
-        exerciseMaxes: exerciseMaxWeight
+        exerciseMaxes: exerciseMaxTracker.toObject()
     };
 }
 
@@ -248,7 +248,7 @@ export function evaluateHistory(sessions, catalog) {
         totalReps: 0,
         prsCount: 0,
         distinctExercises: new Set(),
-        exerciseMaxes: {} // name -> maxWeight
+        exerciseMaxTracker: createExerciseMaxTracker()
     };
 
     // Sliding window for 7 days: array of timestamps
@@ -324,7 +324,9 @@ export function evaluateHistory(sessions, catalog) {
         };
 
         const processExercise = (name, data) => {
-            runningStats.distinctExercises.add(name);
+            const key = normalizeExerciseName(name);
+            if (!key) return;
+            runningStats.distinctExercises.add(key);
             let sessionMax = 0;
             const sets = Array.isArray(data) ? data : [data];
 
@@ -333,14 +335,9 @@ export function evaluateHistory(sessions, catalog) {
                 if (w > sessionMax) sessionMax = w;
             });
 
-            if (sessionMax > 0) {
-                const currentMax = runningStats.exerciseMaxes[name] || 0;
-                if (sessionMax > currentMax) {
-                    // Always count as PR? Or only if currentMax > 0?
-                    // Catalog implies "First PR" is a thing. Let's count all improvements/firsts.
-                    runningStats.prsCount++;
-                    runningStats.exerciseMaxes[name] = sessionMax;
-                }
+            // A primeira vez no exercício também conta como recorde.
+            if (runningStats.exerciseMaxTracker.record(name, sessionMax)) {
+                runningStats.prsCount++;
             }
         };
 

--- a/src/utils/evaluateAchievements.test.js
+++ b/src/utils/evaluateAchievements.test.js
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { calculateStats, evaluateAchievements, evaluateHistory } from './evaluateAchievements';
+
+function session(date, exercises) {
+    return { completedAt: new Date(date), exercises };
+}
+
+function exercise(name, weight) {
+    return { name, sets: [{ weight, reps: 10, completed: true }] };
+}
+
+const catalog = [
+    { id: 'pr_50', type: 'prs_count', target: 50 },
+    { id: 'ex_10', type: 'distinct_exercises', target: 10 }
+];
+
+describe('calculateStats', () => {
+    it('trata grafias diferentes do mesmo exercício como um só', () => {
+        const stats = calculateStats([
+            session('2026-07-01T10:00:00.000Z', [exercise('Leg Press 45°', '200')]),
+            session('2026-07-02T10:00:00.000Z', [exercise('leg press 45', '180')])
+        ]);
+
+        expect(stats.distinctExercises).toBe(1);
+        expect(stats.prsCount).toBe(1);
+        expect(stats.exerciseMaxes).toEqual({ 'Leg Press 45°': 200 });
+    });
+
+    it('conta como PR quando a marca sobe, mesmo com outra grafia', () => {
+        const stats = calculateStats([
+            session('2026-07-01T10:00:00.000Z', [exercise('leg press 45', '180')]),
+            session('2026-07-02T10:00:00.000Z', [exercise('Leg Press 45°', '200')])
+        ]);
+
+        expect(stats.prsCount).toBe(2);
+        expect(stats.exerciseMaxes).toEqual({ 'Leg Press 45°': 200 });
+    });
+});
+
+describe('evaluateHistory', () => {
+    it('não desbloqueia conquistas com PRs duplicados por grafia', () => {
+        const history = evaluateHistory([
+            session('2026-07-01T10:00:00.000Z', [exercise('Leg Press 45°', '200')]),
+            session('2026-07-02T10:00:00.000Z', [exercise('leg press 45', '180')])
+        ], [{ id: 'pr_2', type: 'prs_count', target: 2 }]);
+
+        expect(history.pr_2).toBeUndefined();
+    });
+});
+
+describe('evaluateAchievements', () => {
+    it('mantém desbloqueada a conquista já registrada, mesmo com valor menor', () => {
+        const [prAchievement] = evaluateAchievements(
+            catalog,
+            { prsCount: 47, distinctExercises: 3 },
+            { pr_50: { unlockedAt: '2026-05-01T00:00:00.000Z' } }
+        );
+
+        expect(prAchievement.isUnlocked).toBe(true);
+        expect(prAchievement.unlockedAt).toBe('2026-05-01T00:00:00.000Z');
+        // Barra cheia: a medalha já foi ganha.
+        expect(prAchievement.progressRatio).toBe(1);
+        expect(prAchievement.progressText).toBe('50 / 50');
+    });
+
+    it('mantém bloqueada a conquista que nunca foi atingida', () => {
+        const [, variety] = evaluateAchievements(
+            catalog,
+            { prsCount: 47, distinctExercises: 3 },
+            {}
+        );
+
+        expect(variety.isUnlocked).toBe(false);
+        expect(variety.progressText).toBe('3 / 10');
+    });
+});


### PR DESCRIPTION
## O que foi alterado

## Como foi testado

## Impacto em segurança

## Impacto em Firestore/rules/indexes

## Impacto visual

## Checklist

- [ ] Rodei `npm run lint`
- [ ] Rodei `npm test -- --run`
- [ ] Rodei `npm run test:rules`
- [ ] Rodei `npm run build`
- [ ] Revisei regras do Firestore, se aplicável
- [ ] Atualizei documentação, se aplicável
