### PR TITLE
fix: mover o aviso do treino para o centro da tela

### DIFF
--- a/src/components/design-system/Toast.jsx
+++ b/src/components/design-system/Toast.jsx
@@ -17,13 +17,26 @@ export function Toast({ message, type = 'error', onClose, duration = 3000 }) {
     };
 
     const icons = {
-        success: <CheckCircle2 size={20} className="text-white" />,
-        error: <AlertCircle size={20} className="text-white" />,
-        info: <AlertCircle size={20} className="text-white" />
+        success: <CheckCircle2 size={20} className="text-white shrink-0" />,
+        error: <AlertCircle size={20} className="text-white shrink-0" />,
+        info: <AlertCircle size={20} className="text-white shrink-0" />
     };
 
+    // Centralizado, e não no topo: ancorado em `top-6` o aviso ficava atrás da
+    // status bar do iPhone (relógio/bateria) e passava despercebido. No centro
+    // ele cai logo acima dos campos de peso/repetições da tela de execução —
+    // aponta para o campo que a mensagem manda corrigir, sem cobri-lo.
+    //
+    // Só este Toast mudou; os toasts do `sonner` (o verde de "salvo" e os avisos
+    // do resto do app) continuam no topo, por decisão do usuário em 31/07/2026.
+    //
+    // O eixo X usa `inset-x-4 mx-auto w-fit`, e não `left-1/2 -translate-x-1/2`:
+    // com `left-1/2` o elemento começa na metade da tela e só tem metade da
+    // largura para diagramar, então "Preencha peso e repetições em todas as
+    // sub-séries." quebrava numa coluna estreita de cinco linhas. O `mx-auto`
+    // centraliza dentro dos recuos sem estrangular a largura disponível.
     return (
-        <div className={`fixed top-6 left-1/2 -translate-x-1/2 z-[200] flex items-center gap-3 px-5 py-3 rounded-2xl shadow-xl text-white ${colors[type] || colors.error} animate-bounce-in transition-all`}>
+        <div className={`fixed top-1/2 -translate-y-1/2 inset-x-4 mx-auto w-fit max-w-[28rem] z-[200] flex items-center gap-3 px-5 py-3 rounded-2xl shadow-xl text-white ${colors[type] || colors.error} transition-all`}>
             {icons[type] || icons.error}
             <span className="font-bold text-sm">{message}</span>
             <button


### PR DESCRIPTION
## Contexto

Terceiro item do report que gerou o #50. Ancorado em `top-6`, o aviso de validação da tela de execução ficava atrás da status bar do iPhone (relógio/bateria) e passava despercebido — justamente quando o usuário acabara de tocar em CONCLUIR SÉRIE e precisava saber por que nada aconteceu.

No centro ele cai logo acima dos campos de peso/repetições: aponta para o campo que a mensagem manda corrigir, sem cobri-lo. Isso foi medido na screenshot do #50 rodando em produção no iPhone — o centro exato da tela cai na altura do stepper, com os controles de peso bem abaixo.

**Escopo:** só o `Toast` da execução. Os toasts do `sonner` (o verde de "salvo", e os avisos de perfil, lista de treinos e importação de PDF) continuam no topo, por decisão do usuário.

## Dois defeitos que a centralização deixou visíveis

Ambos são anteriores a esta mudança — o layout horizontal é o mesmo — mas ficavam disfarçados no topo.

**Largura.** O eixo X usava `left-1/2 -translate-x-1/2`. Com `left-1/2` o elemento começa na metade da tela e só tem metade da largura para diagramar, então `"Preencha peso e repetições em todas as sub-séries."` quebrava numa coluna estreita de **cinco linhas**. Passou a usar `inset-x-4 mx-auto w-fit`, que centraliza dentro dos recuos sem estrangular a largura: agora quebra em duas linhas.

**Ícone esmagado.** Sem `shrink-0`, o flex comprimia o ícone a quase nada quando a mensagem era longa.

Removida também a classe `animate-bounce-in`, que não existe no `@theme` do `index.css` nem no `tailwind.config.js` (Tailwind v4, sem `extend`) — era código morto.

## Verificação

- `npx eslint src/ api/` → exit 0
- 321 testes Vitest, 12 das Cloud Functions, build de produção OK
- Visual a 393×852 (iPhone 15/16) com as duas mensagens que o app produz: a longa (`Preencha peso e repetições…`) e a curta (`Informe o peso utilizado.`). Medido por DOM: 361px de largura, de 16 a 377 num viewport de 393 — largura útil cheia e centralizado.

⚠️ Ainda não testado em produção no iPhone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
