### PR TITLE
fix: empilha cópias em ordem cronológica na lista de treinos

### DIFF
--- a/src/pages/WorkoutsPage.jsx
+++ b/src/pages/WorkoutsPage.jsx
@@ -33,7 +33,7 @@ import { AddCardioModal } from '../components/AddCardioModal';
 import { StarterWorkoutsLibrary } from '../components/workout/StarterWorkoutsLibrary';
 import { ConfirmDialog } from '../components/design-system/ConfirmDialog';
 import { nextDisplayOrder, normalizeActiveWorkoutOrder, sortWorkoutTemplates } from '../utils/workoutTemplateOrder';
-import { buildCopyName, isCopyName } from '../utils/workoutCopyName';
+import { buildCopyName, copyInsertIndex, isCopyName } from '../utils/workoutCopyName';
 import { countBySourceFilter, matchesSourceFilter } from '../utils/workoutSourceFilter';
 import { SourceFilterChips } from '../components/workout/SourceFilterChips';
 import { toast } from 'sonner';
@@ -215,9 +215,13 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
 
     /**
      * Duplica uma ficha pelo caminho único de escrita (`workoutService`) e
-     * posiciona a cópia logo abaixo do original. Sem o reposicionamento a cópia
-     * pulava para o topo da lista: ela era a única com `displayOrder` definido,
-     * e `compareWorkoutTemplates` coloca quem tem ordem antes de quem não tem.
+     * posiciona a cópia no fim do bloco de cópias daquele treino — cronológico,
+     * "(Cópia)" e depois "(Cópia 2)". Entrar sempre logo abaixo do original
+     * deixava a mais recente por cima da mais antiga.
+     *
+     * Sem o reposicionamento a cópia pulava para o topo da lista: ela era a
+     * única com `displayOrder` definido, e `compareWorkoutTemplates` coloca
+     * quem tem ordem antes de quem não tem.
      */
     const duplicateWorkout = async (workout) => {
         const { workoutService } = await import('../services/workoutService');
@@ -269,7 +273,7 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
             const activeWorkouts = normalizeActiveWorkoutOrder(workouts);
             const originalIndex = activeWorkouts.findIndex(item => item.id === workout.id);
             const reordered = [...activeWorkouts];
-            reordered.splice(originalIndex >= 0 ? originalIndex + 1 : reordered.length, 0, copy);
+            reordered.splice(copyInsertIndex(activeWorkouts, originalIndex, workout.name), 0, copy);
 
             const normalized = reordered.map((item, displayOrder) => ({ ...item, displayOrder }));
             const orderById = new Map(normalized.map(item => [item.id, item]));

--- a/src/pages/WorkoutsPage.test.jsx
+++ b/src/pages/WorkoutsPage.test.jsx
@@ -179,6 +179,28 @@ describe('WorkoutsPage', () => {
             });
         });
 
+        // Cronológico: a segunda cópia entra depois da primeira, não em cima.
+        it('empilha a cópia seguinte no fim do bloco de cópias', async () => {
+            workoutService.createTemplate.mockResolvedValue('w1-copy');
+            workoutService.saveTemplateOrder.mockResolvedValue(undefined);
+            await renderPage();
+
+            await duplicate('Treino Peito');
+            await screen.findByText('Treino Peito (Cópia)');
+
+            workoutService.createTemplate.mockResolvedValue('w1-copy-2');
+            await duplicate('Treino Peito');
+
+            await waitFor(() => {
+                expect(workoutService.saveTemplateOrder).toHaveBeenLastCalledWith([
+                    expect.objectContaining({ id: 'w1', displayOrder: 0 }),
+                    expect.objectContaining({ id: 'w1-copy', displayOrder: 1 }),
+                    expect.objectContaining({ id: 'w1-copy-2', displayOrder: 2 }),
+                    expect.objectContaining({ id: 'w2', displayOrder: 3 })
+                ]);
+            });
+        });
+
         it('marca a cópia com o selo CÓPIA e numera a duplicação seguinte', async () => {
             workoutService.createTemplate.mockResolvedValue('w1-copy');
             workoutService.saveTemplateOrder.mockResolvedValue(undefined);

--- a/src/utils/workoutCopyName.js
+++ b/src/utils/workoutCopyName.js
@@ -30,6 +30,36 @@ export function isCopyName(name) {
 }
 
 /**
+ * Onde encaixar uma cópia nova: no fim do bloco de cópias que já segue o
+ * original, para a ordem ficar cronológica — "(Cópia)" e só então "(Cópia 2)".
+ * Entrar sempre logo abaixo do original deixava a mais recente por cima.
+ *
+ * Só percorre o bloco contíguo: uma cópia que o usuário arrastou para longe
+ * fica onde ele a colocou, e a nova continua junto do original.
+ *
+ * @param {Array<{name: string}>} templates Fichas na ordem exibida.
+ * @param {number} originalIndex Posição do treino duplicado (-1 se não achou).
+ * @param {string} originalName Nome do treino duplicado.
+ * @returns {number} Índice de inserção.
+ */
+export function copyInsertIndex(templates = [], originalIndex, originalName) {
+    if (originalIndex < 0) return templates.length;
+
+    const base = stripCopySuffix(originalName);
+    let index = originalIndex + 1;
+
+    while (
+        index < templates.length
+        && isCopyName(templates[index]?.name)
+        && stripCopySuffix(templates[index]?.name) === base
+    ) {
+        index += 1;
+    }
+
+    return index;
+}
+
+/**
  * Primeiro nome livre da sequência "<base> (Cópia)", "<base> (Cópia 2)"...
  * Preenche lacunas: com "(Cópia)" e "(Cópia 3)" ocupados, devolve "(Cópia 2)".
  *

--- a/src/utils/workoutCopyName.test.js
+++ b/src/utils/workoutCopyName.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildCopyName, isCopyName, stripCopySuffix } from './workoutCopyName';
+import { buildCopyName, copyInsertIndex, isCopyName, stripCopySuffix } from './workoutCopyName';
 
 describe('stripCopySuffix', () => {
     it('remove apenas o sufixo final de cópia', () => {
@@ -57,5 +57,34 @@ describe('buildCopyName', () => {
 
     it('funciona sem lista de nomes existentes', () => {
         expect(buildCopyName('Treino A')).toBe('Treino A (Cópia)');
+    });
+});
+
+describe('copyInsertIndex', () => {
+    const list = names => names.map(name => ({ name }));
+
+    it('entra logo abaixo do original quando ainda não há cópia', () => {
+        expect(copyInsertIndex(list(['Treino A', 'Treino B']), 0, 'Treino A')).toBe(1);
+    });
+
+    // Ordem cronológica: "(Cópia)" primeiro, "(Cópia 2)" depois.
+    it('entra no fim do bloco de cópias do mesmo treino', () => {
+        const templates = list(['Treino A', 'Treino A (Cópia)', 'Treino A (Cópia 2)', 'Treino B']);
+        expect(copyInsertIndex(templates, 0, 'Treino A')).toBe(3);
+    });
+
+    it('para no primeiro treino que não é cópia daquele original', () => {
+        const templates = list(['Treino A', 'Treino A (Cópia)', 'Treino B (Cópia)', 'Treino B']);
+        expect(copyInsertIndex(templates, 0, 'Treino A')).toBe(2);
+    });
+
+    // Duplicar a cópia continua alimentando o mesmo bloco.
+    it('usa o nome-base ao duplicar uma cópia', () => {
+        const templates = list(['Treino A', 'Treino A (Cópia)', 'Treino B']);
+        expect(copyInsertIndex(templates, 1, 'Treino A (Cópia)')).toBe(2);
+    });
+
+    it('joga para o fim quando o original não está na lista', () => {
+        expect(copyInsertIndex(list(['Treino A', 'Treino B']), -1, 'Treino C')).toBe(2);
     });
 });


### PR DESCRIPTION
Ajuste em cima do #58, pedido depois de ver o resultado no iPhone.

## Problema

A cópia nova entrava sempre logo abaixo do original, então duplicar duas vezes deixava a `(Cópia 2)` **acima** da `(Cópia)` — ordem invertida em relação a quando cada uma foi criada.

## Solução

A cópia passa a entrar no fim do bloco contíguo de cópias daquele treino (`copyInsertIndex` em `src/utils/workoutCopyName.js`), deixando a ordem cronológica: original → `(Cópia)` → `(Cópia 2)`.

O bloco é percorrido só enquanto os nomes seguem sendo cópia do mesmo nome-base. Duas consequências propositais:

- uma cópia que o usuário arrastou para longe na tela de Ordem fica onde ele a colocou, e a cópia nova continua junto do original;
- duplicar uma cópia alimenta o mesmo bloco, porque o índice parte do nome-base e não do nome completo.

## Verificação

- `npm run lint` e os 347 testes passando em cima da `main` já com o #58.
- Cobertura nova: `copyInsertIndex` (bloco vazio, bloco com cópias, parada no primeiro treino que não é cópia daquele original, duplicação de cópia, original ausente da lista) e um cenário de página duplicando duas vezes e conferindo a ordem final persistida em `saveTemplateOrder`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)