### PR TITLE
feat: avisar sobre bi-set antes da volta e método ao lado da meta

### DIFF
--- a/src/components/execution/ExerciseCard.jsx
+++ b/src/components/execution/ExerciseCard.jsx
@@ -7,8 +7,12 @@ import { LinearCardCompactV2 } from './LinearCardCompactV2';
  *
  * `handlers` agrupa os callbacks vindos da página/hooks; `activeSetIndices`
  * mapeia exerciseId → índice de série selecionada.
+ *
+ * `groupRound` (opcional) é o resumo da volta do grupo, vindo de
+ * `getGroupRoundPreview`. Só o Modo Foco passa: na lista os exercícios do
+ * grupo já aparecem juntos dentro da moldura do `ExerciseGroupCard`.
  */
-export function ExerciseCard({ exercise: ex, activeSetIndices, progression, handlers }) {
+export function ExerciseCard({ exercise: ex, activeSetIndices, progression, handlers, groupRound }) {
     const {
         updateExerciseSet,
         updateSetMultiple,
@@ -58,6 +62,7 @@ export function ExerciseCard({ exercise: ex, activeSetIndices, progression, hand
             onToggleWeightMode={() => toggleExerciseWeightMode(ex.id)}
             onValidationError={onValidationError}
             progressionHint={progression?.[ex.id]}
+            groupRound={groupRound}
         />
     );
 }

--- a/src/components/execution/GroupRoundNotice.jsx
+++ b/src/components/execution/GroupRoundNotice.jsx
@@ -1,0 +1,97 @@
+import { Link2, ArrowRight, RotateCcw } from 'lucide-react';
+
+/**
+ * Aviso de volta de grupo (bi-set/tri-set/circuito) no Modo Foco.
+ *
+ * O problema que ele resolve: no Modo Foco só um exercício aparece por vez, e
+ * ao concluir a série a navegação salta para o parceiro do grupo — que às
+ * vezes exige outro equipamento. Sem aviso o usuário começa a volta e precisa
+ * levantar no meio dela para buscar halter, barra ou anilha.
+ *
+ * A tag de método do card ("BI-SET") não resolve isso: ela nomeia o método,
+ * nunca o exercício parceiro — e some quando o `method` é "Convencional", que
+ * é o caso dos grupos feitos pelo botão de corrente. Por isso o `round` vem de
+ * `getGroupRoundPreview`, derivado do `groupId`.
+ *
+ * Dois estados, para ser alto quando importa e discreto depois:
+ * - volta ainda zerada → bloco com os exercícios da volta em ordem, que é
+ *   quando ainda dá para separar tudo sem interromper nada;
+ * - volta em andamento → uma linha só, dizendo quem vem depois desta série.
+ */
+export function GroupRoundNotice({ round, currentSet, totalSets }) {
+    if (!round) return null;
+
+    if (round.roundNotStarted) {
+        // Curto de propósito: a 375px o cabeçalho precisa caber numa linha.
+        // O que "preparar" significa fica claro na lista logo abaixo.
+        const prepare = round.members.length === 2 ? 'prepare os dois' : 'prepare todos';
+
+        return (
+            <div
+                data-testid="group-round-notice"
+                className="flex flex-col gap-2 px-3 py-2.5 rounded-xl bg-cyan-500/10 border border-cyan-500/40 mb-1"
+            >
+                <div className="flex items-center gap-1.5 text-cyan-300 text-[11px] font-bold uppercase tracking-wide">
+                    <Link2 size={12} className="shrink-0" />
+                    <span>{round.label} — {prepare}</span>
+                </div>
+
+                {/* Sem `truncate`: ler os dois nomes inteiros é o motivo deste
+                    bloco existir, e exercícios de bi-set costumam diferir só no
+                    fim do nome. Em tela estreita o nome quebra em duas linhas —
+                    daí o `items-start`, para o número acompanhar a primeira. */}
+                <ol className="flex flex-col gap-1">
+                    {round.members.map((member, position) => (
+                        <li key={member.index} className="flex items-start gap-2 text-[12px] leading-snug">
+                            <span className={`w-4 h-4 mt-px shrink-0 rounded-full flex items-center justify-center text-[9px] font-bold ${member.isCurrent
+                                ? 'bg-cyan-400 text-slate-950'
+                                : 'bg-slate-800 text-slate-400 border border-slate-700'
+                                }`}>
+                                {position + 1}
+                            </span>
+                            <span className={`min-w-0 font-medium ${member.isCurrent ? 'text-cyan-200' : 'text-slate-300'}`}>
+                                {member.name}
+                                {member.isCurrent && (
+                                    <span className="ml-2 text-[9px] font-bold uppercase tracking-wider text-cyan-400/80 whitespace-nowrap">
+                                        agora
+                                    </span>
+                                )}
+                            </span>
+                        </li>
+                    ))}
+                </ol>
+
+                <p className="text-[11px] leading-snug text-cyan-200/70">
+                    Você alterna a cada série; o descanso vem só ao fim da volta.
+                </p>
+            </div>
+        );
+    }
+
+    // Última série do último membro: a volta está terminando e a navegação
+    // segue para o próximo exercício da ficha, não de volta ao grupo — a linha
+    // não teria o que prometer.
+    if (round.isLastMember && currentSet >= totalSets) return null;
+
+    // Rótulo e nome empilhados, não lado a lado: nomes de exercício são longos
+    // ("Puxada pegada supinada") e costumam diferir só no fim, então truncar
+    // numa linha só apagaria justamente o que distingue um do outro.
+    return (
+        <div
+            data-testid="group-round-notice"
+            className="flex items-center gap-2 px-3 py-2 rounded-lg bg-cyan-500/10 border border-cyan-500/25 mb-1"
+        >
+            {round.isLastMember
+                ? <RotateCcw size={13} className="shrink-0 text-cyan-400" />
+                : <ArrowRight size={13} className="shrink-0 text-cyan-400" />}
+            <div className="min-w-0 flex flex-col">
+                <span className="text-[10px] font-medium uppercase tracking-wide text-cyan-300/80 leading-tight">
+                    {round.isLastMember ? 'Depois desta série, volta para' : 'Depois desta série'}
+                </span>
+                <span className="text-[12px] font-bold uppercase tracking-wide text-cyan-200 leading-tight">
+                    {round.nextName}
+                </span>
+            </div>
+        </div>
+    );
+}

--- a/src/components/execution/GroupRoundNotice.test.jsx
+++ b/src/components/execution/GroupRoundNotice.test.jsx
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { GroupRoundNotice } from './GroupRoundNotice';
+import { getGroupRoundPreview } from '../../utils/exerciseGroups';
+
+// Os dados vêm do helper real, não de objetos montados à mão: assim o teste
+// quebra se a forma do `getGroupRoundPreview` mudar.
+const pair = (completedFlags = [[false, false], [false, false]]) => [
+    { id: 'a', name: 'Puxada pela frente pronada', groupId: 'g1', sets: completedFlags[0].map(completed => ({ completed })) },
+    { id: 'b', name: 'Puxada pegada supinada', groupId: 'g1', sets: completedFlags[1].map(completed => ({ completed })) }
+];
+
+describe('GroupRoundNotice', () => {
+    it('não renderiza nada para exercício avulso', () => {
+        const { container } = render(<GroupRoundNotice round={null} currentSet={1} totalSets={3} />);
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    describe('volta ainda zerada', () => {
+        it('lista os exercícios da volta em ordem, marcando o atual', () => {
+            render(<GroupRoundNotice round={getGroupRoundPreview(pair(), 0)} currentSet={1} totalSets={2} />);
+
+            expect(screen.getByText(/Bi-set/)).toBeInTheDocument();
+            expect(screen.getByText(/prepare os dois/i)).toBeInTheDocument();
+            expect(screen.getByText('Puxada pela frente pronada')).toBeInTheDocument();
+            expect(screen.getByText('Puxada pegada supinada')).toBeInTheDocument();
+            expect(screen.getByText('agora')).toBeInTheDocument();
+        });
+
+        it('usa "prepare todos" em grupos maiores que dois', () => {
+            const trio = [
+                { id: 'a', name: 'A', groupId: 'g1', sets: [{ completed: false }] },
+                { id: 'b', name: 'B', groupId: 'g1', sets: [{ completed: false }] },
+                { id: 'c', name: 'C', groupId: 'g1', sets: [{ completed: false }] }
+            ];
+            render(<GroupRoundNotice round={getGroupRoundPreview(trio, 0)} currentSet={1} totalSets={1} />);
+
+            expect(screen.getByText(/Tri-set/)).toBeInTheDocument();
+            expect(screen.getByText(/prepare todos/i)).toBeInTheDocument();
+        });
+    });
+
+    describe('volta em andamento', () => {
+        const started = () => pair([[true, false], [false, false]]);
+
+        it('anuncia o próximo exercício do grupo', () => {
+            render(<GroupRoundNotice round={getGroupRoundPreview(started(), 0)} currentSet={2} totalSets={2} />);
+
+            expect(screen.queryByText(/prepare/i)).not.toBeInTheDocument();
+            expect(screen.getByText('Depois desta série')).toBeInTheDocument();
+            expect(screen.getByText('Puxada pegada supinada')).toBeInTheDocument();
+        });
+
+        it('no último membro, anuncia a volta ao primeiro', () => {
+            render(<GroupRoundNotice round={getGroupRoundPreview(started(), 1)} currentSet={1} totalSets={2} />);
+
+            expect(screen.getByText('Depois desta série, volta para')).toBeInTheDocument();
+            expect(screen.getByText('Puxada pela frente pronada')).toBeInTheDocument();
+        });
+
+        // O nome fica numa linha própria justamente para não ser truncado:
+        // exercícios de bi-set costumam diferir só no fim do nome.
+        it('mostra o nome do próximo por inteiro, sem truncar', () => {
+            render(<GroupRoundNotice round={getGroupRoundPreview(started(), 0)} currentSet={2} totalSets={2} />);
+
+            const nome = screen.getByText('Puxada pegada supinada');
+            expect(nome.className).not.toMatch(/truncate/);
+        });
+
+        // Aqui a navegação segue para o próximo exercício da ficha, não de
+        // volta ao grupo — a linha não teria o que prometer.
+        it('some na última série do último membro', () => {
+            render(<GroupRoundNotice round={getGroupRoundPreview(started(), 1)} currentSet={2} totalSets={2} />);
+
+            expect(screen.queryByTestId('group-round-notice')).not.toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/execution/LinearCardCompactV2.jsx
+++ b/src/components/execution/LinearCardCompactV2.jsx
@@ -1,6 +1,7 @@
 import React, { useState, memo, useRef } from 'react';
 import { Minus, Plus, CheckCircle2, Info, Check, ArrowRight, Scale, LayoutList, Target, ArrowDown, TrendingUp, AlertTriangle } from 'lucide-react';
 import { NumericKeypad } from '../common/NumericKeypad';
+import { GroupRoundNotice } from './GroupRoundNotice';
 
 function generateId() {
     return Math.random().toString(36).substr(2, 9);
@@ -29,7 +30,8 @@ export const LinearCardCompactV2 = memo(function LinearCardCompactV2({
     onUpdateSetMultiple,
     onToggleWeightMode,
     onValidationError,
-    progressionHint
+    progressionHint,
+    groupRound
 }) {
     const completedCount = completedSets.filter(Boolean).length;
     const isExerciseFullyCompleted = completedCount === totalSets && totalSets > 0;
@@ -239,30 +241,45 @@ export const LinearCardCompactV2 = memo(function LinearCardCompactV2({
 
     return (
         <div className={`rounded-[24px] p-4 flex flex-col gap-3 transition-all duration-300 relative overflow-hidden ${containerClass}`}>
-            <div className="flex justify-between items-start mb-2 gap-3">
+            <div className="flex justify-between items-start gap-3">
                 <div className="flex-1 min-w-0">
                     <h3 className="text-[#e2e8f0] text-[20px] font-bold leading-tight uppercase relative" style={{ whiteSpace: 'normal', wordWrap: 'break-word', overflowWrap: 'break-word', display: 'block' }}>
                         {exerciseName}
                     </h3>
-                    <div className="flex flex-wrap items-center gap-2 mt-2 mb-0.5">
-                        <div className="flex items-center gap-1.5 bg-slate-800/50 px-2 py-0.5 rounded-md border border-slate-700/50">
-                            <LayoutList size={11} className="text-slate-400" />
-                            <span className="text-[11px] font-medium text-slate-300">{totalSets} Séries</span>
-                        </div>
-                        <div className="flex items-center gap-1.5 bg-slate-800/50 px-2 py-0.5 rounded-md border border-slate-700/50">
-                            <Target size={11} className="text-cyan-500" />
-                            <span className="text-[11px] font-bold text-cyan-400 tracking-wide">Meta: {repsGoal}</span>
-                        </div>
-                        <div onClick={onMethodClick} className="flex items-center gap-1.5 bg-slate-800/50 px-2 py-0.5 rounded-md border border-slate-700/50 cursor-pointer hover:bg-slate-700 transition-all group/badge">
-                            <Info size={11} className="text-blue-400 group-hover/badge:text-cyan-400 transition-colors" />
-                            <span className="text-[10px] font-bold text-slate-300 uppercase truncate max-w-[120px]">{method}</span>
-                        </div>
-                    </div>
                 </div>
                 <div className={`px-3 py-1.5 rounded-full text-base font-bold flex-shrink-0 border ${isExerciseFullyCompleted ? 'text-green-500 bg-green-500/10 border-green-500/30' : 'text-blue-500 bg-blue-500/10 border-blue-500/25'}`}>
                     {completedCount} / {totalSets}
                 </div>
             </div>
+
+            {/* Ocupa a largura inteira do card, e não a coluna do título: assim o
+                método fica ao lado da meta em vez de cair para a linha de baixo.
+
+                Os espaçamentos são apertados de propósito (gap-1, px-1.5, ícones
+                de 10px). A régua é "Convencional", o método padrão e a pill mais
+                larga: a 375px sobram 277px para a linha, e com o layout antigo
+                (dentro da coluna do título, px-2/gap-2/ícones 11px) faltavam
+                17px — ou seja, o caso mais comum do app quebrava. Com estes
+                valores sobram 12px. Mexer neles pede remedir. O `flex-wrap`
+                continua sendo a saída quando de fato não couber. */}
+            <div className="flex flex-wrap items-center gap-1 mt-2 mb-2">
+                <div className="flex items-center gap-1 bg-slate-800/50 px-1.5 py-0.5 rounded-md border border-slate-700/50">
+                    <LayoutList size={10} className="text-slate-400" />
+                    <span className="text-[11px] font-medium text-slate-300">{totalSets} Séries</span>
+                </div>
+                <div className="flex items-center gap-1 bg-slate-800/50 px-1.5 py-0.5 rounded-md border border-slate-700/50">
+                    <Target size={10} className="text-cyan-500" />
+                    <span className="text-[11px] font-bold text-cyan-400 tracking-wide">Meta: {repsGoal}</span>
+                </div>
+                <div onClick={onMethodClick} className="flex items-center gap-1 bg-slate-800/50 px-1.5 py-0.5 rounded-md border border-slate-700/50 cursor-pointer hover:bg-slate-700 transition-all group/badge">
+                    <Info size={10} className="text-blue-400 group-hover/badge:text-cyan-400 transition-colors" />
+                    <span className="text-[10px] font-bold text-slate-300 uppercase truncate max-w-[160px]">{method}</span>
+                </div>
+            </div>
+
+            {/* Antes do progressionHint de propósito: o que preparar vem antes
+                de quanto levantar. */}
+            <GroupRoundNotice round={groupRound} currentSet={currentSet} totalSets={totalSets} />
 
             {progressionHint && !isExerciseFullyCompleted && (
                 <div

--- a/src/pages/WorkoutExecutionPage.jsx
+++ b/src/pages/WorkoutExecutionPage.jsx
@@ -32,7 +32,7 @@ import { useWakeLock } from '../hooks/useWakeLock';
 import { useExecutionNavigation } from '../hooks/workout-execution/useExecutionNavigation';
 import { useFinishWorkoutFlow } from '../hooks/workout-execution/useFinishWorkoutFlow';
 import { useWorkoutShare } from '../hooks/workout-execution/useWorkoutShare';
-import { computeGroupSegments, focusGroupBehaviorLabel } from '../utils/exerciseGroups';
+import { computeGroupSegments, focusGroupBehaviorLabel, getGroupRoundPreview } from '../utils/exerciseGroups';
 import { computeSessionStats } from '../utils/computeSessionStats';
 import { userPreferencesService } from '../services/userPreferencesService';
 const AchievementUnlockedModal = React.lazy(() => import('../components/achievements/AchievementUnlockedModal').then(module => ({ default: module.AchievementUnlockedModal })));
@@ -315,6 +315,7 @@ export function WorkoutExecutionPage({ user }) {
                                 activeSetIndices={activeSetIndices}
                                 progression={progression}
                                 handlers={cardHandlers}
+                                groupRound={getGroupRoundPreview(exercises, currentExerciseIndex)}
                             />
                         )
                     ) : (

--- a/src/pages/WorkoutExecutionPage.test.jsx
+++ b/src/pages/WorkoutExecutionPage.test.jsx
@@ -45,8 +45,20 @@ vi.mock('../components/design-system/Skeleton', () => ({
     Skeleton: () => <div>Skeleton</div>
 }));
 
+// O card é mockado, mas expõe o `groupRound` recebido: o que esta suíte
+// verifica é a fiação (a página calcular e passar o resumo da volta). A
+// renderização dos dois estados do aviso é coberta por GroupRoundNotice.test.
 vi.mock('../components/execution/LinearCardCompactV2', () => ({
-    LinearCardCompactV2: () => <div>Card</div>
+    LinearCardCompactV2: ({ groupRound }) => (
+        <div>
+            Card
+            {groupRound && (
+                <div data-testid="card-group-round">
+                    {groupRound.label}|{groupRound.nextName}|{String(groupRound.roundNotStarted)}
+                </div>
+            )}
+        </div>
+    )
 }));
 
 vi.mock('../components/execution/RestTimer', () => ({
@@ -210,6 +222,48 @@ describe('WorkoutExecutionPage', () => {
         fireEvent.click(screen.getByRole('button', { name: 'FOCO' }));
 
         expect(screen.queryByText(/Alterna/i)).not.toBeInTheDocument();
+    });
+
+    // No Modo Foco só um exercício aparece por vez, então nada revelaria que
+    // concluir a série salta para o parceiro — que pode exigir outro
+    // equipamento. Nomear o parceiro é a informação que faltava.
+    it('passes the group round preview to the card in focus mode', () => {
+        useWorkoutSession.mockReturnValue({ ...baseReturn, exercises: groupedExercises });
+        render(<WorkoutExecutionPage user={{ uid: 'u1' }} />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'FOCO' }));
+
+        // `method` é "Convencional" nestes dados: o resumo vem do `groupId`.
+        expect(screen.getByTestId('card-group-round')).toHaveTextContent('Bi-set|Crucifixo|true');
+    });
+
+    it('omits the group round preview for an ungrouped exercise', () => {
+        render(<WorkoutExecutionPage user={{ uid: 'u1' }} />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'FOCO' }));
+
+        expect(screen.queryByTestId('card-group-round')).not.toBeInTheDocument();
+    });
+
+    it('marks the round as started once any member has a completed set', () => {
+        const started = groupedExercises.map((ex, i) =>
+            i === 0 ? { ...ex, sets: [{ ...ex.sets[0], completed: true }] } : ex
+        );
+        useWorkoutSession.mockReturnValue({ ...baseReturn, exercises: started });
+        render(<WorkoutExecutionPage user={{ uid: 'u1' }} />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'FOCO' }));
+
+        expect(screen.getByTestId('card-group-round')).toHaveTextContent('Bi-set|Crucifixo|false');
+    });
+
+    // A lista mostra os exercícios do grupo juntos na moldura do
+    // ExerciseGroupCard — lá o aviso seria redundante.
+    it('does not pass the group round preview outside focus mode', () => {
+        useWorkoutSession.mockReturnValue({ ...baseReturn, exercises: groupedExercises });
+        render(<WorkoutExecutionPage user={{ uid: 'u1' }} />);
+
+        expect(screen.queryByTestId('card-group-round')).not.toBeInTheDocument();
     });
 
     it('finishes workout and shows finish modal', async () => {

--- a/src/utils/exerciseGroups.js
+++ b/src/utils/exerciseGroups.js
@@ -102,6 +102,49 @@ export function focusGroupBehaviorLabel(exercises, index) {
 }
 
 /**
+ * Resumo da volta do grupo do exercício em `index`, para o Modo Foco.
+ *
+ * No Modo Foco só um exercício aparece por vez, então nada revela que a
+ * conclusão da série vai saltar para outro exercício — que às vezes exige
+ * outro equipamento (halter, barra, anilha). Este resumo existe para nomear
+ * os companheiros de volta *antes* da primeira série.
+ *
+ * ⚠️ Tudo aqui deriva do `groupId` (via `getGroupInfo`), inclusive o `label`,
+ * que vem do tamanho do grupo. O `method` do exercício não é lido: ele é um
+ * rótulo informativo e costuma valer "Convencional" mesmo em grupos criados
+ * pelo botão de corrente. Ver o skill `method-vs-groupid`.
+ *
+ * @returns {{ label: string,
+ *             members: Array<{ index: number, name: string, isCurrent: boolean }>,
+ *             nextIndex: number, nextName: string,
+ *             isLastMember: boolean, roundNotStarted: boolean } | null}
+ *          `null` para exercício avulso.
+ */
+export function getGroupRoundPreview(exercises, index) {
+    const group = getGroupInfo(exercises, index);
+    if (!group) return null;
+
+    // No último membro a volta reinicia no primeiro do grupo — o mesmo destino
+    // que `useExecutionNavigation` escolhe enquanto restam séries.
+    const nextIndex = group.nextMemberIndex !== null ? group.nextMemberIndex : group.firstIndex;
+
+    return {
+        label: group.label,
+        members: group.indices.map(i => ({
+            index: i,
+            name: exercises[i]?.name || '',
+            isCurrent: i === index
+        })),
+        nextIndex,
+        nextName: exercises[nextIndex]?.name || '',
+        isLastMember: group.isLastMember,
+        roundNotStarted: group.indices.every(
+            i => !(exercises[i]?.sets || []).some(set => set?.completed)
+        )
+    };
+}
+
+/**
  * Liga/desliga o exercício em `index` ao grupo do exercício anterior.
  * Retorna uma nova lista (não muta a original).
  */

--- a/src/utils/exerciseGroups.test.js
+++ b/src/utils/exerciseGroups.test.js
@@ -3,6 +3,7 @@ import {
     groupLabel,
     groupBehaviorLabel,
     focusGroupBehaviorLabel,
+    getGroupRoundPreview,
     computeGroupSegments,
     getGroupInfo,
     toggleGroupWithPrevious,
@@ -108,6 +109,91 @@ describe('focusGroupBehaviorLabel', () => {
     it('ignora diferença de caixa e espaços no método', () => {
         const list = [withMethod('a', 'g1', '  bi-SET '), withMethod('b', 'g1', 'Bi-set')];
         expect(focusGroupBehaviorLabel(list, 0)).toBeNull();
+    });
+});
+
+describe('getGroupRoundPreview', () => {
+    // `sets` entra aqui só para o cálculo de `roundNotStarted`.
+    const withSets = (id, groupId, completedFlags) => ({
+        id,
+        name: `Exercício ${id}`,
+        ...(groupId ? { groupId } : {}),
+        sets: completedFlags.map(completed => ({ completed }))
+    });
+
+    const pair = () => [
+        withSets('a', 'g1', [false, false]),
+        withSets('b', 'g1', [false, false])
+    ];
+
+    it('retorna null para exercício avulso', () => {
+        const list = [withSets('a', null, [false]), withSets('b', 'g1', [false]), withSets('c', 'g1', [false])];
+        expect(getGroupRoundPreview(list, 0)).toBeNull();
+    });
+
+    // O rótulo vem do TAMANHO do grupo, nunca do campo `method` — um bi-set
+    // feito pelo botão de corrente costuma manter `method: "Convencional"`.
+    it('nomeia o grupo pelo tamanho, ignorando o method', () => {
+        const list = pair().map(ex => ({ ...ex, method: 'Convencional' }));
+        expect(getGroupRoundPreview(list, 0).label).toBe('Bi-set');
+    });
+
+    it('lista os membros na ordem e marca o atual', () => {
+        const preview = getGroupRoundPreview(pair(), 1);
+        expect(preview.members).toEqual([
+            { index: 0, name: 'Exercício a', isCurrent: false },
+            { index: 1, name: 'Exercício b', isCurrent: true }
+        ]);
+    });
+
+    it('aponta para o próximo membro do grupo', () => {
+        const preview = getGroupRoundPreview(pair(), 0);
+        expect(preview.isLastMember).toBe(false);
+        expect(preview.nextIndex).toBe(1);
+        expect(preview.nextName).toBe('Exercício b');
+    });
+
+    // No último membro a volta reinicia no primeiro — é o que
+    // `useExecutionNavigation` faz quando ainda restam séries.
+    it('no último membro, volta para o primeiro do grupo', () => {
+        const preview = getGroupRoundPreview(pair(), 1);
+        expect(preview.isLastMember).toBe(true);
+        expect(preview.nextIndex).toBe(0);
+        expect(preview.nextName).toBe('Exercício a');
+    });
+
+    it('roundNotStarted é verdadeiro só enquanto nenhum membro tem série concluída', () => {
+        expect(getGroupRoundPreview(pair(), 0).roundNotStarted).toBe(true);
+
+        const started = [
+            withSets('a', 'g1', [true, false]),
+            withSets('b', 'g1', [false, false])
+        ];
+        expect(getGroupRoundPreview(started, 0).roundNotStarted).toBe(false);
+
+        // Série concluída no parceiro também conta: a volta já começou.
+        const partnerStarted = [
+            withSets('a', 'g1', [false, false]),
+            withSets('b', 'g1', [true, false])
+        ];
+        expect(getGroupRoundPreview(partnerStarted, 0).roundNotStarted).toBe(false);
+    });
+
+    it('trata exercício sem sets como volta não iniciada', () => {
+        const list = [ex('a', 'g1'), ex('b', 'g1')];
+        expect(getGroupRoundPreview(list, 0).roundNotStarted).toBe(true);
+    });
+
+    it('funciona com grupos maiores que dois', () => {
+        const trio = [
+            withSets('a', 'g1', [false]),
+            withSets('b', 'g1', [false]),
+            withSets('c', 'g1', [false])
+        ];
+        const preview = getGroupRoundPreview(trio, 1);
+        expect(preview.label).toBe('Tri-set');
+        expect(preview.members).toHaveLength(3);
+        expect(preview.nextIndex).toBe(2);
     });
 });
 


### PR DESCRIPTION
## Contexto

Dois problemas observados em uso real, num treino com bi-set importado por PDF (`groupId` definido **e** `method: "Bi-set"`).

**1. Nada avisava que o exercício era um bi-set antes da série 1.** No Modo Foco só um exercício aparece por vez. Ao concluir a série, `useExecutionNavigation` salta para o parceiro do grupo — que às vezes exige outro equipamento (halter, barra, anilha). O usuário começava a volta e precisava levantar no meio dela para buscar.

A tag `BI-SET` do card não resolvia: ela nomeia o *método*, nunca o *exercício parceiro*. E `focusGroupBehaviorLabel` omite de propósito a pill "Alterna em dupla" justamente quando `method === "Bi-set"` — o caso das fichas vindas do PDF.

**2. A tag do método caía para a linha de baixo.** As três pills (`4 Séries`, `Meta: 15`, `BI-SET`) dividiam a coluna `flex-1 min-w-0` com o contador `0 / 4`, sobrando ~219px para ~248px de conteúdo.

## O que mudou

**Aviso de volta de grupo** (`GroupRoundNotice`, só no Modo Foco — na lista os exercícios do grupo já aparecem juntos na moldura do `ExerciseGroupCard`). Dois estados:

- **Volta zerada** → bloco listando os exercícios do grupo em ordem, com o atual marcado "AGORA". É quando ainda dá para separar tudo sem interromper nada.
- **Volta em andamento** → uma linha só: "DEPOIS DESTA SÉRIE / PUXADA PEGADA SUPINADA". No último membro vira "volta para"; e na última série do grupo some, porque aí a navegação segue para o próximo exercício da ficha.

Rótulo e nome ficam **empilhados**, e a lista de preparo **não trunca**: nomes de bi-set costumam diferir só no fim ("Puxada pela frente pronada" vs "Puxada pegada supinada"), então cortar apagaria justamente o que distingue um do outro. Isso foi pego na verificação visual, não pelos testes.

**Linha de pills** sai da coluna do título e ocupa a largura inteira do card. A régua é `"Convencional"` — o método padrão e a pill mais larga: mover sozinho não bastava, ainda faltavam 17px a 375px. Os espaçamentos foram apertados (`gap-1`, `px-1.5`, ícones de 10px) até sobrarem 12px. Em tela mais estreita o `flex-wrap` continua sendo a saída.

## `groupId`, nunca `method`

O novo `getGroupRoundPreview` deriva tudo de `getGroupInfo`, inclusive o `label`, que vem do **tamanho** do grupo. Verificado no browser que o aviso aparece com `method: "Convencional"` — o caso do botão de corrente, que foi o que o #47 quebrou. Nada do que existia foi removido: a pill do `FocusModeNav` e a moldura do `ExerciseGroupCard` continuam como estavam.

## Verificação

- `npx eslint src/ api/` → exit 0
- 321 testes Vitest, 12 das Cloud Functions, build de produção OK
- Visual num preview temporário com os componentes reais, a 375px e 320px: cinco cenários (volta zerada, em andamento, último membro, grupo com `method` "Convencional", exercício avulso). Medido por DOM que as três pills ficam na mesma linha e que nenhum nome é truncado.

⚠️ **Ainda não testado em produção no iPhone** — é o próximo passo, já que preview da Vercel não autentica nem lê o Firestore.

## Fora de escopo

Um terceiro pedido do mesmo report — mover os avisos do topo para o centro da tela (o `Toast` da execução e o `sonner`) — ficou de fora de propósito, para revisar depois que estas mudanças forem validadas no aparelho.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
