### PR TITLE
chore: ignora .claude/** no ESLint para não lintar worktrees locais

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,7 +8,9 @@ import pluginCypress from 'eslint-plugin-cypress/flat'
 import pluginReact from 'eslint-plugin-react'
 
 export default defineConfig([
-  globalIgnores(['dist', 'dev-dist', 'coverage']),
+  // '.claude/**' porque padrões de flat config são ancorados na raiz: 'dist' e
+  // 'dev-dist' não alcançam as cópias dentro de .claude/worktrees/<branch>/.
+  globalIgnores(['dist', 'dev-dist', 'coverage', '.claude/**']),
   pluginCypress.configs.recommended,
   pluginReact.configs.flat.recommended,
   {


### PR DESCRIPTION
## Problema

`npm run lint` local reportava **698 erros — todos** vindos de `.claude/worktrees/`, pasta não versionada onde o Claude Code cria worktrees. O código real do projeto sempre passou limpo.

| Origem | Erros |
|---|---|
| `.claude/worktrees/*/dist/` | 605 |
| `.claude/worktrees/*/dev-dist/` | 33 |
| `.claude/worktrees/*/api/` e `functions/` | 60 |

O CI **nunca foi afetado** — um checkout limpo não tem essa pasta. Mas localmente o comando ficava inutilizável, e o `CLAUDE.md` manda rodar lint antes de commitar.

## Causa

Os padrões de ignore do flat config são **ancorados na raiz do projeto**, não são gitignore-style. `'dist'` casa com `<raiz>/dist` e nunca com `<raiz>/.claude/worktrees/x/dist`.

Confirmado via API do ESLint:

```
IGNORADO dist/index.js              LINTADO .claude/worktrees/w/dist/index.js
IGNORADO dev-dist/sw.js             LINTADO .claude/worktrees/w/dev-dist/sw.js
IGNORADO coverage/lcov-report/x.js  LINTADO .claude/worktrees/w/coverage/x.js
```

A mesma ancoragem explica os 60 erros em `api/` e `functions/`, todos `no-undef: 'process' is not defined`: o bloco `files: ['functions/**/*.js', 'api/**/*.js']` que injeta os globals do Node também não alcança cópias aninhadas. Não é código quebrado.

## Solução

Uma entrada `.claude/**` no `globalIgnores` que já existia.

Não foi preciso acrescentar `dist/**`, `dev-dist/**` nem `coverage/**`: na raiz os três já eram ignorados corretamente, e as cópias aninhadas passam a ser cobertas pelo próprio `.claude/**`.

Sem impacto no CI: sob `.claude/` há 12 arquivos versionados (11 `SKILL.md` + `launch.json`) e **zero** JS/JSX, então num checkout limpo o ignore é no-op.

## Verificação

`npm run lint` no repo principal: exit **1 → 0**.

O número que importa é a contagem de arquivos varridos, que garante que nada legítimo saiu do lint:

| | antes | depois |
|---|---|---|
| arquivos analisados fora de `.claude/` | 207 | **207** |
| arquivos analisados dentro de `.claude/` | 477 | 0 |
| erros | 698 | 0 |

Sequência completa do `ci.yml`, 6/6 exit 0:

| Passo | Resultado |
|---|---|
| `npm run lint` | limpo |
| `npm test -- --run` | 39 arquivos, 302 testes |
| `npm --prefix functions test` | 2 arquivos, 12 testes |
| `npm run test:rules` | 12 testes (emulador) |
| `npm run build` | built in 2.53s |
| `npm run test:coverage` | 302 testes, 61,23% linhas |

Ressalva: o `test:rules` rodou com Java 26 localmente, enquanto o CI usa Java 21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)