### PR TITLE
fix: remover declaração duplicada de previousStats no backfill

### DIFF
--- a/functions/scripts/backfillUserStats.js
+++ b/functions/scripts/backfillUserStats.js
@@ -160,8 +160,6 @@ async function processUser(db, userId, options, summary, log, startedAt, userDat
             return;
         }
 
-        const previousStats = (await db.doc(`user_stats/${userId}`).get()).data();
-
         await db.doc(`user_stats/${userId}`).set({
             ...stats,
             achievements: mergeUnlockedAchievements(previousStats?.achievements, stats.achievements),


### PR DESCRIPTION
## Contexto

A `main` está vermelha desde o merge do #37: o ESLint para com um **parsing error** em `functions/scripts/backfillUserStats.js:163`.

```
163:15  error  Parsing error: Identifier 'previousStats' has already been declared
```

Como o `Run Lint` é o primeiro passo do job, ele derruba tudo que vem depois — `Run Vitest`, `Run Functions Tests`, `Run Firestore Rules Tests`, `Run Build` e `Run Test Coverage` aparecem com `0s` e nunca executaram. Na prática, a `main` está sem cobertura de teste no CI desde então.

O #37 foi mergeado com o check `Run Tests` ainda em `pending`, então a falha só apareceu depois.

## O problema

O #37 passou a buscar `previousStats` **antes** do bloco de dry-run, para logar os deltas de PRs e exercícios distintos, mas manteve a busca original logo abaixo dele. Como o dry-run dá `return` cedo, o caminho de escrita chegava na segunda declaração com a variável já no escopo.

## A correção

Remover a segunda declaração. A que sobrou já cobre os dois caminhos — nenhuma mudança de comportamento.

## Verificação

- `npm run lint` — limpo
- `npm test` — 228 testes, 34 arquivos, todos passando

Depois deste merge o CI da `main` volta a rodar a suíte inteira, o que também valida retroativamente o conteúdo do #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)