### PR TITLE
docs: corrigir instrução de teste local do App Check

### DIFF
--- a/MANUAL_TECNICO.md
+++ b/MANUAL_TECNICO.md
@@ -185,8 +185,21 @@ typeof window.grecaptcha            // "object"
 
 Filtrar a aba de rede por `recaptcha` não serve — as chamadas são cross-origin e podem não aparecer.
 
-Para testar localmente, use `VITE_FIREBASE_APP_CHECK_DEBUG=true` no `.env.local` (só funciona fora
-de produção) e registre no Firebase Console o token de debug impresso no console.
+Para testar localmente, o `.env.local` precisa das **duas** variáveis:
+
+```
+VITE_FIREBASE_APP_CHECK_SITE_KEY=<site key do reCAPTCHA Enterprise>
+VITE_FIREBASE_APP_CHECK_DEBUG=true
+```
+
+`getAppCheckRuntimeConfig` exige um site key não vazio mesmo em modo debug
+(`src/utils/appCheck.js`, linha 11: `enabled` depende de `Boolean(normalizedSiteKey)`), e o
+`.env.example` deixa esse campo em branco. Setar apenas o `DEBUG=true` não inicializa nada e
+**nenhum token de debug é impresso** — o App Check fica silenciosamente desligado. O site key é
+público, então pode ser copiado do console sem cuidado especial.
+
+Com as duas definidas, registre no Firebase Console o token de debug impresso no console do
+navegador. O modo debug só funciona fora de produção.
 
 **Pendente:** o enforcement ainda está desligado — o App Check apenas coleta métricas e não bloqueia
 nada. Só ligue depois de alguns dias com as requisições verificadas perto de 100% no Firebase


### PR DESCRIPTION
## Contexto

Correção de um erro introduzido pelo #39, apontado pela revisão automática daquele PR e confirmado contra o código.

A seção 7.3 do `MANUAL_TECNICO.md` dizia:

> Para testar localmente, use `VITE_FIREBASE_APP_CHECK_DEBUG=true` no `.env.local`

Isso não funciona. Em `src/utils/appCheck.js:11`:

```js
enabled: hasWindow && Boolean(normalizedSiteKey) && (isProduction || debugEnabled)
```

O site key é exigido **também** em modo debug. E o `.env.example` deixa `VITE_FIREBASE_APP_CHECK_SITE_KEY` em branco.

O efeito de seguir a instrução antiga é silencioso: o App Check simplesmente não inicializa e nenhum token de debug é impresso. Sem erro no console, sem pista — o tipo de instrução errada que custa uma tarde.

## O que muda

Só `MANUAL_TECNICO.md`. A seção agora mostra as duas variáveis necessárias, aponta a linha exata que faz a exigência, e registra que o site key é público (então não há cuidado especial ao colocá-lo no `.env.local`).

## Verificação

`npm run lint` limpo. Mudança exclusivamente de documentação.

🤖 Generated with [Claude Code](https://claude.com/claude-code)