### PR TITLE
chore: sobe o runtime das Cloud Functions para nodejs24

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,7 +1,7 @@
 {
   "functions": {
     "source": "functions",
-    "runtime": "nodejs22"
+    "runtime": "nodejs24"
   },
   "firestore": {
     "rules": "firestore.rules",

--- a/functions/package.json
+++ b/functions/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "main": "src/index.js",
   "engines": {
-    "node": "22"
+    "node": "24"
   },
   "scripts": {
     "backfill:user-stats": "node scripts/backfillUserStats.js",


### PR DESCRIPTION
## Contexto

Fecha a pendência deixada pelo #54, que padronizou o projeto em **Node 24 + npm 11** mas manteve as Functions em `nodejs22` de propósito — por ser mudança de produção, merecia PR próprio.

Com o CI já rodando Node 24, o `npm ci --prefix functions` passou a emitir **5 warnings `EBADENGINE`** por rodada, porque `functions/package.json` declarava `node: "22"`.

## Por que nodejs24

Está **GA** no `firebase-tools` 15.x (não é preview) e compra um ano a mais de fôlego:

| runtime | status | depreciação | desativação |
|---|---|---|---|
| nodejs22 | GA | **2027-04-30** | 2028-10-31 |
| nodejs24 | GA | **2028-04-30** | 2028-10-31 |

## Mudanças

- `firebase.json`: `runtime` `nodejs22` → `nodejs24`
- `functions/package.json`: `engines.node` `22` → `24`

O `functions/package-lock.json` **não muda** — a troca de `engines` não afeta a resolução de dependências.

## Verificação

Com Node 24.19.0 + npm 11.17.0:

| | antes | depois |
|---|---|---|
| `EBADENGINE` em `npm ci --prefix functions` | **5** | **0** |

Sequência completa do `ci.yml`, 6/6 exit 0:

| Passo | Resultado |
|---|---|
| `npm run lint` | limpo |
| `npm test -- --run` | 321 testes |
| `npm --prefix functions test` | 12 testes |
| `npm run test:rules` | 12 testes (emulador) |
| `npm run build` | ok |
| `npm run test:coverage` | ok |

## ⚠️ Validação pendente

Este PR muda **o runtime que o Google executa em produção**. O CI verde prova que o código roda em Node 24 e que a configuração é aceita localmente, mas **a validação real é um deploy** — que não foi executado:

```
firebase deploy --only functions
```

Recomendo mergear e deployar em seguida, verificando os logs das Functions. Vale lembrar que a `VITE_ENABLE_SERVER_USER_STATS` está desligada por padrão, então a Cloud Function de user_stats não é lida pelo app — o raio de impacto de um problema aqui é menor do que parece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)