### PR TITLE
chore: padroniza o projeto em Node 24 + npm 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       
-      - name: Use Node.js 22
+      - name: Use Node.js 24
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'npm'
           cache-dependency-path: |
             package-lock.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "vitest": "^4.0.17"
       },
       "engines": {
-        "node": "22.x || 24.x"
+        "node": "24.x"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -17075,26 +17075,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/proxy-agent-negotiate": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent-negotiate/-/proxy-agent-negotiate-1.1.0.tgz",
-      "integrity": "sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "kerberos": "^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "kerberos": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/proxy-agent/node_modules/lru-cache": {
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
@@ -17200,18 +17180,6 @@
         }
       }
     },
-    "node_modules/puppeteer-core/node_modules/agent-base": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
-      "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20"
-      }
-    },
     "node_modules/puppeteer-core/node_modules/ansi-regex": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
@@ -17253,38 +17221,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/puppeteer-core/node_modules/data-uri-to-buffer": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-8.0.0.tgz",
-      "integrity": "sha512-6UHfyCux51b8PTGDgveqtz1tvphBku5DrMKKJbFAZAJOI2zsjDpDoYE1+QGj7FOMS4BdTFNJsJiR3zEB0xH0yQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/degenerator": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-7.0.1.tgz",
-      "integrity": "sha512-ABErK0IefDSyHjlPH7WUEenIAX2rPPnrDcDM+TS3z3+zu9TfyKKi07BQM+8rmxpdE2y1v5fjjdoAS/x4D2U60w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "ast-types": "^0.13.4",
-        "escodegen": "^2.1.0",
-        "esprima": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "quickjs-wasi": "^2.2.0"
-      }
-    },
     "node_modules/puppeteer-core/node_modules/devtools-protocol": {
       "version": "0.0.1638949",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1638949.tgz",
@@ -17298,161 +17234,6 @@
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/puppeteer-core/node_modules/get-uri": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-8.0.1.tgz",
-      "integrity": "sha512-/5N/P4Lrh0p/mDwlDRi7Y1+P2o/OyzZI3l6Iz1Ov6XXwwm1y3RlZLuo3gVgML99djrEDtV980bBxSuOeHLk8ww==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "basic-ftp": "^5.3.1",
-        "data-uri-to-buffer": "8.0.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/http-proxy-agent": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-9.1.0.tgz",
-      "integrity": "sha512-2NxoveTT58mjYT4n3RPTEfCZGLMbidoO8XEieXfpSYxu+PQJ1qpx4ypwH6N+uF9twBPIvRRgvkvW5HUTYWENig==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "9.0.0",
-        "debug": "^4.3.4",
-        "proxy-agent-negotiate": "1.1.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/https-proxy-agent": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.1.0.tgz",
-      "integrity": "sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "9.0.0",
-        "debug": "^4.3.4",
-        "proxy-agent-negotiate": "1.1.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/pac-proxy-agent": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-9.1.0.tgz",
-      "integrity": "sha512-1aU+1mpj3DrQPfo3gh+3Gap3G5x+axnMx1P/y0ZF2ch7kb2meyOCAH8K2k9d27ROsTE7TnAerzxqF9aon2jqnA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "9.0.0",
-        "debug": "^4.3.4",
-        "get-uri": "8.0.1",
-        "http-proxy-agent": "9.1.0",
-        "https-proxy-agent": "9.1.0",
-        "pac-resolver": "9.0.1",
-        "quickjs-wasi": "^2.2.0",
-        "socks-proxy-agent": "10.1.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/pac-resolver": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-9.0.1.tgz",
-      "integrity": "sha512-lJbS008tmkj08VhoM8Hzuv/VE5tK9MS0OIQ/7+s0lIF+BYhiQWFYzkSpML7lXs9iBu2jfmzBTLzhe9n6BX+dYw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "degenerator": "7.0.1",
-        "netmask": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "quickjs-wasi": "^2.2.0"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/proxy-agent": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-8.0.2.tgz",
-      "integrity": "sha512-idLLRewuemWd7GH/BDJzGiB0dWGfT2SQs3jy6NtZtGWU9uPTTSdeC1/cdbqLwgzhfv027daGFuXX426e2Eg20A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "9.0.0",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "9.1.0",
-        "https-proxy-agent": "9.1.0",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "9.1.0",
-        "proxy-from-env": "^2.0.0",
-        "socks-proxy-agent": "10.1.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/socks-proxy-agent": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-10.1.0.tgz",
-      "integrity": "sha512-WlMj/67cEJ6MDI1OcsnjuYKDNDoyPCCYZ249kuuXPiMDw9F8PXkVaQ7YWu3siTydfQ/4BEZcvGzu+aYvz7dDCQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "9.0.0",
-        "debug": "^4.3.4",
-        "socks": "^2.8.3"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
     },
     "node_modules/puppeteer-core/node_modules/string-width": {
       "version": "7.2.0",
@@ -17550,15 +17331,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/quickjs-wasi": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/quickjs-wasi/-/quickjs-wasi-2.2.0.tgz",
-      "integrity": "sha512-zQxXmQMrEoD3S+jQdYsloq4qAuaxKFHZj6hHqOYGwB2iQZH+q9e/lf5zQPXCKOk0WJuAjzRFbO4KwHIp2D05Iw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/railroad-diagrams": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "treino",
   "private": true,
   "version": "0.0.0",
-  "packageManager": "npm@10.9.4",
+  "packageManager": "npm@11.17.0",
   "engines": {
-    "node": "22.x || 24.x"
+    "node": "24.x"
   },
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Contexto

Um `brew upgrade` levou o ambiente local para Node 26 / npm 11, e isso expôs uma divergência que já existia no projeto:

| onde | Node | npm |
|---|---|---|
| `.nvmrc` | **24** | 11 |
| Vercel (produção) | **24.x** | 11 |
| CI (`ci.yml`) | **22** | 10 |
| `packageManager` | — | **10.9.4** |

A Vercel já buildava produção em Node 24 com npm 11. Só o CI seguia no 22.

## O diagnóstico

Essa divergência é a causa real do incidente de 23/07 (`e8b8812`). **O npm 11 não corrompe o lockfile** — ele e o npm 10 apenas discordam sobre 14 entradas aninhadas (subárvore de proxy do `puppeteer-core`, transitiva do `lighthouse`, mais `quickjs-wasi`), e cada um é internamente coerente.

Testado nos dois sentidos com o lockfile real do projeto:

| lock escrito por | lido por `npm ci` | resultado |
|---|---|---|
| npm 11 | npm 10.9.4 | ❌ `EUSAGE — Missing: proxy-agent@8.0.2 from lock file` |
| npm 11 | npm 11.17 | ✅ `added 1487 packages` |

Ou seja: o problema nunca foi a versão, foi **escritor e leitor discordarem**.

## A escolha

Em vez de arrastar o projeto de volta ao npm 10, alinha tudo no npm 11 — que é o que o Node 24 traz por padrão. Isso faz o **comportamento padrão** de quem clona o repo virar o correto, em vez de depender de lembrar de usar uma versão específica do npm ao instalar dependências.

Node 24 porque é o LTS ativo (manutenção em out/2026, EOL abr/2028), contra um Node 22 que já está em manutenção e morre em abr/2027. O `firebase-tools` 15.x suporta `nodejs24` e a Vercel já está em `24.x`.

## Mudanças

- `ci.yml`: `node-version` 22 → 24
- `packageManager`: `npm@10.9.4` → `npm@11.17.0`
- `engines.node`: `"22.x || 24.x"` → `"24.x"` — o 22 traz npm 10 e reintroduziria o problema, então deixa de ser suportado
- `package-lock.json` regerado com npm 11 (−14 entradas, −229 linhas)

O `.nvmrc` já estava em 24 e não muda. O `functions/package-lock.json` foi regerado e ficou **idêntico** — npm 10 e 11 concordam ali.

## Fora do escopo, de propósito

O runtime das Cloud Functions segue em `nodejs22` (`firebase.json` e `functions/engines`). É o que o Google executa em produção e a troca merece PR próprio com deploy verificado. Consequência: `npm ci --prefix functions` passa a emitir um warning `EBADENGINE` no CI (esperado, exit 0).

## Verificação

Sequência completa do `ci.yml` rodada localmente em **Node 24.19.0 + npm 11.17.0**, 6/6 exit 0:

| Passo | Resultado |
|---|---|
| `npm ci` (raiz e functions) | `added 1487 packages`, lock consumível |
| `npm run lint` | limpo |
| `npm test -- --run` | 40 arquivos, 321 testes |
| `npm --prefix functions test` | 2 arquivos, 12 testes |
| `npm run test:rules` | 12 testes (emulador) |
| `npm run build` | built in 2.95s |
| `npm run test:coverage` | 321 testes, 61,37% linhas |

🤖 Generated with [Claude Code](https://claude.com/claude-code)