### PR TITLE
fix: sincroniza o functions/package-lock.json com engines node 24

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -13,7 +13,7 @@
         "vitest": "^4.0.17"
       },
       "engines": {
-        "node": "22"
+        "node": "24"
       }
     },
     "node_modules/@emnapi/core": {


### PR DESCRIPTION
Corrige uma inconsistência deixada pelo #55, apontada pela revisão automática do Codex naquele PR.

## O problema

O #55 subiu `functions/package.json` para `engines.node: "24"` mas deixou o `packages[""].engines` do `functions/package-lock.json` em `"22"`:

| arquivo | valor |
|---|---|
| `functions/package.json` | `24` |
| `functions/package-lock.json` → `packages[""].engines.node` | **`22`** |

Consequência: o próximo `npm install` dentro de `functions` reescreveria essa linha sozinho, produzindo um diff de lockfile sem relação nenhuma com a mudança que a pessoa estivesse fazendo.

Confirmado antes de corrigir — rodando `npm install --package-lock-only --prefix functions` numa cópia isolada:

```
16c16
<         "node": "22"
---
>         "node": "24"
```

## Por que passou despercebido no #55

A verificação de lá usou `npm ci`, que **nunca escreve** no lockfile. Só o caminho de leitura foi exercitado; o de escrita, onde a divergência aparece, não. Uma linha de código, mas a lição de verificação é a mesma que o #54 já tinha documentado: `install` e `ci` fazem coisas opostas.

## Verificação

Com Node 24.19.0 + npm 11.17.0:

| | resultado |
|---|---|
| `npm install --package-lock-only --prefix functions` | **idempotente** — não gera mais diff |
| `npm ci --prefix functions` | `added 297 packages`, **0** `EBADENGINE` |
| `npm --prefix functions test` | 2 arquivos, 12 testes |

Sequência completa do `ci.yml`, 6/6 exit 0: lint, 321 testes, functions, regras do Firestore, build e coverage.

Diff: **1 linha**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)