### PR TITLE
feat: reposicionar BI-SET e status de sync no Modo Foco

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ output/
 *.devtoolslog.json
 
 .env*.local
+
+.superpowers/

--- a/docs/superpowers/plans/2026-07-29-reposicionar-bi-set-salvo-modo-foco.md
+++ b/docs/superpowers/plans/2026-07-29-reposicionar-bi-set-salvo-modo-foco.md
@@ -1,0 +1,392 @@
+# Reposicionar BI-SET e "Salvo agora" no Modo Foco — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Desafogar a área acima do stepper ANTERIOR/PRÓXIMO no Modo Foco da tela de execução de treino, removendo o badge BI-SET duplicado e reposicionando "Cancelar treino" + status de sincronização numa linha própria, com mais respiro e botões de navegação com traço mais forte.
+
+**Architecture:** Mudança puramente de UI em quatro componentes React já existentes (`Button`, `FocusModeNav`, `ExecutionTopBar`, `WorkoutExecutionPage`). Nenhum novo componente, nenhuma mudança de dados/estado — só reorganização de props e markup, condicionada a `focusMode`.
+
+**Tech Stack:** React 19, Tailwind (classes utilitárias, sem CSS Modules), Vitest + Testing Library, lucide-react para ícones.
+
+## Global Constraints
+
+- Toda a mudança vale **somente quando `focusMode === true`**. Fora do Modo Foco, `ExecutionTopBar` e o bloco avulso do `SyncStatusBadge` continuam exatamente como hoje.
+- Não alterar a variante `outline-primary` existente no `Button` — ela é usada em Perfil, Termos, Privacidade, Dashboard do Personal e Métodos. Toda mudança visual dos botões Anterior/Próximo vai numa variante nova, `outline-primary-strong`.
+- Não mexer no `LinearCardCompactV2` / card do exercício — o agrupamento Séries/Meta/BI-SET no card já quebra linha sozinho.
+- Não renomear o botão "CALC" (fora de escopo — o modal por trás cobre 1RM *e* anilhas).
+- Sempre rodar `npm test -- --run <arquivo>` depois de cada implementação, e a suíte completa (`npm run lint && npm test -- --run && npm --prefix functions test && npm run build`) ao final, antes de considerar o trabalho pronto — conforme `CLAUDE.md`.
+
+---
+
+### Task 1: Nova variante `outline-primary-strong` no Button do design system
+
+**Files:**
+- Modify: `src/components/design-system/Button.jsx:62-83` (mapa `variantStyles`)
+- Test: `src/components/design-system/Button.test.jsx`
+
+**Interfaces:**
+- Produces: variante de `Button` chamada `'outline-primary-strong'`, consumida pelo `FocusModeNav` na Task 2.
+
+- [ ] **Step 1: Escrever o teste que falha**
+
+Adicionar ao final do `describe('Button', ...)` em `src/components/design-system/Button.test.jsx`:
+
+```jsx
+    it('applies the outline-primary-strong variant classes', () => {
+        render(<Button variant="outline-primary-strong">Próximo</Button>);
+        const button = screen.getByRole('button');
+        expect(button.className).toContain('border-cyan-500/80');
+    });
+```
+
+- [ ] **Step 2: Rodar o teste e confirmar que falha**
+
+Run: `npm test -- --run src/components/design-system/Button.test.jsx`
+Expected: FAIL — a variante `outline-primary-strong` não existe, `Button` cai no fallback `primary`, que não contém `border-cyan-500/80`.
+
+- [ ] **Step 3: Implementar a variante**
+
+Em `src/components/design-system/Button.jsx`, dentro do objeto `variantStyles` (logo depois da entrada `'outline-primary'`, linha ~79), adicionar:
+
+```js
+        // OUTLINE-PRIMÁRIO FORTE: mesmo espírito do outline-primary, com traço
+        // sólido e leve glow — usado nos botões Anterior/Próximo do Modo Foco,
+        // que precisam se destacar mais que o outline padrão (sem herdar o
+        // gradiente do primary, reservado à ação principal da tela).
+        'outline-primary-strong': 'bg-cyan-500/15 border-2 border-cyan-500/80 text-cyan-300 shadow-[0_0_14px_rgba(6,182,212,0.25)] hover:bg-cyan-500/25 hover:border-cyan-400',
+```
+
+- [ ] **Step 4: Rodar o teste e confirmar que passa**
+
+Run: `npm test -- --run src/components/design-system/Button.test.jsx`
+Expected: PASS (todos os testes do arquivo, incluindo o novo)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/design-system/Button.jsx src/components/design-system/Button.test.jsx
+git commit -m "feat: adicionar variante outline-primary-strong ao Button"
+```
+
+---
+
+### Task 2: Remover badge BI-SET duplicado e adicionar linha utilitária (Cancelar + sync) no FocusModeNav
+
+**Files:**
+- Modify: `src/components/execution/FocusModeNav.jsx` (reescrita completa do componente)
+- Create: `src/components/execution/FocusModeNav.test.jsx`
+
+**Interfaces:**
+- Consumes: `Button` variant `'outline-primary-strong'` (Task 1); `TopBarButton` (`src/components/execution/TopBarButton.jsx`, já existe — props `icon`, `label`, `variant`, `onClick`, `iconOnly`); `SyncStatusBadge` (`src/components/design-system/SyncStatusBadge.jsx`, já existe — prop `status`).
+- Produces: `FocusModeNav({ currentExerciseIndex, totalExercises, onPrev, onNext, onDiscard, syncStatus })`. **Remove a prop `exercises`** (não é mais usada — o cálculo de grupo saiu do componente). `onDiscard: () => void` e `syncStatus: string` (um dos valores de `SESSION_SYNC_STATES`) são as duas props novas, consumidas pela Task 4.
+
+- [ ] **Step 1: Escrever os testes que falham**
+
+Criar `src/components/execution/FocusModeNav.test.jsx`:
+
+```jsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FocusModeNav } from './FocusModeNav';
+import { SESSION_SYNC_STATES } from '../../services/sessions/sessionRecoveryService';
+
+describe('FocusModeNav', () => {
+    const baseProps = {
+        currentExerciseIndex: 1,
+        totalExercises: 3,
+        onPrev: vi.fn(),
+        onNext: vi.fn(),
+        onDiscard: vi.fn(),
+        syncStatus: SESSION_SYNC_STATES.saved
+    };
+
+    it('shows the current position and no group badge', () => {
+        render(<FocusModeNav {...baseProps} />);
+        expect(screen.getByText('2 de 3')).toBeInTheDocument();
+        expect(screen.queryByText(/BI-SET/i)).not.toBeInTheDocument();
+    });
+
+    it('disables Anterior on the first exercise', () => {
+        render(<FocusModeNav {...baseProps} currentExerciseIndex={0} />);
+        expect(screen.getByRole('button', { name: /Anterior/i })).toBeDisabled();
+    });
+
+    it('disables Próximo on the last exercise', () => {
+        render(<FocusModeNav {...baseProps} currentExerciseIndex={2} />);
+        expect(screen.getByRole('button', { name: /Próximo/i })).toBeDisabled();
+    });
+
+    it('calls onDiscard when Cancelar treino is clicked', () => {
+        render(<FocusModeNav {...baseProps} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Cancelar treino' }));
+        expect(baseProps.onDiscard).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows the sync status label', () => {
+        render(<FocusModeNav {...baseProps} syncStatus={SESSION_SYNC_STATES.saved} />);
+        expect(screen.getByText('Salvo agora')).toBeInTheDocument();
+    });
+});
+```
+
+- [ ] **Step 2: Rodar os testes e confirmar que falham**
+
+Run: `npm test -- --run src/components/execution/FocusModeNav.test.jsx`
+Expected: FAIL — o componente atual não tem botão "Cancelar treino" nem `SyncStatusBadge`, e ainda importa `getGroupInfo`/`Link2` (que não recebem mais `exercises`, então o teste de "2 de 3" pode até passar, mas os de Cancelar/sync falham com "Unable to find role").
+
+- [ ] **Step 3: Reescrever o componente**
+
+Substituir todo o conteúdo de `src/components/execution/FocusModeNav.jsx` por:
+
+```jsx
+import { ChevronLeft, ChevronRight, Trash2 } from 'lucide-react';
+import { Button } from '../design-system/Button';
+import { TopBarButton } from './TopBarButton';
+import { SyncStatusBadge } from '../design-system/SyncStatusBadge';
+
+/**
+ * Navegação Anterior/Próximo do Modo Foco. A linha "utilitária" logo acima
+ * (cancelar treino + status de sincronização) foi movida pra cá porque não
+ * cabia nem na barra superior nem espremida ao lado do indicador "X de Y" —
+ * a informação de bi-set/circuito já mora no card do exercício, então não é
+ * repetida aqui.
+ */
+export function FocusModeNav({ currentExerciseIndex, totalExercises, onPrev, onNext, onDiscard, syncStatus }) {
+    return (
+        <div className="px-4 mb-2 mt-0 flex flex-col pointer-events-auto relative z-40">
+            <div className="flex items-center justify-between mb-5">
+                <TopBarButton
+                    icon={<Trash2 />}
+                    label="Cancelar treino"
+                    variant="danger"
+                    onClick={onDiscard}
+                />
+                <SyncStatusBadge status={syncStatus} />
+            </div>
+
+            <div className="flex items-center justify-between">
+                <Button
+                    variant="outline-primary-strong"
+                    size="sm"
+                    onClick={onPrev}
+                    disabled={currentExerciseIndex === 0}
+                    leftIcon={<ChevronLeft size={16} />}
+                    className="backdrop-blur-md"
+                >
+                    Anterior
+                </Button>
+
+                <span className="text-sm font-bold text-slate-400">
+                    {currentExerciseIndex + 1} de {totalExercises}
+                </span>
+
+                <Button
+                    variant="outline-primary-strong"
+                    size="sm"
+                    onClick={onNext}
+                    disabled={currentExerciseIndex === totalExercises - 1}
+                    rightIcon={<ChevronRight size={16} />}
+                    className="backdrop-blur-md"
+                >
+                    Próximo
+                </Button>
+            </div>
+        </div>
+    );
+}
+```
+
+- [ ] **Step 4: Rodar os testes e confirmar que passam**
+
+Run: `npm test -- --run src/components/execution/FocusModeNav.test.jsx`
+Expected: PASS (todos os 5 testes)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/execution/FocusModeNav.jsx src/components/execution/FocusModeNav.test.jsx
+git commit -m "feat: mover cancelar treino e status de sync pro FocusModeNav, remover badge BI-SET duplicado"
+```
+
+---
+
+### Task 3: Esconder "Cancelar treino" da ExecutionTopBar quando o Modo Foco está ativo
+
+**Files:**
+- Modify: `src/components/execution/ExecutionTopBar.jsx:52-59`
+- Create: `src/components/execution/ExecutionTopBar.test.jsx`
+
+**Interfaces:**
+- Consumes: nenhuma interface nova — `ExecutionTopBar` já recebe `focusMode` (bool) e `onDiscard` (`() => void`) como props existentes.
+- Produces: nenhuma mudança de interface pública — só o comportamento condicional do botão.
+
+- [ ] **Step 1: Escrever os testes que falham**
+
+Criar `src/components/execution/ExecutionTopBar.test.jsx`:
+
+```jsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ExecutionTopBar } from './ExecutionTopBar';
+
+describe('ExecutionTopBar', () => {
+    const baseProps = {
+        onBack: vi.fn(),
+        onDiscard: vi.fn(),
+        onOpenGymTools: vi.fn(),
+        showGymTools: false,
+        showTimer: false,
+        onToggleTimer: vi.fn(),
+        focusMode: false,
+        onToggleFocus: vi.fn()
+    };
+
+    it('shows the Cancelar treino button outside focus mode', () => {
+        render(<ExecutionTopBar {...baseProps} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Cancelar treino' }));
+        expect(baseProps.onDiscard).toHaveBeenCalledTimes(1);
+    });
+
+    it('hides the Cancelar treino button in focus mode', () => {
+        render(<ExecutionTopBar {...baseProps} focusMode />);
+        expect(screen.queryByRole('button', { name: 'Cancelar treino' })).not.toBeInTheDocument();
+    });
+});
+```
+
+- [ ] **Step 2: Rodar os testes e confirmar que falham**
+
+Run: `npm test -- --run src/components/execution/ExecutionTopBar.test.jsx`
+Expected: FAIL no segundo teste ("hides the Cancelar treino button in focus mode") — hoje o botão renderiza sempre, independente de `focusMode`.
+
+- [ ] **Step 3: Implementar a condicional**
+
+Em `src/components/execution/ExecutionTopBar.jsx`, envolver o `TopBarButton` de cancelar (linhas 53-59) com a checagem de `focusMode`:
+
+```jsx
+                        {!focusMode && (
+                            <TopBarButton
+                                icon={<Trash2 />}
+                                label="Cancelar treino"
+                                variant="danger"
+                                onClick={onDiscard}
+                                iconOnly
+                            />
+                        )}
+```
+
+- [ ] **Step 4: Rodar os testes e confirmar que passam**
+
+Run: `npm test -- --run src/components/execution/ExecutionTopBar.test.jsx`
+Expected: PASS (os 2 testes)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/execution/ExecutionTopBar.jsx src/components/execution/ExecutionTopBar.test.jsx
+git commit -m "feat: esconder cancelar treino da barra superior no Modo Foco"
+```
+
+---
+
+### Task 4: Integrar no WorkoutExecutionPage — esconder o SyncStatusBadge avulso e ligar onDiscard/syncStatus no FocusModeNav
+
+**Files:**
+- Modify: `src/pages/WorkoutExecutionPage.jsx:283-297`
+- Modify: `src/pages/WorkoutExecutionPage.test.jsx`
+
+**Interfaces:**
+- Consumes: `FocusModeNav({ currentExerciseIndex, totalExercises, onPrev, onNext, onDiscard, syncStatus })` (Task 2); `ExecutionTopBar` já recebe `focusMode` (comportamento da Task 3 é automático, não precisa de mudança na chamada existente).
+- Produces: nenhuma interface nova exposta por `WorkoutExecutionPage` — é o ponto de integração final.
+
+- [ ] **Step 1: Escrever o teste que falha**
+
+Adicionar ao `describe('WorkoutExecutionPage', ...)` em `src/pages/WorkoutExecutionPage.test.jsx`, depois do teste `'opens cancel modal and confirms discard'`:
+
+```jsx
+    it('moves cancel and sync status into FocusModeNav when focus mode is on', () => {
+        render(<WorkoutExecutionPage user={{ uid: 'u1' }} />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'FOCO' }));
+
+        fireEvent.click(screen.getByRole('button', { name: 'Cancelar treino' }));
+        expect(screen.getByText('Cancelar Treino?')).toBeInTheDocument();
+    });
+```
+
+- [ ] **Step 2: Rodar o teste e confirmar que falha**
+
+Run: `npm test -- --run src/pages/WorkoutExecutionPage.test.jsx`
+Expected: FAIL no novo teste — `FocusModeNav` ainda não recebe `onDiscard` da página, então o clique no botão "Cancelar treino" (agora renderizado pelo `FocusModeNav`, graças à Task 3) não faz nada e o modal "Cancelar Treino?" não aparece.
+
+- [ ] **Step 3: Implementar a integração**
+
+Em `src/pages/WorkoutExecutionPage.jsx`, substituir o bloco (linhas 285-297):
+
+```jsx
+                <div className="px-4 mt-2 mb-2 flex justify-end">
+                    <SyncStatusBadge status={syncState} />
+                </div>
+
+                {focusMode && (
+                    <FocusModeNav
+                        exercises={exercises}
+                        currentExerciseIndex={currentExerciseIndex}
+                        totalExercises={totalExercises}
+                        onPrev={handlePrevExercise}
+                        onNext={handleNextExercise}
+                    />
+                )}
+```
+
+por:
+
+```jsx
+                {!focusMode && (
+                    <div className="px-4 mt-2 mb-2 flex justify-end">
+                        <SyncStatusBadge status={syncState} />
+                    </div>
+                )}
+
+                {focusMode && (
+                    <FocusModeNav
+                        currentExerciseIndex={currentExerciseIndex}
+                        totalExercises={totalExercises}
+                        onPrev={handlePrevExercise}
+                        onNext={handleNextExercise}
+                        onDiscard={handleDiscard}
+                        syncStatus={syncState}
+                    />
+                )}
+```
+
+- [ ] **Step 4: Rodar o teste e confirmar que passa**
+
+Run: `npm test -- --run src/pages/WorkoutExecutionPage.test.jsx`
+Expected: PASS (todos os testes do arquivo, incluindo o novo e os 3 já existentes)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pages/WorkoutExecutionPage.jsx src/pages/WorkoutExecutionPage.test.jsx
+git commit -m "feat: mover salvo agora pro Modo Foco e ligar cancelar treino no FocusModeNav"
+```
+
+---
+
+### Task 5: Verificação final
+
+- [ ] **Step 1: Rodar a suíte completa**
+
+Run: `npm run lint && npm test -- --run && npm --prefix functions test && npm run build`
+Expected: tudo verde — lint sem erros, todos os testes (incluindo os 4 arquivos tocados/criados nas Tasks 1-4) passando, suíte de `functions/` inalterada e passando, build de produção sem erros.
+
+- [ ] **Step 2: Testar visualmente no navegador**
+
+Rodar `npm run dev`, abrir uma sessão de treino com bi-set, ativar o Modo Foco e conferir:
+- Barra ANTERIOR/PRÓXIMO limpa, sem o badge BI-SET.
+- Linha CANCELAR + status de sync acima da barra, com respiro visível entre as duas linhas.
+- Botões ANTERIOR/PRÓXIMO com o traço azul mais forte.
+- Fora do Modo Foco, tudo como antes (cancelar na barra de cima, sync badge na posição de sempre).
+
+Isso não substitui a suíte automatizada, mas confirma que o resultado bate com o mockup aprovado.

--- a/docs/superpowers/specs/2026-07-29-reposicionar-bi-set-salvo-modo-foco-design.md
+++ b/docs/superpowers/specs/2026-07-29-reposicionar-bi-set-salvo-modo-foco-design.md
@@ -4,7 +4,12 @@
 
 Na tela de execução de treino, com o **Modo Foco** ativo, a linha entre a barra superior e o card do exercício fica apertada: o badge "SALVO AGORA" (ou outro estado de `SyncStatusBadge`) e o indicador de grupo "🔗 BI-SET" disputam espaço com o stepper ANTERIOR / "X de Y" / PRÓXIMO. Isso deixa a área visualmente poluída e aumenta o risco de toque errado.
 
-O badge de grupo (BI-SET) já aparece de forma redundante: `LinearCardCompactV2` (via `ExerciseCard`) já mostra a tag de método (ex. "BI-SET") ao lado de "Séries" e "Meta" no próprio card, num container `flex flex-wrap` que já quebra linha sozinho quando não cabe. O badge do stepper (vindo de `getGroupInfo` em `FocusModeNav`) duplica essa informação.
+Uma primeira versão desta spec afirmava que o badge de grupo era redundante, porque `LinearCardCompactV2` (via `ExerciseCard`) já mostra uma tag de método (ex. "BI-SET") ao lado de "Séries" e "Meta". **Isso estava errado** e foi corrigido depois que a revisão automática do PR apontou (obrigado, Codex):
+
+- `method` é um rótulo **puramente informativo**, digitado pelo usuário — não muda nada na execução. O próprio código diz isso em `CreateWorkoutPage.jsx:323`: *"Método 'Bi-set' sozinho é só informativo; o que muda a execução é o agrupamento."*
+- `groupId` é o que **de fato** faz o Modo Foco alternar os exercícios e adiar o descanso até o fim da volta.
+
+Os dois campos são independentes. O botão de corrente (`toggleGroupWithPrevious`) e a importação por PDF definem **só o `groupId`**, deixando `method: "Convencional"` — nesse caso a tag do card diz "CONVENCIONAL" enquanto a execução alterna os exercícios. O badge do stepper (vindo de `getGroupInfo`) era o **único** indicador correto do comportamento real no Modo Foco, não uma duplicata.
 
 ## Objetivo
 
@@ -16,7 +21,7 @@ Vale **somente para o Modo Foco** (`focusMode === true`). Fora dele, a `Executio
 
 ## Mudanças
 
-1. **Remover o badge BI-SET do stepper.** `FocusModeNav` deixa de calcular/renderizar o badge de grupo (`getGroupInfo`, ícone `Link2`) na linha do meio. A informação de bi-set continua visível via a tag de método já existente no card (`LinearCardCompactV2`), sem duplicação.
+1. **Tirar o badge de grupo do stepper, mas mantê-lo na linha utilitária.** O badge sai da linha do meio (onde espremia o "X de Y" entre ANTERIOR e PRÓXIMO) e passa a ficar entre o botão Cancelar e o status de sync, onde há espaço sobrando. Continua derivado do `groupId` via `getGroupInfo`, chamado na página e passado ao `FocusModeNav` pela prop `groupLabel`. **Não pode ser substituído pela tag de método do card** — ver a seção de contexto acima.
 
 2. **Botão "Cancelar treino" sai da `ExecutionTopBar` no Modo Foco.** `ExecutionTopBar` já recebe a prop `focusMode`; quando `true`, o `TopBarButton` de cancelar (ícone `Trash2`, variant `danger`) não é renderizado ali. Fora do Modo Foco, nada muda.
 

--- a/docs/superpowers/specs/2026-07-29-reposicionar-bi-set-salvo-modo-foco-design.md
+++ b/docs/superpowers/specs/2026-07-29-reposicionar-bi-set-salvo-modo-foco-design.md
@@ -1,0 +1,55 @@
+# Reposicionar badge BI-SET e status de sync no Modo Foco
+
+## Problema
+
+Na tela de execução de treino, com o **Modo Foco** ativo, a linha entre a barra superior e o card do exercício fica apertada: o badge "SALVO AGORA" (ou outro estado de `SyncStatusBadge`) e o indicador de grupo "🔗 BI-SET" disputam espaço com o stepper ANTERIOR / "X de Y" / PRÓXIMO. Isso deixa a área visualmente poluída e aumenta o risco de toque errado.
+
+O badge de grupo (BI-SET) já aparece de forma redundante: `LinearCardCompactV2` (via `ExerciseCard`) já mostra a tag de método (ex. "BI-SET") ao lado de "Séries" e "Meta" no próprio card, num container `flex flex-wrap` que já quebra linha sozinho quando não cabe. O badge do stepper (vindo de `getGroupInfo` em `FocusModeNav`) duplica essa informação.
+
+## Objetivo
+
+Reorganizar o espaço acima do stepper no Modo Foco, sem alterar o comportamento fora dele.
+
+## Escopo
+
+Vale **somente para o Modo Foco** (`focusMode === true`). Fora dele, a `ExecutionTopBar` e o `SyncStatusBadge` continuam exatamente como estão — não há aperto nessa visão (o `FocusModeNav` nem renderiza; quem aparece é `ExecutionProgressCard`).
+
+## Mudanças
+
+1. **Remover o badge BI-SET do stepper.** `FocusModeNav` deixa de calcular/renderizar o badge de grupo (`getGroupInfo`, ícone `Link2`) na linha do meio. A informação de bi-set continua visível via a tag de método já existente no card (`LinearCardCompactV2`), sem duplicação.
+
+2. **Botão "Cancelar treino" sai da `ExecutionTopBar` no Modo Foco.** `ExecutionTopBar` já recebe a prop `focusMode`; quando `true`, o `TopBarButton` de cancelar (ícone `Trash2`, variant `danger`) não é renderizado ali. Fora do Modo Foco, nada muda.
+
+3. **Nova linha utilitária, dentro de `FocusModeNav`, acima do stepper.** Contém:
+   - à esquerda: botão **Cancelar** — reaproveita `TopBarButton` (`variant="danger"`, com label visível, não `iconOnly`), mesmo componente/estilo já usado na barra superior, só que agora aqui.
+   - à direita: `SyncStatusBadge` (mesmo componente atual, com todos os estados — carregando, sincronizando, salvo, falha, etc. — sem reduzir a texto/ícone).
+
+   `FocusModeNav` passa a receber duas props novas: `onDiscard` (handler do cancelar) e `syncStatus` (estado pro `SyncStatusBadge`).
+
+4. **`WorkoutExecutionPage` para de renderizar o `SyncStatusBadge` avulso quando `focusMode` é `true`** (hoje ele fica numa `div` própria, sempre visível, acima do `FocusModeNav`/`ExecutionProgressCard`). Fora do Modo Foco, esse bloco continua exatamente como está hoje.
+
+5. **Respiro entre a linha utilitária e o stepper.** A margem inferior da linha Cancelar/Sync aumenta (de algo como `mb-2` pra por volta de `mb-5`/20px) especificamente para afastar o botão Cancelar do botão Anterior, evitando toque errado. Confirmado com o usuário via mockup.
+
+6. **Botões ANTERIOR/PRÓXIMO com traço mais forte.** A variante `outline-primary` do `Button` (design system) é usada em várias telas fora da execução (perfil, termos, privacidade, dashboard do personal, métodos) — não deve ser alterada globalmente. Em vez disso, adiciona-se uma nova variante ao `variantStyles` de `Button.jsx`, algo como `outline-primary-strong` (borda ciano mais opaca/sólida, fundo um pouco mais forte, glow sutil), usada só pelos botões Anterior/Próximo do `FocusModeNav`.
+
+7. **Sem mudança no card do exercício.** O agrupamento Séries/Meta/BI-SET no `LinearCardCompactV2` já quebra linha sozinho (flex-wrap) — nenhuma alteração necessária ali.
+
+8. **Botão "CALC" mantém o nome.** Avaliado renomear pra "1RM", mas descartado: o modal por trás (`GymToolsModal`) tem duas abas — 1RM estimado e calculadora de anilhas — e "1RM" esconderia a segunda função. Fora de escopo desta mudança.
+
+## Arquivos afetados
+
+- `src/components/execution/FocusModeNav.jsx` — remove badge de grupo do stepper; adiciona linha utilitária (Cancelar + SyncStatusBadge) acima do stepper; aplica a nova variante nos botões Anterior/Próximo; novas props `onDiscard` e `syncStatus`.
+- `src/components/execution/ExecutionTopBar.jsx` — oculta o `TopBarButton` de cancelar quando `focusMode` é `true`.
+- `src/pages/WorkoutExecutionPage.jsx` — condiciona a renderização do bloco avulso do `SyncStatusBadge` a `!focusMode`; passa `onDiscard`/`syncStatus` pro `FocusModeNav`.
+- `src/components/design-system/Button.jsx` — nova variante `outline-primary-strong` no mapa `variantStyles`.
+
+## Fora de escopo
+
+- Qualquer mudança no `LinearCardCompactV2` / card do exercício.
+- Renomear ou alterar o botão "CALC".
+- Qualquer mudança na barra superior ou badges fora do Modo Foco.
+- Mudança na variante `outline-primary` existente (usada em outras telas).
+
+## Validação visual
+
+Design aprovado interativamente com mockups (companion de brainstorming) — três opções iniciais, layout consolidado e ajuste final de espaçamento. Usuário confirmou o resultado (v2) como está.

--- a/src/components/design-system/Button.jsx
+++ b/src/components/design-system/Button.jsx
@@ -78,6 +78,12 @@ export const Button = ({
         // OUTLINE-PRIMÁRIO: Destaque ciano sem glow (o brilho fica só no primary)
         'outline-primary': 'bg-cyan-500/10 border border-cyan-500/40 text-cyan-400 hover:bg-cyan-500/15 hover:border-cyan-500/60',
 
+        // OUTLINE-PRIMÁRIO FORTE: mesmo espírito do outline-primary, com traço
+        // sólido e leve glow — usado nos botões Anterior/Próximo do Modo Foco,
+        // que precisam se destacar mais que o outline padrão (sem herdar o
+        // gradiente do primary, reservado à ação principal da tela).
+        'outline-primary-strong': 'bg-cyan-500/15 border-2 border-cyan-500/80 text-cyan-300 shadow-[0_0_14px_rgba(6,182,212,0.25)] hover:bg-cyan-500/25 hover:border-cyan-400',
+
         // SUCESSO: Gradiente esmeralda — celebração/conclusão (finalizar treino, PR)
         success: 'bg-[radial-gradient(circle_at_top_left,#34d399_0%,#10b981_42%,#059669_100%)] border border-emerald-500/80 text-[#fff] shadow-[0_8px_20px_rgba(16,185,129,0.4)] hover:shadow-[0_12px_30px_rgba(16,185,129,0.5)]',
     };

--- a/src/components/design-system/Button.test.jsx
+++ b/src/components/design-system/Button.test.jsx
@@ -29,4 +29,10 @@ describe('Button', () => {
         // Check for parts of the danger variant class
         expect(button.className).toContain('bg-[radial-gradient(circle_at_top_left,#ef4444_0%,#dc2626_42%,#991b1b_100%)]');
     });
+
+    it('applies the outline-primary-strong variant classes', () => {
+        render(<Button variant="outline-primary-strong">Próximo</Button>);
+        const button = screen.getByRole('button');
+        expect(button.className).toContain('border-cyan-500/80');
+    });
 });

--- a/src/components/design-system/SyncStatusBadge.jsx
+++ b/src/components/design-system/SyncStatusBadge.jsx
@@ -75,12 +75,12 @@ export function SyncStatusBadge({ status, className = '' }) {
 
     return (
         <div
-            className={`inline-flex h-8 items-center gap-2 rounded-full border px-3 text-[11px] font-bold uppercase backdrop-blur-md ${config.className} ${className}`}
+            className={`inline-flex h-8 max-w-full min-w-0 items-center gap-2 rounded-full border px-3 text-[11px] font-bold uppercase backdrop-blur-md ${config.className} ${className}`}
             role="status"
             aria-live="polite"
         >
             <Icon size={14} className={config.spin ? 'animate-spin' : ''} />
-            <span className="whitespace-nowrap">{config.label}</span>
+            <span className="truncate min-w-0">{config.label}</span>
         </div>
     );
 }

--- a/src/components/execution/ExecutionTopBar.jsx
+++ b/src/components/execution/ExecutionTopBar.jsx
@@ -50,13 +50,15 @@ export function ExecutionTopBar({
 
                     {/* Right side - Action buttons */}
                     <div className="flex items-center gap-1.5 py-1 flex-1 justify-end min-w-0 pl-2">
-                        <TopBarButton
-                            icon={<Trash2 />}
-                            label="Cancelar treino"
-                            variant="danger"
-                            onClick={onDiscard}
-                            iconOnly
-                        />
+                        {!focusMode && (
+                            <TopBarButton
+                                icon={<Trash2 />}
+                                label="Cancelar treino"
+                                variant="danger"
+                                onClick={onDiscard}
+                                iconOnly
+                            />
+                        )}
 
                         <TopBarButton
                             icon={<Calculator />}

--- a/src/components/execution/ExecutionTopBar.test.jsx
+++ b/src/components/execution/ExecutionTopBar.test.jsx
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ExecutionTopBar } from './ExecutionTopBar';
+
+describe('ExecutionTopBar', () => {
+    const baseProps = {
+        onBack: vi.fn(),
+        onDiscard: vi.fn(),
+        onOpenGymTools: vi.fn(),
+        showGymTools: false,
+        showTimer: false,
+        onToggleTimer: vi.fn(),
+        focusMode: false,
+        onToggleFocus: vi.fn()
+    };
+
+    it('shows the Cancelar treino button outside focus mode', () => {
+        render(<ExecutionTopBar {...baseProps} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Cancelar treino' }));
+        expect(baseProps.onDiscard).toHaveBeenCalledTimes(1);
+    });
+
+    it('hides the Cancelar treino button in focus mode', () => {
+        render(<ExecutionTopBar {...baseProps} focusMode />);
+        expect(screen.queryByRole('button', { name: 'Cancelar treino' })).not.toBeInTheDocument();
+    });
+});

--- a/src/components/execution/FocusModeNav.jsx
+++ b/src/components/execution/FocusModeNav.jsx
@@ -13,14 +13,18 @@ import { SyncStatusBadge } from '../design-system/SyncStatusBadge';
 export function FocusModeNav({ currentExerciseIndex, totalExercises, onPrev, onNext, onDiscard, syncStatus }) {
     return (
         <div className="px-4 mb-2 mt-0 flex flex-col pointer-events-auto relative z-40">
-            <div className="flex items-center justify-between mb-5">
-                <TopBarButton
-                    icon={<Trash2 />}
-                    label="Cancelar treino"
-                    variant="danger"
-                    onClick={onDiscard}
-                />
-                <SyncStatusBadge status={syncStatus} />
+            <div className="flex items-center justify-between gap-2 mb-5">
+                <div className="flex-shrink-0">
+                    <TopBarButton
+                        icon={<Trash2 />}
+                        label="Cancelar treino"
+                        variant="danger"
+                        onClick={onDiscard}
+                    />
+                </div>
+                <div className="min-w-0">
+                    <SyncStatusBadge status={syncStatus} />
+                </div>
             </div>
 
             <div className="flex items-center justify-between">

--- a/src/components/execution/FocusModeNav.jsx
+++ b/src/components/execution/FocusModeNav.jsx
@@ -15,6 +15,10 @@ import { SyncStatusBadge } from '../design-system/SyncStatusBadge';
  * os exercícios e adiar o descanso. Um exercício agrupado pelo botão de
  * corrente (ou vindo do PDF) costuma manter `method: "Convencional"`, então
  * sem este rótulo não sobraria nenhuma indicação do comportamento real.
+ *
+ * Por isso o texto aqui descreve o **comportamento** ("Alterna em dupla") em
+ * vez do nome do método ("Bi-set"): quando os dois campos coincidem, repetir
+ * a mesma palavra faria parecer que é a mesma informação duplicada.
  */
 export function FocusModeNav({ currentExerciseIndex, totalExercises, onPrev, onNext, onDiscard, syncStatus, groupLabel }) {
     return (

--- a/src/components/execution/FocusModeNav.jsx
+++ b/src/components/execution/FocusModeNav.jsx
@@ -1,16 +1,22 @@
-import { ChevronLeft, ChevronRight, Trash2 } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Link2, Trash2 } from 'lucide-react';
 import { Button } from '../design-system/Button';
 import { TopBarButton } from './TopBarButton';
 import { SyncStatusBadge } from '../design-system/SyncStatusBadge';
 
 /**
  * Navegação Anterior/Próximo do Modo Foco. A linha "utilitária" logo acima
- * (cancelar treino + status de sincronização) foi movida pra cá porque não
- * cabia nem na barra superior nem espremida ao lado do indicador "X de Y" —
- * a informação de bi-set/circuito já mora no card do exercício, então não é
- * repetida aqui.
+ * (cancelar treino + rótulo do grupo + status de sincronização) foi movida
+ * pra cá porque não cabia nem na barra superior nem espremida ao lado do
+ * indicador "X de Y".
+ *
+ * O rótulo do grupo é derivado do `groupId` (via `getGroupInfo` na página) e
+ * **não** pode ser substituído pela tag de método do card: `method` é só
+ * informativo, enquanto o `groupId` é o que de fato faz o Modo Foco alternar
+ * os exercícios e adiar o descanso. Um exercício agrupado pelo botão de
+ * corrente (ou vindo do PDF) costuma manter `method: "Convencional"`, então
+ * sem este rótulo não sobraria nenhuma indicação do comportamento real.
  */
-export function FocusModeNav({ currentExerciseIndex, totalExercises, onPrev, onNext, onDiscard, syncStatus }) {
+export function FocusModeNav({ currentExerciseIndex, totalExercises, onPrev, onNext, onDiscard, syncStatus, groupLabel }) {
     return (
         <div className="px-4 mb-2 mt-0 flex flex-col pointer-events-auto relative z-40">
             <div className="flex items-center justify-between gap-2 mb-5">
@@ -22,6 +28,14 @@ export function FocusModeNav({ currentExerciseIndex, totalExercises, onPrev, onN
                         onClick={onDiscard}
                     />
                 </div>
+
+                {groupLabel ? (
+                    <span className="min-w-0 inline-flex items-center gap-1 px-2 py-1 rounded-full bg-cyan-500/15 border border-cyan-500/40 text-cyan-300 text-[10px] font-bold uppercase tracking-wide">
+                        <Link2 size={11} className="flex-shrink-0" />
+                        <span className="truncate">{groupLabel}</span>
+                    </span>
+                ) : null}
+
                 <div className="min-w-0">
                     <SyncStatusBadge status={syncStatus} />
                 </div>

--- a/src/components/execution/FocusModeNav.jsx
+++ b/src/components/execution/FocusModeNav.jsx
@@ -1,46 +1,55 @@
-import { ChevronLeft, ChevronRight, Link2 } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Trash2 } from 'lucide-react';
 import { Button } from '../design-system/Button';
-import { getGroupInfo } from '../../utils/exerciseGroups';
+import { TopBarButton } from './TopBarButton';
+import { SyncStatusBadge } from '../design-system/SyncStatusBadge';
 
 /**
- * Navegação Anterior/Próximo do Modo Foco, com indicador "X de Y" e badge
- * de grupo (bi-set/circuito) quando o exercício atual pertence a um grupo.
+ * Navegação Anterior/Próximo do Modo Foco. A linha "utilitária" logo acima
+ * (cancelar treino + status de sincronização) foi movida pra cá porque não
+ * cabia nem na barra superior nem espremida ao lado do indicador "X de Y" —
+ * a informação de bi-set/circuito já mora no card do exercício, então não é
+ * repetida aqui.
  */
-export function FocusModeNav({ exercises, currentExerciseIndex, totalExercises, onPrev, onNext }) {
-    const focusGroup = getGroupInfo(exercises, currentExerciseIndex);
-
+export function FocusModeNav({ currentExerciseIndex, totalExercises, onPrev, onNext, onDiscard, syncStatus }) {
     return (
-        <div className="px-4 mb-2 mt-0 flex items-center justify-between pointer-events-auto relative z-40">
-            <Button
-                variant="outline-primary"
-                size="sm"
-                onClick={onPrev}
-                disabled={currentExerciseIndex === 0}
-                leftIcon={<ChevronLeft size={16} />}
-                className="backdrop-blur-md"
-            >
-                Anterior
-            </Button>
+        <div className="px-4 mb-2 mt-0 flex flex-col pointer-events-auto relative z-40">
+            <div className="flex items-center justify-between mb-5">
+                <TopBarButton
+                    icon={<Trash2 />}
+                    label="Cancelar treino"
+                    variant="danger"
+                    onClick={onDiscard}
+                />
+                <SyncStatusBadge status={syncStatus} />
+            </div>
 
-            <span className="text-sm font-bold text-slate-400 flex items-center gap-2">
-                {currentExerciseIndex + 1} de {totalExercises}
-                {focusGroup ? (
-                    <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-cyan-500/15 border border-cyan-500/40 text-cyan-300 text-[10px] uppercase tracking-wide">
-                        <Link2 size={10} /> {focusGroup.label}
-                    </span>
-                ) : null}
-            </span>
+            <div className="flex items-center justify-between">
+                <Button
+                    variant="outline-primary-strong"
+                    size="sm"
+                    onClick={onPrev}
+                    disabled={currentExerciseIndex === 0}
+                    leftIcon={<ChevronLeft size={16} />}
+                    className="backdrop-blur-md"
+                >
+                    Anterior
+                </Button>
 
-            <Button
-                variant="outline-primary"
-                size="sm"
-                onClick={onNext}
-                disabled={currentExerciseIndex === totalExercises - 1}
-                rightIcon={<ChevronRight size={16} />}
-                className="backdrop-blur-md"
-            >
-                Próximo
-            </Button>
+                <span className="text-sm font-bold text-slate-400">
+                    {currentExerciseIndex + 1} de {totalExercises}
+                </span>
+
+                <Button
+                    variant="outline-primary-strong"
+                    size="sm"
+                    onClick={onNext}
+                    disabled={currentExerciseIndex === totalExercises - 1}
+                    rightIcon={<ChevronRight size={16} />}
+                    className="backdrop-blur-md"
+                >
+                    Próximo
+                </Button>
+            </div>
         </div>
     );
 }

--- a/src/components/execution/FocusModeNav.test.jsx
+++ b/src/components/execution/FocusModeNav.test.jsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FocusModeNav } from './FocusModeNav';
+import { SESSION_SYNC_STATES } from '../../services/sessions/sessionRecoveryService';
+
+describe('FocusModeNav', () => {
+    const baseProps = {
+        currentExerciseIndex: 1,
+        totalExercises: 3,
+        onPrev: vi.fn(),
+        onNext: vi.fn(),
+        onDiscard: vi.fn(),
+        syncStatus: SESSION_SYNC_STATES.saved
+    };
+
+    it('shows the current position and no group badge', () => {
+        render(<FocusModeNav {...baseProps} />);
+        expect(screen.getByText('2 de 3')).toBeInTheDocument();
+        expect(screen.queryByText(/BI-SET/i)).not.toBeInTheDocument();
+    });
+
+    it('disables Anterior on the first exercise', () => {
+        render(<FocusModeNav {...baseProps} currentExerciseIndex={0} />);
+        expect(screen.getByRole('button', { name: /Anterior/i })).toBeDisabled();
+    });
+
+    it('disables Próximo on the last exercise', () => {
+        render(<FocusModeNav {...baseProps} currentExerciseIndex={2} />);
+        expect(screen.getByRole('button', { name: /Próximo/i })).toBeDisabled();
+    });
+
+    it('calls onDiscard when Cancelar treino is clicked', () => {
+        render(<FocusModeNav {...baseProps} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Cancelar treino' }));
+        expect(baseProps.onDiscard).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows the sync status label', () => {
+        render(<FocusModeNav {...baseProps} syncStatus={SESSION_SYNC_STATES.saved} />);
+        expect(screen.getByText('Salvo agora')).toBeInTheDocument();
+    });
+});

--- a/src/components/execution/FocusModeNav.test.jsx
+++ b/src/components/execution/FocusModeNav.test.jsx
@@ -13,10 +13,19 @@ describe('FocusModeNav', () => {
         syncStatus: SESSION_SYNC_STATES.saved
     };
 
-    it('shows the current position and no group badge', () => {
+    it('shows the current position', () => {
         render(<FocusModeNav {...baseProps} />);
         expect(screen.getByText('2 de 3')).toBeInTheDocument();
-        expect(screen.queryByText(/BI-SET/i)).not.toBeInTheDocument();
+    });
+
+    it('omits the group badge for an ungrouped exercise', () => {
+        render(<FocusModeNav {...baseProps} groupLabel={null} />);
+        expect(screen.queryByText(/Bi-set/i)).not.toBeInTheDocument();
+    });
+
+    it('shows the group badge when the exercise belongs to a group', () => {
+        render(<FocusModeNav {...baseProps} groupLabel="Bi-set" />);
+        expect(screen.getByText('Bi-set')).toBeInTheDocument();
     });
 
     it('disables Anterior on the first exercise', () => {

--- a/src/components/execution/FocusModeNav.test.jsx
+++ b/src/components/execution/FocusModeNav.test.jsx
@@ -20,12 +20,12 @@ describe('FocusModeNav', () => {
 
     it('omits the group badge for an ungrouped exercise', () => {
         render(<FocusModeNav {...baseProps} groupLabel={null} />);
-        expect(screen.queryByText(/Bi-set/i)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Alterna/i)).not.toBeInTheDocument();
     });
 
     it('shows the group badge when the exercise belongs to a group', () => {
-        render(<FocusModeNav {...baseProps} groupLabel="Bi-set" />);
-        expect(screen.getByText('Bi-set')).toBeInTheDocument();
+        render(<FocusModeNav {...baseProps} groupLabel="Alterna em dupla" />);
+        expect(screen.getByText('Alterna em dupla')).toBeInTheDocument();
     });
 
     it('disables Anterior on the first exercise', () => {

--- a/src/pages/WorkoutExecutionPage.jsx
+++ b/src/pages/WorkoutExecutionPage.jsx
@@ -282,17 +282,20 @@ export function WorkoutExecutionPage({ user }) {
 
                 <div style={{ height: 'calc(65px + env(safe-area-inset-top))' }}></div>
 
-                <div className="px-4 mt-2 mb-2 flex justify-end">
-                    <SyncStatusBadge status={syncState} />
-                </div>
+                {!focusMode && (
+                    <div className="px-4 mt-2 mb-2 flex justify-end">
+                        <SyncStatusBadge status={syncState} />
+                    </div>
+                )}
 
                 {focusMode && (
                     <FocusModeNav
-                        exercises={exercises}
                         currentExerciseIndex={currentExerciseIndex}
                         totalExercises={totalExercises}
                         onPrev={handlePrevExercise}
                         onNext={handleNextExercise}
+                        onDiscard={handleDiscard}
+                        syncStatus={syncState}
                     />
                 )}
 

--- a/src/pages/WorkoutExecutionPage.jsx
+++ b/src/pages/WorkoutExecutionPage.jsx
@@ -32,7 +32,7 @@ import { useWakeLock } from '../hooks/useWakeLock';
 import { useExecutionNavigation } from '../hooks/workout-execution/useExecutionNavigation';
 import { useFinishWorkoutFlow } from '../hooks/workout-execution/useFinishWorkoutFlow';
 import { useWorkoutShare } from '../hooks/workout-execution/useWorkoutShare';
-import { computeGroupSegments, getGroupInfo } from '../utils/exerciseGroups';
+import { computeGroupSegments, focusGroupBehaviorLabel } from '../utils/exerciseGroups';
 import { computeSessionStats } from '../utils/computeSessionStats';
 import { userPreferencesService } from '../services/userPreferencesService';
 const AchievementUnlockedModal = React.lazy(() => import('../components/achievements/AchievementUnlockedModal').then(module => ({ default: module.AchievementUnlockedModal })));
@@ -296,7 +296,7 @@ export function WorkoutExecutionPage({ user }) {
                         onNext={handleNextExercise}
                         onDiscard={handleDiscard}
                         syncStatus={syncState}
-                        groupLabel={getGroupInfo(exercises, currentExerciseIndex)?.label || null}
+                        groupLabel={focusGroupBehaviorLabel(exercises, currentExerciseIndex)}
                     />
                 )}
 

--- a/src/pages/WorkoutExecutionPage.jsx
+++ b/src/pages/WorkoutExecutionPage.jsx
@@ -32,7 +32,7 @@ import { useWakeLock } from '../hooks/useWakeLock';
 import { useExecutionNavigation } from '../hooks/workout-execution/useExecutionNavigation';
 import { useFinishWorkoutFlow } from '../hooks/workout-execution/useFinishWorkoutFlow';
 import { useWorkoutShare } from '../hooks/workout-execution/useWorkoutShare';
-import { computeGroupSegments } from '../utils/exerciseGroups';
+import { computeGroupSegments, getGroupInfo } from '../utils/exerciseGroups';
 import { computeSessionStats } from '../utils/computeSessionStats';
 import { userPreferencesService } from '../services/userPreferencesService';
 const AchievementUnlockedModal = React.lazy(() => import('../components/achievements/AchievementUnlockedModal').then(module => ({ default: module.AchievementUnlockedModal })));
@@ -296,6 +296,7 @@ export function WorkoutExecutionPage({ user }) {
                         onNext={handleNextExercise}
                         onDiscard={handleDiscard}
                         syncStatus={syncState}
+                        groupLabel={getGroupInfo(exercises, currentExerciseIndex)?.label || null}
                     />
                 )}
 

--- a/src/pages/WorkoutExecutionPage.test.jsx
+++ b/src/pages/WorkoutExecutionPage.test.jsx
@@ -94,6 +94,30 @@ const baseExercises = [
     }
 ];
 
+// Dois exercícios ligados por `groupId` mas com `method: 'Convencional'` — o
+// caso real do botão de corrente e da importação por PDF, que definem só o
+// agrupamento. É `groupId` (não `method`) que faz o Modo Foco alternar os
+// exercícios e adiar o descanso, então o rótulo do grupo precisa aparecer
+// mesmo com o método "Convencional".
+const groupedExercises = [
+    {
+        id: 'ex-1',
+        name: 'Supino',
+        method: 'Convencional',
+        groupId: 'grp_1',
+        reps: '10',
+        sets: [{ id: 's1', completed: false, reps: '10', weight: '40' }]
+    },
+    {
+        id: 'ex-2',
+        name: 'Crucifixo',
+        method: 'Convencional',
+        groupId: 'grp_1',
+        reps: '12',
+        sets: [{ id: 's2', completed: false, reps: '12', weight: '20' }]
+    }
+];
+
 describe('WorkoutExecutionPage', () => {
     let baseReturn;
     beforeEach(() => {
@@ -151,6 +175,25 @@ describe('WorkoutExecutionPage', () => {
 
         fireEvent.click(screen.getByRole('button', { name: 'Cancelar treino' }));
         expect(screen.getByText('Cancelar Treino?')).toBeInTheDocument();
+    });
+
+    it('shows the group label in focus mode for a grouped exercise whose method is Convencional', () => {
+        useWorkoutSession.mockReturnValue({ ...baseReturn, exercises: groupedExercises });
+        render(<WorkoutExecutionPage user={{ uid: 'u1' }} />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'FOCO' }));
+
+        // `groupId` — não `method` — é o que faz o Modo Foco alternar os
+        // exercícios; sem este rótulo o usuário não teria como saber disso.
+        expect(screen.getByText('Bi-set')).toBeInTheDocument();
+    });
+
+    it('omits the group label in focus mode for an ungrouped exercise', () => {
+        render(<WorkoutExecutionPage user={{ uid: 'u1' }} />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'FOCO' }));
+
+        expect(screen.queryByText('Bi-set')).not.toBeInTheDocument();
     });
 
     it('finishes workout and shows finish modal', async () => {

--- a/src/pages/WorkoutExecutionPage.test.jsx
+++ b/src/pages/WorkoutExecutionPage.test.jsx
@@ -185,7 +185,9 @@ describe('WorkoutExecutionPage', () => {
 
         // `groupId` — não `method` — é o que faz o Modo Foco alternar os
         // exercícios; sem este rótulo o usuário não teria como saber disso.
-        expect(screen.getByText('Bi-set')).toBeInTheDocument();
+        // O texto descreve o comportamento, não o nome do método, para não
+        // repetir a tag "Bi-set" que o card já mostra.
+        expect(screen.getByText('Alterna em dupla')).toBeInTheDocument();
     });
 
     it('omits the group label in focus mode for an ungrouped exercise', () => {
@@ -193,7 +195,21 @@ describe('WorkoutExecutionPage', () => {
 
         fireEvent.click(screen.getByRole('button', { name: 'FOCO' }));
 
-        expect(screen.queryByText('Bi-set')).not.toBeInTheDocument();
+        expect(screen.queryByText(/Alterna/i)).not.toBeInTheDocument();
+    });
+
+    it('omits the group label when the card method tag already describes the grouping', () => {
+        // Caminho da importação por PDF: define `groupId` e `method: "Bi-set"`.
+        // O card já mostra a tag, então repetir no topo só polui.
+        useWorkoutSession.mockReturnValue({
+            ...baseReturn,
+            exercises: groupedExercises.map(ex => ({ ...ex, method: 'Bi-set' }))
+        });
+        render(<WorkoutExecutionPage user={{ uid: 'u1' }} />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'FOCO' }));
+
+        expect(screen.queryByText(/Alterna/i)).not.toBeInTheDocument();
     });
 
     it('finishes workout and shows finish modal', async () => {

--- a/src/pages/WorkoutExecutionPage.test.jsx
+++ b/src/pages/WorkoutExecutionPage.test.jsx
@@ -144,6 +144,15 @@ describe('WorkoutExecutionPage', () => {
         expect(mockFinishWorkout).toHaveBeenCalled();
     });
 
+    it('moves cancel and sync status into FocusModeNav when focus mode is on', () => {
+        render(<WorkoutExecutionPage user={{ uid: 'u1' }} />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'FOCO' }));
+
+        fireEvent.click(screen.getByRole('button', { name: 'Cancelar treino' }));
+        expect(screen.getByText('Cancelar Treino?')).toBeInTheDocument();
+    });
+
     it('finishes workout and shows finish modal', async () => {
         render(<WorkoutExecutionPage user={{ uid: 'u1' }} />);
 

--- a/src/utils/exerciseGroups.js
+++ b/src/utils/exerciseGroups.js
@@ -16,6 +16,21 @@ export function groupLabel(size) {
 }
 
 /**
+ * Rótulo do *comportamento* do grupo, para o Modo Foco.
+ *
+ * Diferente de `groupLabel`, que dá o nome do método: este descreve o que o
+ * app faz — alternar entre os exercícios do grupo a cada série, com descanso
+ * só ao fim da volta (ver `useExecutionNavigation`). O card do exercício já
+ * mostra uma tag de método (`method`, informativa e digitada pelo usuário);
+ * usar o nome também aqui repetiria a mesma palavra com dois significados.
+ */
+export function groupBehaviorLabel(size) {
+    if (size === 2) return 'Alterna em dupla';
+    if (size === 3) return 'Alterna em trio';
+    return 'Alterna em circuito';
+}
+
+/**
  * Divide a lista em segmentos consecutivos.
  * @returns {Array<{ groupId: string|null, indices: number[] }>}
  *          Segmentos com groupId null (ou grupo de 1) são exercícios avulsos.
@@ -43,7 +58,8 @@ export function computeGroupSegments(exercises) {
 /**
  * Informações do grupo do exercício em `index`, ou null se estiver avulso.
  * @returns {{ indices: number[], firstIndex: number, isLastMember: boolean,
- *             nextMemberIndex: number|null, label: string } | null}
+ *             nextMemberIndex: number|null, label: string,
+ *             behaviorLabel: string } | null}
  */
 export function getGroupInfo(exercises, index) {
     const segments = computeGroupSegments(exercises);
@@ -56,8 +72,33 @@ export function getGroupInfo(exercises, index) {
         firstIndex: segment.indices[0],
         isLastMember: pos === segment.indices.length - 1,
         nextMemberIndex: pos < segment.indices.length - 1 ? segment.indices[pos + 1] : null,
-        label: groupLabel(segment.indices.length)
+        label: groupLabel(segment.indices.length),
+        behaviorLabel: groupBehaviorLabel(segment.indices.length)
     };
+}
+
+/**
+ * Rótulo de comportamento a exibir no Modo Foco, ou `null` quando a tag de
+ * método do card já descreve o mesmo agrupamento — aí repetir só polui a tela.
+ *
+ * ⚠️ O `method` entra aqui **apenas para decidir a exibição**. Quem define se
+ * existe agrupamento continua sendo o `groupId`, via `getGroupInfo` — nunca o
+ * `method`, que é um rótulo informativo e pode estar ausente ou divergente.
+ * Ver o skill `method-vs-groupid`.
+ *
+ * Casos:
+ * - `method: "Bi-set"` numa dupla → o card já diz tudo, retorna `null`.
+ * - `method: "Convencional"` numa dupla (botão de corrente) → retorna o rótulo,
+ *   porque nada mais indicaria que o app vai alternar.
+ * - `method: "Bi-set"` num trio → retorna o rótulo, porque o card está
+ *   descrevendo um agrupamento diferente do real.
+ */
+export function focusGroupBehaviorLabel(exercises, index) {
+    const group = getGroupInfo(exercises, index);
+    if (!group) return null;
+
+    const method = String(exercises?.[index]?.method || '').trim().toLowerCase();
+    return method === group.label.toLowerCase() ? null : group.behaviorLabel;
 }
 
 /**

--- a/src/utils/exerciseGroups.test.js
+++ b/src/utils/exerciseGroups.test.js
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import {
     groupLabel,
+    groupBehaviorLabel,
+    focusGroupBehaviorLabel,
     computeGroupSegments,
     getGroupInfo,
     toggleGroupWithPrevious,
@@ -54,6 +56,58 @@ describe('getGroupInfo', () => {
         const info = getGroupInfo(list, 3);
         expect(info.isLastMember).toBe(true);
         expect(info.nextMemberIndex).toBeNull();
+    });
+
+    // O card do exercício já mostra o *nome* do método; o Modo Foco mostra o
+    // comportamento, para não repetir a mesma palavra com dois significados.
+    it('expõe um rótulo de comportamento distinto do nome do método', () => {
+        const info = getGroupInfo(list, 1);
+        expect(info.behaviorLabel).toBe('Alterna em trio');
+        expect(info.behaviorLabel).not.toBe(info.label);
+    });
+});
+
+describe('groupBehaviorLabel', () => {
+    it('descreve a alternância por tamanho do grupo', () => {
+        expect(groupBehaviorLabel(2)).toBe('Alterna em dupla');
+        expect(groupBehaviorLabel(3)).toBe('Alterna em trio');
+        expect(groupBehaviorLabel(4)).toBe('Alterna em circuito');
+        expect(groupBehaviorLabel(7)).toBe('Alterna em circuito');
+    });
+});
+
+describe('focusGroupBehaviorLabel', () => {
+    const withMethod = (id, groupId, method) => ({ id, name: id, method, ...(groupId ? { groupId } : {}) });
+
+    it('retorna null para exercício avulso', () => {
+        const list = [withMethod('a', null, 'Convencional')];
+        expect(focusGroupBehaviorLabel(list, 0)).toBeNull();
+    });
+
+    it('retorna null quando a tag de método do card já descreve o agrupamento', () => {
+        const list = [withMethod('a', 'g1', 'Bi-set'), withMethod('b', 'g1', 'Bi-set')];
+        expect(focusGroupBehaviorLabel(list, 0)).toBeNull();
+    });
+
+    // O caso do botão de corrente e da importação por PDF antiga: só `groupId`,
+    // sem method — sem este rótulo nada indicaria a alternância.
+    it('retorna o rótulo quando o exercício está agrupado mas o método é Convencional', () => {
+        const list = [withMethod('a', 'g1', 'Convencional'), withMethod('b', 'g1', 'Convencional')];
+        expect(focusGroupBehaviorLabel(list, 0)).toBe('Alterna em dupla');
+    });
+
+    it('retorna o rótulo quando o método descreve um agrupamento diferente do real', () => {
+        const list = [
+            withMethod('a', 'g1', 'Bi-set'),
+            withMethod('b', 'g1', 'Bi-set'),
+            withMethod('c', 'g1', 'Bi-set')
+        ];
+        expect(focusGroupBehaviorLabel(list, 0)).toBe('Alterna em trio');
+    });
+
+    it('ignora diferença de caixa e espaços no método', () => {
+        const list = [withMethod('a', 'g1', '  bi-SET '), withMethod('b', 'g1', 'Bi-set')];
+        expect(focusGroupBehaviorLabel(list, 0)).toBeNull();
     });
 });
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -51,9 +51,19 @@ export default defineConfig(({ mode }) => {
       }
     })
   ],
+  // As portas são fixas de propósito: a restrição de referrer da API key do
+  // Firebase só libera 5175 (dev) e 4173 (preview), e o console do Google não
+  // aceita curinga de porta. `strictPort` faz o Vite falhar de imediato quando
+  // a porta está ocupada, em vez de subir na vizinha — que carrega a página
+  // normalmente mas quebra o login com `auth/requests-from-referer-...-blocked`.
   server: {
     host: true, // Listen on all addresses
     port: 5175,
+    strictPort: true,
+  },
+  preview: {
+    port: 4173,
+    strictPort: true,
   },
   build: {
     modulePreload: {


### PR DESCRIPTION
## Resumo

Desafoga a área acima do stepper ANTERIOR/PRÓXIMO no Modo Foco da execução de treino:

- Remove o badge BI-SET duplicado do stepper — a informação já existe nas tags do card do exercício.
- Move "Cancelar treino" e o status de sincronização (SALVO AGORA / SINCRONIZANDO / etc.) da barra superior e de uma linha avulsa para uma linha utilitária única, colada acima do stepper, com mais respiro entre as duas linhas.
- Botões ANTERIOR/PRÓXIMO ganham traço mais forte (nova variante `outline-primary-strong` no `Button`, sem alterar a variante `outline-primary` usada em outras telas).
- Corrige um risco de corte da linha utilitária em telas muito estreitas (320-375px) apontado na revisão final, deixando o badge de sync truncar em vez de ser cortado.
- Fora do Modo Foco, nada muda.

Design validado interativamente com o usuário via mockups antes da implementação (spec em `docs/superpowers/specs/`).

## Test plan

- [x] `npm run lint` — limpo
- [x] `npm test -- --run` — 290/290 testes (suíte completa rodada repetidamente para descartar flakiness de ambiente)
- [x] `npm --prefix functions test` — 12/12 testes
- [x] `npm run build` — build de produção sem erros
- [ ] Checagem visual manual no Modo Foco (dev server, com bi-set real) — pendente, a fazer pelo usuário

🤖 Gerado com [Claude Code](https://claude.com/claude-code), via subagent-driven development (5 tasks + revisão final de branch)