### PR TITLE
chore: workflow do Claude para @claude em issues e PRs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,70 @@
+name: Claude
+
+# Responde a "@claude ..." em comentários de issues e de PRs, para pedir
+# correções sem abrir uma sessão local (ex.: pelo app do GitHub no celular).
+#
+# ATENÇÃO: para eventos `issue_comment`, o GitHub Actions sempre usa a versão
+# deste arquivo que está na branch padrão (`main`). Enquanto este workflow não
+# estiver mergeado na `main`, mencionar @claude não dispara nada.
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+# Uma execução por issue/PR de cada vez, para não empilhar jobs paralelos
+# consumindo minutos do Actions e tokens da API.
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  claude:
+    # Barra o job antes de subir o runner quando o comentário não menciona
+    # @claude — sem isso, todo comentário do repositório gastaria minutos.
+    if: contains(github.event.comment.body, '@claude')
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    permissions:
+      contents: write        # commitar a correção na branch
+      pull-requests: write   # abrir/atualizar PR e comentar
+      issues: write          # responder em issues
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      # Dependências já instaladas para o Claude não gastar turnos com isso —
+      # mesma configuração do ci.yml (Node 22 traz npm 10.x, exigido pelo
+      # lockfile deste projeto).
+      - name: Use Node.js 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            functions/package-lock.json
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Install Functions Dependencies
+        run: npm ci --prefix functions
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          # Repositório público: por padrão a action só aceita gatilho de quem
+          # tem acesso de escrita. Este allowlist é a proteção extra contra
+          # prompt injection — o Claude só lê comentários deste autor, então
+          # instruções escondidas em comentários de terceiros são ignoradas.
+          # Ao adicionar colaboradores, incluir os logins aqui (separados por vírgula).
+          include_comments_by_actor: 'Tiagopbc'
+
+          claude_args: |
+            --model claude-sonnet-5
+            --max-turns 20


### PR DESCRIPTION
## Resumo

Adiciona `.github/workflows/claude.yml`, permitindo pedir correções comentando `@claude ...` num PR ou issue — sem precisar abrir uma sessão local. O caso de uso principal é acompanhar PRs pelo celular e disparar um ajuste ali mesmo.

## Como usar (depois do merge)

Comentar num PR ou issue:

```
@claude o espaçamento entre a linha do CANCELAR e a barra ANTERIOR/PRÓXIMO ficou grande demais no iPhone SE, reduz um pouco
```

O Claude lê o `CLAUDE.md` do projeto, faz a alteração, roda a verificação e commita na branch do PR (ou abre um PR novo, se veio de uma issue).

## Pré-requisitos (fora deste PR)

1. App do Claude instalado no repositório: https://github.com/apps/claude
2. Secret `ANTHROPIC_API_KEY` configurado em Settings → Secrets and variables → Actions

Sem esses dois, o workflow existe mas não faz nada. A chave de API é cobrada por uso, separada da assinatura do Claude.

## Por que só vale na main

Para eventos `issue_comment`, o GitHub Actions sempre usa a versão do workflow que está na branch padrão. Mencionar `@claude` não dispara nada enquanto este PR não estiver mergeado — está anotado em comentário no próprio arquivo.

## Guardas de segurança (repositório é público)

- Gatilho restrito a quem tem acesso de escrita — padrão da action, mantido (não foi usado `allowed_non_write_users` nem `allowed_bots: '*'`).
- `include_comments_by_actor: 'Tiagopbc'` — o Claude só lê comentários do dono, então instruções escondidas em comentário de terceiro são ignoradas (proteção contra prompt injection). Ao adicionar colaboradores, incluir os logins ali.
- `--max-turns 20`, `timeout-minutes: 25` e `concurrency` — limitam o consumo de API e de minutos do Actions caso algo entre em loop.
- `npm ci` roda no próprio workflow em vez de o agente instalar sozinho, poupando turnos.

## Test plan

- [x] Workflow válido em YAML, seguindo as versões de action já usadas no `ci.yml` (`actions/checkout@v7`, `actions/setup-node@v6`, Node 22)
- [ ] Após merge + configuração dos 2 pré-requisitos: comentar `@claude` num PR de teste e confirmar que o job dispara e responde

🤖 Generated with [Claude Code](https://claude.com/claude-code)