### PR TITLE
feat: identifica treino duplicado e reorganiza topo e rodapé

### DIFF
--- a/src/components/workout/SourceFilterChips.jsx
+++ b/src/components/workout/SourceFilterChips.jsx
@@ -1,0 +1,73 @@
+import { useCallback, useLayoutEffect, useRef, useState } from 'react';
+import { SOURCE_FILTERS } from '../../utils/workoutSourceFilter';
+
+/**
+ * Filtros de origem das fichas em uma faixa rolável de chips.
+ *
+ * O grid 2x2 anterior tomava uma faixa alta da tela antes do primeiro treino.
+ * Os quatro rótulos não cabem na largura de um iPhone, então a faixa rola — e
+ * um degradê na borda direita avisa que ainda há filtro fora da tela; sem ele
+ * "Arquivados" simplesmente não existiria para quem não tentasse arrastar.
+ *
+ * O contador é decorativo (`aria-hidden`): a lista logo abaixo já é a resposta
+ * para leitores de tela, e mantê-lo fora do nome acessível deixa cada chip
+ * anunciado só pelo próprio rótulo.
+ */
+export function SourceFilterChips({ value, counts, onChange }) {
+    const stripRef = useRef(null);
+    const [showEndFade, setShowEndFade] = useState(false);
+
+    const syncFade = useCallback(() => {
+        const strip = stripRef.current;
+        if (!strip) return;
+        const remaining = strip.scrollWidth - strip.clientWidth - strip.scrollLeft;
+        setShowEndFade(remaining > 8);
+    }, []);
+
+    useLayoutEffect(() => {
+        syncFade();
+        window.addEventListener('resize', syncFade);
+        return () => window.removeEventListener('resize', syncFade);
+    }, [syncFade]);
+
+    return (
+        <div className="relative border-t border-slate-800/70">
+            <div
+                ref={stripRef}
+                onScroll={syncFade}
+                className="no-scrollbar flex snap-x gap-1.5 overflow-x-auto px-3 py-2.5"
+            >
+                {SOURCE_FILTERS.map(({ id, label }) => {
+                    const isActive = value === id;
+                    return (
+                        <button
+                            key={id}
+                            type="button"
+                            aria-pressed={isActive}
+                            onClick={() => onChange(id)}
+                            className={`inline-flex shrink-0 snap-start items-center gap-1.5 whitespace-nowrap rounded-full px-3 py-1.5 text-xs font-semibold transition-colors ${isActive
+                                ? 'bg-cyan-500 text-black shadow-lg shadow-cyan-500/20'
+                                : 'border border-slate-800 bg-slate-900/60 text-slate-400 hover:bg-slate-800 hover:text-white'
+                                }`}
+                        >
+                            {label}
+                            <span
+                                aria-hidden="true"
+                                className={`rounded-full px-1.5 text-[10px] font-bold tabular-nums ${isActive ? 'bg-black/20 text-black' : 'bg-slate-800 text-slate-400'}`}
+                            >
+                                {counts[id] ?? 0}
+                            </span>
+                        </button>
+                    );
+                })}
+            </div>
+
+            {showEndFade && (
+                <div
+                    aria-hidden="true"
+                    className="pointer-events-none absolute inset-y-0 right-0 w-10 bg-gradient-to-l from-slate-950 to-transparent"
+                />
+            )}
+        </div>
+    );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -342,3 +342,16 @@
         }
     }
 }
+
+/*
+ * Faixa rolável sem barra visível (filtros em chips de "Meus Treinos"). A
+ * rolagem continua funcionando por toque e por teclado — só a barra some.
+ */
+@utility no-scrollbar {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+
+    &::-webkit-scrollbar {
+        display: none;
+    }
+}

--- a/src/pages/WorkoutExecutionPage.jsx
+++ b/src/pages/WorkoutExecutionPage.jsx
@@ -213,14 +213,16 @@ export function WorkoutExecutionPage({ user }) {
         onValidationError: setError
     };
 
+    // Altura exata da área visível — não `min-h-screen`. O `body` já consome os
+    // dois safe-area insets (index.css), então `100vh` puro deixaria a página
+    // mais alta que a tela e o rodapé nunca encostaria embaixo. Com
+    // `flex flex-col`, o `<main>` toma a sobra e empurra o "FINALIZAR TREINO"
+    // para o fim da tela, sem precisar de botão flutuante.
     return (
         <div
             data-testid="workout-execution-page"
             data-focus-mode={focusMode ? 'true' : 'false'}
-            className={`min-h-screen bg-[#020617] text-slate-100 p-4 font-sans selection:bg-cyan-500/30 ${focusMode
-                ? 'pb-[calc(1rem+env(safe-area-inset-bottom))]'
-                : 'pb-4'
-                }`}
+            className="flex min-h-[calc(100dvh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] flex-col bg-[#020617] p-4 font-sans text-slate-100 selection:bg-cyan-500/30"
         >
             {/* LOADER DE FINALIZAÇÃO DA SESSÃO */}
             {isFinishingSession && (
@@ -267,7 +269,7 @@ export function WorkoutExecutionPage({ user }) {
                 onChoose={handleResolveSessionConflict}
                 onKeepRecommended={() => handleResolveSessionConflict(sessionConflict?.source)}
             />
-            <div className="max-w-2xl mx-auto flex flex-col">
+            <div className="max-w-2xl mx-auto flex flex-1 w-full flex-col">
 
                 <ExecutionTopBar
                     onBack={() => onFinish()}
@@ -311,7 +313,11 @@ export function WorkoutExecutionPage({ user }) {
                     </div>
                 )}
 
-                <main className={`px-4 mt-2 space-y-4`}>
+                {/* `flex-1` absorve a sobra de altura. No Modo Foco a ficha
+                    ainda é centralizada nessa sobra; quando ela é mais alta que
+                    a tela o próprio `flex-1` cresce e a página rola normalmente,
+                    sem cortar o topo. */}
+                <main className={`px-4 mt-2 space-y-4 flex-1 ${focusMode ? 'flex flex-col justify-center' : ''}`}>
                     {focusMode ? (
                         exercises.length > 0 && (
                             <ExerciseCard
@@ -383,12 +389,16 @@ export function WorkoutExecutionPage({ user }) {
 
                 {/* Footer Fim de Treino - Apenas mostra se o modal de finalização NÃO estiver visível */}
                 {!showFinishModal && (
+                    /* `mt-auto` encosta o rodapé na base da tela sem `position:
+                       fixed` — com ficha curta (série de linha única) o
+                       "FINALIZAR TREINO" ficava colado no "CONCLUIR SÉRIE" e
+                       rendia toque errado. O `pb` não repete
+                       `env(safe-area-inset-bottom)`: o `body` já reserva esse
+                       espaço e somar de novo deixava o botão boiando acima do
+                       rodapé real. */
                     <div
                         data-testid="workout-finish-footer"
-                        className={`w-full ${focusMode
-                            ? 'mt-5 pb-[calc(1rem+env(safe-area-inset-bottom))]'
-                            : 'mt-6 pb-[calc(1.25rem+env(safe-area-inset-bottom))]'
-                            }`}
+                        className="w-full mt-auto pt-8 pb-1"
                     >
                         <div className="max-w-2xl mx-auto flex justify-center">
                             <div className="space-y-4 w-full flex flex-col items-center px-4">

--- a/src/pages/WorkoutExecutionPage.test.jsx
+++ b/src/pages/WorkoutExecutionPage.test.jsx
@@ -284,18 +284,44 @@ describe('WorkoutExecutionPage', () => {
         expect(await screen.findByText('Compartilhar Resultado', {}, { timeout: 2000 })).toBeInTheDocument();
     });
 
-    it('keeps the bottom padding compact in both modes', () => {
+    // O "FINALIZAR TREINO" fica no fim da tela pelo fluxo (coluna flex +
+    // `mt-auto`), nunca por `position: fixed` — botão flutuante sobre a ficha
+    // foi justamente o que gerava toque errado no "CONCLUIR SÉRIE".
+    it('keeps the finish button pinned to the bottom in both modes', () => {
         render(<WorkoutExecutionPage user={{ uid: 'u1' }} />);
 
         const page = screen.getByTestId('workout-execution-page');
         const footer = screen.getByTestId('workout-finish-footer');
+
+        const expectBottomLayout = () => {
+            expect(page.className).toContain('flex');
+            expect(page.className).toContain('flex-col');
+            expect(page.className).toContain('min-h-[calc(100dvh');
+            expect(footer.className).toContain('mt-auto');
+            expect(footer.className).not.toContain('fixed');
+            // O `body` já reserva o safe-area inferior: repetir aqui deixava o
+            // botão boiando acima do rodapé real.
+            expect(footer.className).not.toContain('safe-area-inset-bottom');
+        };
+
         expect(page).toHaveAttribute('data-focus-mode', 'false');
-        expect(page).toHaveClass('pb-4');
-        expect(footer.className).not.toContain('6rem');
+        expectBottomLayout();
 
         fireEvent.click(screen.getByRole('button', { name: 'FOCO' }));
 
         expect(page).toHaveAttribute('data-focus-mode', 'true');
-        expect(page).not.toHaveClass('pb-4');
+        expectBottomLayout();
+    });
+
+    it('centers the exercise card in the leftover height only in focus mode', () => {
+        const { container } = render(<WorkoutExecutionPage user={{ uid: 'u1' }} />);
+        const main = container.querySelector('main');
+
+        expect(main.className).toContain('flex-1');
+        expect(main.className).not.toContain('justify-center');
+
+        fireEvent.click(screen.getByRole('button', { name: 'FOCO' }));
+
+        expect(main.className).toContain('justify-center');
     });
 });

--- a/src/pages/WorkoutsPage.jsx
+++ b/src/pages/WorkoutsPage.jsx
@@ -4,7 +4,6 @@
  * Suporta pesquisa, filtragem (por empurrar/puxar/pernas/etc) e classificação de modelos.
  */
 import React, { useState, useEffect, useCallback } from 'react';
-import { getFirestoreDeps } from '../firebaseDb';
 import { AnimatePresence, motion } from 'framer-motion';
 import {
     Search,
@@ -34,6 +33,9 @@ import { AddCardioModal } from '../components/AddCardioModal';
 import { StarterWorkoutsLibrary } from '../components/workout/StarterWorkoutsLibrary';
 import { ConfirmDialog } from '../components/design-system/ConfirmDialog';
 import { nextDisplayOrder, normalizeActiveWorkoutOrder, sortWorkoutTemplates } from '../utils/workoutTemplateOrder';
+import { buildCopyName, isCopyName } from '../utils/workoutCopyName';
+import { countBySourceFilter, matchesSourceFilter } from '../utils/workoutSourceFilter';
+import { SourceFilterChips } from '../components/workout/SourceFilterChips';
 import { toast } from 'sonner';
 const ExerciseCard = React.lazy(() => import('../components/workout/ExerciseCard').then(module => ({ default: module.ExerciseCard })));
 const EditExerciseModal = React.lazy(() => import('../components/workout/EditExerciseModal').then(module => ({ default: module.EditExerciseModal })));
@@ -142,29 +144,13 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
 
     // --- FILTER LOGIC ---
     const filteredWorkouts = sortWorkoutTemplates(workouts.filter(workout => {
-        // 1. Search
         const matchesSearch = workout.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
             (workout.muscleGroups && workout.muscleGroups.some(g => g.toLowerCase().includes(searchQuery.toLowerCase())));
 
-        // 2. Source Filter (My vs. Personal vs. Archived)
-        let matchesSource = true;
-        
-        if (sourceFilter === 'arquivados') {
-            // Só mostra arquivados
-            matchesSource = workout.isArchived;
-        } else {
-            // Em todas as outras abas, ESCONDE os arquivados
-            if (workout.isArchived) return false;
-            
-            if (sourceFilter === 'meus') {
-                matchesSource = workout.createdBy === user.uid || !workout.createdBy;
-            } else if (sourceFilter === 'personal') {
-                matchesSource = workout.createdBy && workout.createdBy !== user.uid;
-            }
-        }
-
-        return matchesSearch && matchesSource;
+        return matchesSearch && matchesSourceFilter(workout, sourceFilter, user.uid);
     }));
+
+    const sourceCounts = countBySourceFilter(workouts, user.uid);
 
     // --- ACTIONS ---
     const handleCardClick = (id, name) => {
@@ -227,6 +213,74 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
         }
     };
 
+    /**
+     * Duplica uma ficha pelo caminho único de escrita (`workoutService`) e
+     * posiciona a cópia logo abaixo do original. Sem o reposicionamento a cópia
+     * pulava para o topo da lista: ela era a única com `displayOrder` definido,
+     * e `compareWorkoutTemplates` coloca quem tem ordem antes de quem não tem.
+     */
+    const duplicateWorkout = async (workout) => {
+        const { workoutService } = await import('../services/workoutService');
+        const exercises = workout.exercises || [];
+        const muscleGroups = workout.muscleGroups || [];
+        const name = buildCopyName(workout.name, workouts.map(item => item.name));
+
+        const newId = await workoutService.createTemplate(
+            {
+                name,
+                exercises,
+                targetUserId: user.uid,
+                createdBy: user.uid
+            },
+            {
+                category: workout.category || 'fullbody',
+                estimatedDuration: workout.duration,
+                muscleGroups,
+                displayOrder: nextDisplayOrder(workouts)
+            }
+        );
+
+        const copy = {
+            id: newId,
+            name,
+            exercisesCount: exercises.length,
+            exercises,
+            duration: workout.duration || '45-60min',
+            muscleGroups,
+            lastPerformed: 'Nunca',
+            lastPerformedDate: null,
+            frequency: '1x/sem',
+            timesPerformed: 0,
+            isFavorite: false,
+            category: workout.category || 'fullbody',
+            createdBy: user.uid,
+            assignedByTrainer: false,
+            completedToday: false,
+            isArchived: false,
+            displayOrder: nextDisplayOrder(workouts)
+        };
+
+        setWorkouts(prev => [...prev, copy]);
+        toast.success("Treino duplicado.");
+
+        // Reordenar é um extra: se falhar, a cópia continua existindo no fim da
+        // lista — não vale desfazer a duplicação nem alarmar o usuário.
+        try {
+            const activeWorkouts = normalizeActiveWorkoutOrder(workouts);
+            const originalIndex = activeWorkouts.findIndex(item => item.id === workout.id);
+            const reordered = [...activeWorkouts];
+            reordered.splice(originalIndex >= 0 ? originalIndex + 1 : reordered.length, 0, copy);
+
+            const normalized = reordered.map((item, displayOrder) => ({ ...item, displayOrder }));
+            const orderById = new Map(normalized.map(item => [item.id, item]));
+
+            setWorkouts(current => current.map(item => orderById.get(item.id) || item));
+            await workoutService.saveTemplateOrder(normalized);
+        } catch (orderError) {
+            console.error('Erro ao posicionar a cópia na lista:', orderError);
+        }
+    };
+
     const handleMenuAction = async (e, action, workout) => {
         e.stopPropagation();
         setActiveCardMenu(null);
@@ -234,83 +288,24 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
         if (action === 'delete') {
             setWorkoutPendingDelete(workout);
         } else if (action === 'duplicate') {
-            const newWorkoutData = {
-                name: `${workout.name} (Cópia)`,
-                exercises: workout.exercises || [],
-                category: workout.category,
-                estimatedDuration: workout.duration,
-                userId: user.uid,
-                createdBy: user.uid,
-                assignedByTrainer: false,
-                displayOrder: nextDisplayOrder(workouts)
-            };
-
             try {
-                const { db, collection, addDoc, serverTimestamp } = await getFirestoreDeps();
-                const docRef = await addDoc(collection(db, 'workout_templates'), {
-                    ...newWorkoutData,
-                    createdAt: serverTimestamp(),
-                    updatedAt: serverTimestamp()
-                });
-                
-                // Limpar cache após mutação
-                const { workoutService } = await import('../services/workoutService');
-                workoutService.clearCache();
-
-                setWorkouts(prev => ([
-                    {
-                        id: docRef.id,
-                        name: newWorkoutData.name,
-                        exercisesCount: newWorkoutData.exercises?.length || 0,
-                        exercises: newWorkoutData.exercises || [],
-                        duration: newWorkoutData.estimatedDuration || '45-60min',
-                        muscleGroups: workout.muscleGroups || [],
-                        lastPerformed: 'Nunca',
-                        lastPerformedDate: null,
-                        frequency: '1x/sem',
-                        timesPerformed: 0,
-                        isFavorite: false,
-                        category: newWorkoutData.category || 'fullbody',
-                        createdBy: user.uid,
-                        assignedByTrainer: false,
-                        completedToday: false,
-                        isArchived: false,
-                        displayOrder: newWorkoutData.displayOrder
-                    },
-                    ...prev
-                ]));
-                toast.success("Treino duplicado.");
+                await duplicateWorkout(workout);
             } catch (err) {
                 toast.error(err.message || "Erro ao duplicar treino.");
             }
         } else if (action === 'edit') {
             onNavigateToCreate(workout);
-        } else if (action === 'archive') {
+        } else if (action === 'archive' || action === 'unarchive') {
+            const isArchived = action === 'archive';
             try {
-                const { db, doc, updateDoc } = await getFirestoreDeps();
-                await updateDoc(doc(db, 'workout_templates', workout.id), {
-                    isArchived: true
-                });
-                // Limpar cache após mutação
                 const { workoutService } = await import('../services/workoutService');
-                workoutService.clearCache();
+                await workoutService.setTemplateArchived(workout.id, isArchived);
 
-                setWorkouts(prev => prev.map(w => w.id === workout.id ? { ...w, isArchived: true } : w));
-                toast.success("Treino arquivado.");
-            } catch (err) { toast.error(err.message || "Erro ao arquivar treino."); }
-        } else if (action === 'unarchive') {
-            try {
-                const { db, doc, updateDoc } = await getFirestoreDeps();
-                await updateDoc(doc(db, 'workout_templates', workout.id), {
-                    isArchived: false
-                });
-                // Limpar cache após mutação
-                const { workoutService } = await import('../services/workoutService');
-                workoutService.clearCache();
-
-                setWorkouts(prev => prev.map(w => w.id === workout.id ? { ...w, isArchived: false } : w));
-                toast.success("Treino desarquivado.");
-            } catch (err) { toast.error(err.message || "Erro ao desarquivar treino."); }
+                setWorkouts(prev => prev.map(w => w.id === workout.id ? { ...w, isArchived } : w));
+                toast.success(isArchived ? "Treino arquivado." : "Treino desarquivado.");
+            } catch (err) {
+                toast.error(err.message || (isArchived ? "Erro ao arquivar treino." : "Erro ao desarquivar treino."));
+            }
         }
     };
 
@@ -318,11 +313,8 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
         if (!workoutPendingDelete) return;
         setDeletingWorkout(true);
         try {
-            const { db, doc, deleteDoc } = await getFirestoreDeps();
-            await deleteDoc(doc(db, 'workout_templates', workoutPendingDelete.id));
-
             const { workoutService } = await import('../services/workoutService');
-            workoutService.clearCache();
+            await workoutService.deleteTemplate(workoutPendingDelete.id);
 
             setWorkouts(prev => prev.filter(w => w.id !== workoutPendingDelete.id));
             toast.success("Treino excluído.");
@@ -339,7 +331,7 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
         <div className="min-h-screen pb-8 pt-2 px-4 lg:px-8 w-full max-w-5xl mx-auto lg:pt-[calc(1.5rem+env(safe-area-inset-top))] lg:pb-12">
 
             {/* 1. HEADER & SEARCH */}
-            <div className="space-y-6 pt-2 mb-8 lg:space-y-8 lg:pt-6">
+            <div className="space-y-4 pt-2 mb-8 lg:space-y-5 lg:pt-6">
                 {/* Top Bar - Hide if Trainer Mode */}
                 {!isTrainerMode && (
                     <PageHeader
@@ -356,66 +348,44 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
                             >
                                 Concluir
                             </Button>
-                        ) : (
-                            <div className="flex w-full gap-2 sm:w-auto">
-                                <Button
-                                    variant="secondary"
-                                    size="sm"
-                                    onClick={() => setIsLibraryOpen(true)}
-                                    className="flex-1 rounded-xl px-2 sm:flex-none sm:px-4"
-                                    leftIcon={<Sparkles size={16} />}
-                                >
-                                    Modelos
-                                </Button>
-                                <Button
-                                    variant="secondary"
-                                    size="sm"
-                                    onClick={() => setIsAddCardioOpen(true)}
-                                    className="flex-1 rounded-xl px-2 sm:flex-none sm:px-4"
-                                    leftIcon={<Activity size={16} />}
-                                >
-                                    Cardio
-                                </Button>
-                                <Button
-                                    variant="secondary"
-                                    size="sm"
-                                    onClick={toggleOrganizing}
-                                    className="flex-1 rounded-xl px-2 sm:flex-none sm:px-4"
-                                    leftIcon={<ListOrdered size={16} />}
-                                >
-                                    Ordem
-                                </Button>
-                                <Button
-                                    size="sm"
-                                    onClick={() => onNavigateToCreate(null, { targetUserId: user.uid })}
-                                    className="flex-1 rounded-xl px-2 sm:flex-none sm:px-4"
-                                    leftIcon={<Plus size={16} />}
-                                >
-                                    Novo
-                                </Button>
-                            </div>
-                        )}
+                        ) : null}
                         className="mb-0"
                     />
                 )}
 
-
-
-                {/* New: Source Tabs - Hide if Trainer Mode (since trainer sees all relevant) */}
+                {/* Bloco de ações: "Novo treino" em destaque + atalhos compactos.
+                    Antes eram quatro botões dividindo a largura do celular, e o
+                    rótulo de cada um ficava espremido contra o próprio ícone. */}
                 {!isTrainerMode && !isOrganizing && (
-                    <div className="grid grid-cols-2 gap-1 p-1 bg-slate-900/50 rounded-xl mb-6 border border-slate-800 backdrop-blur-sm sm:grid-cols-4">
-                        {['all', 'meus', 'personal', 'arquivados'].map((filter) => (
-                            <button
-                                key={filter}
-                                onClick={() => setSourceFilter(filter)}
-                                className={`min-w-0 py-2 px-2 rounded-lg text-sm font-semibold transition-colors duration-200 whitespace-nowrap ${sourceFilter === filter
-                                    ? 'bg-cyan-500 text-black shadow-lg shadow-cyan-500/20'
-                                    : 'text-slate-400 hover:text-white hover:bg-slate-800'
-                                    }`}
+                    <div className="rounded-3xl border border-slate-800/50 bg-gradient-to-br from-slate-900/90 to-slate-950/95 p-3 shadow-md">
+                        <div className="flex flex-col gap-2 sm:flex-row sm:items-stretch">
+                            <div className="grid grid-cols-3 gap-2 sm:flex-1 sm:order-1">
+                                {[
+                                    { id: 'modelos', label: 'Modelos', icon: <Sparkles size={17} />, onClick: () => setIsLibraryOpen(true) },
+                                    { id: 'cardio', label: 'Cardio', icon: <Activity size={17} />, onClick: () => setIsAddCardioOpen(true) },
+                                    { id: 'ordem', label: 'Ordem', icon: <ListOrdered size={17} />, onClick: toggleOrganizing }
+                                ].map(shortcut => (
+                                    <Button
+                                        key={shortcut.id}
+                                        variant="unstyled"
+                                        haptic="light"
+                                        onClick={shortcut.onClick}
+                                        className="flex h-12 flex-col items-center justify-center gap-0.5 rounded-2xl border border-slate-800 bg-slate-900/60 text-slate-300 transition-colors hover:border-cyan-500/30 hover:bg-slate-800/70 hover:text-white sm:flex-row sm:gap-2"
+                                    >
+                                        <span className="text-cyan-400">{shortcut.icon}</span>
+                                        <span className="text-[11px] font-semibold tracking-wide sm:text-xs">{shortcut.label}</span>
+                                    </Button>
+                                ))}
+                            </div>
+
+                            <Button
+                                onClick={() => onNavigateToCreate(null, { targetUserId: user.uid })}
+                                className="h-12 w-full rounded-2xl sm:order-2 sm:h-auto sm:w-auto sm:px-6"
+                                leftIcon={<Plus size={18} />}
                             >
-                                {filter === 'all' ? 'Todos' : filter === 'meus' ? 'Meus Treinos' : filter === 'personal' ? 'Personal Play' : 'Arquivados'}
-                            </button>
-                        ))}
+                                Novo treino
+                            </Button>
+                        </div>
                     </div>
                 )}
 
@@ -430,7 +400,7 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
                         </span>
                     </div>
                 ) : (
-                    <PremiumCard className="p-0">
+                    <div className="overflow-hidden rounded-3xl border border-slate-800/50 bg-gradient-to-br from-slate-900/90 to-slate-950/95 shadow-md">
                         <div className="relative">
                             <Search className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-500" size={20} />
                             <input
@@ -438,10 +408,18 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
                                 value={searchQuery}
                                 onChange={(e) => setSearchQuery(e.target.value)}
                                 placeholder="Buscar por nome ou músculo..."
-                                className="w-full pl-12 pr-4 py-4 bg-transparent border-none text-white placeholder:text-slate-500 focus:ring-1 focus:ring-cyan-500 rounded-xl transition-colors"
+                                className="w-full pl-12 pr-4 py-4 bg-transparent border-none text-white placeholder:text-slate-500 focus:ring-1 focus:ring-cyan-500 rounded-3xl transition-colors"
                             />
                         </div>
-                    </PremiumCard>
+
+                        {!isTrainerMode && (
+                            <SourceFilterChips
+                                value={sourceFilter}
+                                counts={sourceCounts}
+                                onChange={setSourceFilter}
+                            />
+                        )}
+                    </div>
                 )}
             </div>
 
@@ -474,6 +452,15 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
                                                 <span className="text-[10px] font-bold px-2 py-0.5 rounded-md bg-amber-500/20 text-amber-500 border border-amber-500/30 flex items-center gap-1">
                                                     <Crown size={10} strokeWidth={3} />
                                                     COACH
+                                                </span>
+                                            )}
+                                            {/* Derivado do nome (ver workoutCopyName.js): o sufixo
+                                                "(Cópia)" se perde no fim de um título longo, então o
+                                                selo é o que de fato diferencia a cópia do original. */}
+                                            {isCopyName(workout.name) && (
+                                                <span className="text-[10px] font-bold px-2 py-0.5 rounded-md bg-violet-500/15 text-violet-300 border border-violet-500/30 flex items-center gap-1">
+                                                    <Copy size={10} strokeWidth={3} />
+                                                    CÓPIA
                                                 </span>
                                             )}
                                             {workout.muscleGroups.map((tag, i) => (

--- a/src/pages/WorkoutsPage.test.jsx
+++ b/src/pages/WorkoutsPage.test.jsx
@@ -7,7 +7,8 @@ import { workoutService } from '../services/workoutService';
 vi.mock('../services/workoutService', () => ({
     workoutService: {
         getTemplates: vi.fn(),
-        saveTemplateOrder: vi.fn()
+        saveTemplateOrder: vi.fn(),
+        createTemplate: vi.fn()
     }
 }));
 
@@ -123,8 +124,81 @@ describe('WorkoutsPage', () => {
     it('calls onNavigateToCreate when clicking Novo Treino', async () => {
         const { onNavigateToCreate } = await renderPage();
 
-        fireEvent.click(screen.getByText('Novo'));
+        fireEvent.click(screen.getByRole('button', { name: 'Novo treino' }));
         expect(onNavigateToCreate).toHaveBeenCalledWith(null, { targetUserId: 'user123' });
+    });
+
+    it('shows how many workouts each source filter holds', async () => {
+        await renderPage();
+
+        // Todos 2 · Meus Treinos 1 · Personal Play 1 · Arquivados 0
+        expect(screen.getByRole('button', { name: 'Todos' })).toHaveTextContent('2');
+        expect(screen.getByRole('button', { name: 'Meus Treinos' })).toHaveTextContent('1');
+        expect(screen.getByRole('button', { name: 'Arquivados' })).toHaveTextContent('0');
+    });
+
+    describe('duplicar treino', () => {
+        const duplicate = async (workoutName) => {
+            fireEvent.click(screen.getByRole('button', { name: `Abrir opções de ${workoutName}` }));
+            fireEvent.click(screen.getByText('Duplicar'));
+        };
+
+        it('cria a cópia pelo workoutService, com nome numerado e grupos musculares', async () => {
+            workoutService.createTemplate.mockResolvedValue('w1-copy');
+            workoutService.saveTemplateOrder.mockResolvedValue(undefined);
+            await renderPage();
+
+            await duplicate('Treino Peito');
+
+            await waitFor(() => {
+                expect(workoutService.createTemplate).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        name: 'Treino Peito (Cópia)',
+                        targetUserId: 'user123',
+                        createdBy: 'user123'
+                    }),
+                    expect.objectContaining({ muscleGroups: ['Peito'] })
+                );
+            });
+        });
+
+        // Sem o reposicionamento a cópia pulava para o topo da lista.
+        it('posiciona a cópia logo abaixo do original', async () => {
+            workoutService.createTemplate.mockResolvedValue('w1-copy');
+            workoutService.saveTemplateOrder.mockResolvedValue(undefined);
+            await renderPage();
+
+            await duplicate('Treino Peito');
+
+            await waitFor(() => {
+                expect(workoutService.saveTemplateOrder).toHaveBeenCalledWith([
+                    expect.objectContaining({ id: 'w1', displayOrder: 0 }),
+                    expect.objectContaining({ id: 'w1-copy', displayOrder: 1 }),
+                    expect.objectContaining({ id: 'w2', displayOrder: 2 })
+                ]);
+            });
+        });
+
+        it('marca a cópia com o selo CÓPIA e numera a duplicação seguinte', async () => {
+            workoutService.createTemplate.mockResolvedValue('w1-copy');
+            workoutService.saveTemplateOrder.mockResolvedValue(undefined);
+            await renderPage();
+
+            await duplicate('Treino Peito');
+
+            expect(await screen.findByText('Treino Peito (Cópia)')).toBeInTheDocument();
+            expect(screen.getAllByText('CÓPIA')).toHaveLength(1);
+
+            workoutService.createTemplate.mockResolvedValue('w1-copy-2');
+            await duplicate('Treino Peito');
+
+            await waitFor(() => {
+                expect(workoutService.createTemplate).toHaveBeenLastCalledWith(
+                    expect.objectContaining({ name: 'Treino Peito (Cópia 2)' }),
+                    expect.anything()
+                );
+            });
+        });
     });
 
     it('lets the user move an active workout and persists the new order', async () => {

--- a/src/services/workoutService.js
+++ b/src/services/workoutService.js
@@ -230,6 +230,27 @@ export const workoutService = {
     },
 
     /**
+     * Arquiva ou desarquiva uma ficha.
+     * @param {string} templateId
+     * @param {boolean} isArchived
+     */
+    async setTemplateArchived(templateId, isArchived) {
+        const { db, doc, updateDoc } = await getFirestoreDeps();
+        await updateDoc(doc(db, TEMPLATES_COLLECTION, templateId), { isArchived });
+        this.clearCache();
+    },
+
+    /**
+     * Remove uma ficha. Não altera sessões já concluídas.
+     * @param {string} templateId
+     */
+    async deleteTemplate(templateId) {
+        const { db, doc, deleteDoc } = await getFirestoreDeps();
+        await deleteDoc(doc(db, TEMPLATES_COLLECTION, templateId));
+        this.clearCache();
+    },
+
+    /**
      * Obter a ÚLTIMA sessão CONCLUÍDA do usuário (Limit 1).
      * Otimizado para lógica de "Próxima Sugestão".
      * @param {string} userId 

--- a/src/utils/workoutCopyName.js
+++ b/src/utils/workoutCopyName.js
@@ -1,0 +1,52 @@
+/**
+ * Nome das fichas duplicadas.
+ *
+ * O selo "CÓPIA" do card é derivado do nome, não de um campo no documento:
+ * campo novo no topo de `workout_templates` exigiria mudar as `firestore.rules`
+ * e o cenário correspondente em `tests/security/firestore.rules.test.js`, e o
+ * sufixo já é a fonte da verdade que o usuário edita quando renomeia.
+ */
+
+const COPY_SUFFIX = /\s*\(cópia(?:\s+(\d+))?\)\s*$/i;
+
+// Mesmo collator de `workoutTemplateOrder.js`: comparar "(Cópia)" com "(copia)"
+// como iguais evita gerar dois nomes que o usuário lê como o mesmo.
+const nameCollator = new Intl.Collator('pt-BR', {
+    numeric: true,
+    sensitivity: 'base'
+});
+
+/**
+ * Remove um `(Cópia)` / `(Cópia N)` final. Só um: duplicar uma cópia deve virar
+ * "(Cópia 2)", nunca "(Cópia) (Cópia)".
+ */
+export function stripCopySuffix(name) {
+    return String(name || '').replace(COPY_SUFFIX, '').trim();
+}
+
+/** Indica se o nome foi gerado por uma duplicação (alimenta o selo do card). */
+export function isCopyName(name) {
+    return COPY_SUFFIX.test(String(name || '').trim());
+}
+
+/**
+ * Primeiro nome livre da sequência "<base> (Cópia)", "<base> (Cópia 2)"...
+ * Preenche lacunas: com "(Cópia)" e "(Cópia 3)" ocupados, devolve "(Cópia 2)".
+ *
+ * @param {string} name Nome do treino de origem (pode já ser uma cópia).
+ * @param {string[]} existingNames Nomes já usados nas fichas do usuário.
+ */
+export function buildCopyName(name, existingNames = []) {
+    const trimmed = String(name || '').trim();
+    const base = stripCopySuffix(trimmed) || trimmed;
+    const taken = existingNames.map(existing => String(existing || '').trim());
+    const isTaken = candidate => taken.some(existing => nameCollator.compare(existing, candidate) === 0);
+
+    for (let counter = 1; ; counter += 1) {
+        const candidate = counter === 1
+            ? `${base} (Cópia)`
+            : `${base} (Cópia ${counter})`;
+
+        if (!isTaken(candidate)) return candidate;
+    }
+}

--- a/src/utils/workoutCopyName.test.js
+++ b/src/utils/workoutCopyName.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { buildCopyName, isCopyName, stripCopySuffix } from './workoutCopyName';
+
+describe('stripCopySuffix', () => {
+    it('remove apenas o sufixo final de cópia', () => {
+        expect(stripCopySuffix('Treino A')).toBe('Treino A');
+        expect(stripCopySuffix('Treino A (Cópia)')).toBe('Treino A');
+        expect(stripCopySuffix('Treino A (Cópia 3)')).toBe('Treino A');
+    });
+
+    it('preserva parênteses que não são sufixo de cópia', () => {
+        expect(stripCopySuffix('Treino A (leve)')).toBe('Treino A (leve)');
+        expect(stripCopySuffix('Treino A (Cópia) do personal')).toBe('Treino A (Cópia) do personal');
+    });
+});
+
+describe('isCopyName', () => {
+    it('reconhece nomes gerados por duplicação', () => {
+        expect(isCopyName('Treino A (Cópia)')).toBe(true);
+        expect(isCopyName('Treino A (Cópia 2)')).toBe(true);
+        expect(isCopyName('Treino A (cópia)')).toBe(true);
+    });
+
+    it('não marca nomes comuns', () => {
+        expect(isCopyName('Treino A')).toBe(false);
+        expect(isCopyName('Treino A (leve)')).toBe(false);
+        expect(isCopyName('')).toBe(false);
+        expect(isCopyName(undefined)).toBe(false);
+    });
+});
+
+describe('buildCopyName', () => {
+    it('usa "(Cópia)" quando o nome está livre', () => {
+        expect(buildCopyName('Treino A', ['Treino A'])).toBe('Treino A (Cópia)');
+    });
+
+    it('numera a partir da segunda cópia em vez de repetir o nome', () => {
+        expect(buildCopyName('Treino A', ['Treino A', 'Treino A (Cópia)']))
+            .toBe('Treino A (Cópia 2)');
+    });
+
+    // Duplicar a cópia não pode empilhar sufixos.
+    it('parte do nome-base ao duplicar uma cópia', () => {
+        expect(buildCopyName('Treino A (Cópia)', ['Treino A', 'Treino A (Cópia)']))
+            .toBe('Treino A (Cópia 2)');
+    });
+
+    it('preenche lacunas da sequência', () => {
+        expect(buildCopyName('Treino A', ['Treino A', 'Treino A (Cópia)', 'Treino A (Cópia 3)']))
+            .toBe('Treino A (Cópia 2)');
+    });
+
+    it('ignora caixa e acento ao verificar o que já existe', () => {
+        expect(buildCopyName('Treino A', ['Treino A', 'treino a (copia)']))
+            .toBe('Treino A (Cópia 2)');
+    });
+
+    it('funciona sem lista de nomes existentes', () => {
+        expect(buildCopyName('Treino A')).toBe('Treino A (Cópia)');
+    });
+});

--- a/src/utils/workoutSourceFilter.js
+++ b/src/utils/workoutSourceFilter.js
@@ -1,0 +1,38 @@
+/**
+ * Filtro de origem das fichas em "Meus Treinos".
+ * Fonte única de verdade: a lista e os contadores dos chips leem daqui para
+ * não divergirem.
+ */
+
+export const SOURCE_FILTERS = [
+    { id: 'all', label: 'Todos' },
+    { id: 'meus', label: 'Meus Treinos' },
+    { id: 'personal', label: 'Personal Play' },
+    { id: 'arquivados', label: 'Arquivados' }
+];
+
+/**
+ * Arquivados só aparecem na própria aba; nas outras ficam sempre escondidos.
+ * @param {Object} workout
+ * @param {string} filter Id de `SOURCE_FILTERS`.
+ * @param {string} uid Usuário logado.
+ */
+export function matchesSourceFilter(workout, filter, uid) {
+    if (filter === 'arquivados') return Boolean(workout.isArchived);
+    if (workout.isArchived) return false;
+    if (filter === 'meus') return workout.createdBy === uid || !workout.createdBy;
+    if (filter === 'personal') return Boolean(workout.createdBy) && workout.createdBy !== uid;
+    return true;
+}
+
+/**
+ * Quantas fichas cada filtro tem. Ignora a busca de propósito: piscando a cada
+ * tecla digitada, o contador atrapalharia mais do que informaria.
+ * @returns {Record<string, number>}
+ */
+export function countBySourceFilter(workouts = [], uid) {
+    return SOURCE_FILTERS.reduce((counts, { id }) => ({
+        ...counts,
+        [id]: workouts.filter(workout => matchesSourceFilter(workout, id, uid)).length
+    }), {});
+}

--- a/src/utils/workoutSourceFilter.test.js
+++ b/src/utils/workoutSourceFilter.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { countBySourceFilter, matchesSourceFilter } from './workoutSourceFilter';
+
+const UID = 'user123';
+
+const workouts = [
+    { id: 'a', createdBy: UID },
+    { id: 'b', createdBy: 'trainer-1' },
+    { id: 'c' }, // ficha antiga, sem createdBy
+    { id: 'd', createdBy: UID, isArchived: true }
+];
+
+describe('matchesSourceFilter', () => {
+    it('esconde arquivados em todas as abas menos a própria', () => {
+        expect(matchesSourceFilter(workouts[3], 'all', UID)).toBe(false);
+        expect(matchesSourceFilter(workouts[3], 'meus', UID)).toBe(false);
+        expect(matchesSourceFilter(workouts[3], 'arquivados', UID)).toBe(true);
+    });
+
+    // Ficha sem createdBy é de antes do campo existir: conta como do usuário.
+    it('trata ficha sem dono como do próprio usuário', () => {
+        expect(matchesSourceFilter(workouts[2], 'meus', UID)).toBe(true);
+        expect(matchesSourceFilter(workouts[2], 'personal', UID)).toBe(false);
+    });
+
+    it('separa o que veio do personal', () => {
+        expect(matchesSourceFilter(workouts[1], 'personal', UID)).toBe(true);
+        expect(matchesSourceFilter(workouts[0], 'personal', UID)).toBe(false);
+    });
+});
+
+describe('countBySourceFilter', () => {
+    it('conta cada aba do mesmo jeito que a lista filtra', () => {
+        expect(countBySourceFilter(workouts, UID)).toEqual({
+            all: 3,
+            meus: 2,
+            personal: 1,
+            arquivados: 1
+        });
+    });
+
+    it('devolve zeros sem fichas', () => {
+        expect(countBySourceFilter([], UID)).toEqual({
+            all: 0, meus: 0, personal: 0, arquivados: 0
+        });
+    });
+});


### PR DESCRIPTION
Três ajustes de UX levantados a partir de prints do app no iPhone.

## 1. Duplicar treino não comunicava nada

O sufixo `(Cópia)` já existia, mas caía no fim de um nome longo, sumia na quebra de linha do card e ainda ficava atrás do toast. Duplicar duas vezes gerava dois nomes idênticos.

- Selo **CÓPIA** ao lado do título, derivado do nome (`src/utils/workoutCopyName.js`). Sem campo novo no topo de `workout_templates` — as `firestore.rules` não mudam.
- Nome numerado a partir da segunda cópia: `(Cópia)`, `(Cópia 2)`… Duplicar uma cópia não empilha sufixo e lacunas da sequência são reaproveitadas.
- A cópia passa a ficar **logo abaixo do original**. Antes pulava para o topo por acidente: era a única com `displayOrder` definido, e `compareWorkoutTemplates` coloca quem tem ordem antes de quem não tem.
- A escrita foi do `addDoc` direto na página para o `workoutService` (caminho único do projeto). Isso conserta de quebra um bug: a cópia perdia as tags de músculo, porque `muscleGroups` só entrava no estado local. Arquivar, desarquivar e excluir foram junto para o serviço.

## 2. Topo de "Meus Treinos" apertado

- Bloco de ações com **Novo treino** em destaque e Modelos/Cardio/Ordem como atalhos compactos. Medido no DOM a 390px: os botões foram de 84px para 105px (atalhos) e 332px (primário), nenhum rótulo truncado.
- O grid 2x2 de filtros virou uma faixa de chips com contador (`SourceFilterChips`). Os quatro rótulos não cabem em 390px, então a faixa rola e um degradê na borda direita avisa que há mais filtro — sem ele "Arquivados" simplesmente não existiria para quem não tentasse arrastar. O degradê some ao chegar no fim da rolagem.
- Altura até o primeiro treino: **403px contra 404px** do layout anterior. Botões folgados sem custar espaço vertical.
- O predicado do filtro virou fonte única de verdade (`src/utils/workoutSourceFilter.js`), lido tanto pela lista quanto pelos contadores.

## 3. "FINALIZAR TREINO" perto demais do "CONCLUIR SÉRIE"

No Modo Foco com ficha curta (comum desde a mudança do bi-set) os dois botões ficavam quase colados, rendendo toque errado, e sobrava tela vazia embaixo.

- A ficha fica centralizada na sobra de altura e o rodapé encosta na base **pelo fluxo** (coluna flex + `mt-auto`), nunca por `position: fixed` — botão flutuante sobre a ficha era justamente o problema.
- Distância entre os dois botões na ficha curta: de ~76px para **222px**.
- A raiz usa `min-h-[calc(100dvh - insets)]` em vez de `min-h-screen`, e o `pb` parou de repetir `env(safe-area-inset-bottom)`: o `body` já reserva esse espaço (`index.css`) e somar de novo deixava o botão boiando acima do rodapé real.

## Verificação

- `npm run lint`, 341 testes do app, 12 das Functions e `npm run build` — todos passando.
- Cobertura nova: `buildCopyName`/`isCopyName`, `countBySourceFilter`, duplicação chamando o `workoutService` com nome numerado e `muscleGroups`, posição da cópia, selo CÓPIA, e o contrato de layout do rodapé nos dois modos.
- Checagem visual com entry point temporário do Vite (já removido), medindo por DOM em 390x844: nenhum truncamento, chips e atalhos na mesma linha, rodapé a 824px de 844. Com viewport forçada a 480px de altura o conteúdo alto não é cortado — a página rola normalmente.
- `npm run test:rules` roda junto no CI, mas nenhum campo de topo novo entra em `workout_templates`.

⚠️ Falta a validação no iPhone, principalmente o Modo Foco com o teclado numérico aberto — o preview não reproduz isso.

🤖 Generated with [Claude Code](https://claude.com/claude-code)