### PR TITLE
fix: aviso verde no centro da tela e em tema escuro

### DIFF
--- a/src/AppAuthed.jsx
+++ b/src/AppAuthed.jsx
@@ -442,9 +442,27 @@ function AppAuthedContent() {
                 </div>
             </div>
 
+            {/*
+              * `theme="dark"`: sem isso o sonner usa o tema claro por padrão, e o
+              * aviso saía num bloco quase branco no meio de um app todo escuro.
+              *
+              * `offset` no eixo Y: ancorado no topo, o aviso ficava atrás da status
+              * bar do iPhone e chegava a cobrir o título da tela. `42vh` ancora a
+              * borda de cima e cai opticamente no centro — é a API pública do
+              * sonner, preferida a sobrescrever CSS porque o pacote anima
+              * `transform` no eixo X e uma sobrescrita brigaria com isso.
+              * Objeto parcial: o sonner completa os lados omitidos com os padrões
+              * dele (24px no desktop, 16px no mobile).
+              */}
             {shouldRenderToaster && (
                 <Suspense fallback={null}>
-                    <SonnerToaster richColors position="top-center" />
+                    <SonnerToaster
+                        richColors
+                        theme="dark"
+                        position="top-center"
+                        offset={{ top: '42vh' }}
+                        mobileOffset={{ top: '42vh' }}
+                    />
                 </Suspense>
             )}
 


### PR DESCRIPTION
## Contexto

Fecha o report que gerou os #50 e #51. O aviso da tela de execução já foi tratado no #51 (componente próprio); este cobre os **oito lugares** que passam pelo `sonner`:

| Onde | Mensagens |
|---|---|
| Lista de fichas | "Treino duplicado", "arquivado", "desarquivado", "excluído", "adicionado às suas fichas" |
| Perfil | "Perfil atualizado", "Personal vinculado", "Exportação criada" |
| Cardio | "Cardio registrado com sucesso!" |
| Importação por PDF | "Treino salvo. Revise o próximo (2 de 5)" |

Dois problemas, os dois só evidentes ao ver o componente renderizado lado a lado num iPhone simulado:

**Posição.** Ancorado no topo, o aviso ficava atrás da status bar e chegava a **cobrir o título da tela** — some antes de ser lido.

**Tema.** O `sonner` estava sem a prop `theme`, cujo padrão é **claro**. O aviso saía num bloco quase branco no meio de um app todo escuro: parecia alerta do sistema colado por cima, não parte da interface.

## O que mudou

```jsx
<SonnerToaster
    richColors
    theme="dark"
    position="top-center"
    offset={{ top: '42vh' }}
    mobileOffset={{ top: '42vh' }}
/>
```

`offset`/`mobileOffset` em vez de sobrescrever CSS: o sonner ancora o container por `top`/`bottom` e usa `transform` para o eixo X (`translateX(-50%)` no desktop, `none` no mobile, com `transition: transform .4s`). Sobrescrever `transform` brigaria com isso. O `42vh` ancora a borda de cima e cai opticamente no centro — trade-off consciente: é centro visual, não 50% exato.

Objeto parcial de propósito. Verificado em `node_modules/sonner/dist/index.mjs` (`assignOffset`): lados omitidos recebem os padrões do próprio sonner (24px desktop, 16px mobile), então os recuos horizontais seguem corretos.

Com `theme="dark"` + `richColors`, o sucesso fica `hsl(150,100%,6%)` de fundo com texto `hsl(150,86%,65%)` — mesma família do `emerald` que o app já usa para sucesso.

## Descartado no caminho

Cogitamos trocar o aviso por um **popup com OK**. Descartado: a própria tela já confirma a maioria dessas ações — você exclui uma ficha e ela some da lista, duplica e a cópia aparece. O popup cobraria um toque para repetir o que os olhos já viram. As duas exceções reais ("Perfil atualizado" e "Exportação criada", onde nada muda na tela) ficam resolvidas pela visibilidade nova; se ainda escaparem no uso, dá para promover só elas depois.

## Verificação

- `npx eslint src/ api/` → exit 0
- 321 testes Vitest, 12 das Cloud Functions, build de produção OK
- Comparação visual a 393×852 com o `Toaster` real e as mesmas props, em três variantes (hoje / só recentralizado / recentralizado + escuro). A variante 2 deixou claro que mudar só a posição resolvia pela metade.

⚠️ Ainda não testado em produção no iPhone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
