### PR TITLE
docs: registra o 403 de chave trocada que segurou o App Check em 0%

### DIFF
--- a/MANUAL_TECNICO.md
+++ b/MANUAL_TECNICO.md
@@ -208,6 +208,66 @@ Console → App Check → APIs, e **apenas no Cloud Firestore**. Deixe o Authent
 estiver marcado como PRÉ-LANÇAMENTO: travar o login com um recurso em beta tranca você para fora do
 próprio app.
 
+#### Verificadas em 0% não é falta de uso — é falha
+
+De 21/07 a 07/08/2026 o Cloud Firestore ficou em **0% verificadas / 100% sem verificação**, o que
+parecia "pouco tráfego ainda". Não era: o App Check nunca conseguiu emitir um token. O console do
+navegador em produção mostrava
+
+```
+@firebase/app-check: AppCheck: 403 error.
+Attempts allowed again after 01d:00m:00s (appCheck/initial-throttle)
+```
+
+**Causa:** existiam duas chaves reCAPTCHA Enterprise no projeto — `vitalita-appcheck` (a do bundle,
+criada em 21/07) e `vitalita-web-app-check` (órfã, de uma tentativa de 16/07, com domínio de preview
+do git na lista). O registro em App Check → Apps apontava para a **órfã**, então o Firebase recebia
+um atestado assinado por uma chave que não era a esperada e respondia `App attestation failed`.
+Corrigido em 07/08/2026 apontando o registro para a chave do bundle. Não exigiu redeploy — o bundle
+já tinha a chave certa.
+
+**Como diagnosticar isso em segundos**, sem depender do throttle de 24h do SDK: no console do
+navegador em produção, gere um token real e troque na mão.
+
+```js
+const siteKey = '<VITE_FIREBASE_APP_CHECK_SITE_KEY do bundle>';
+const appId = '<appId do firebaseConfig>';
+const apiKey = '<apiKey do firebaseConfig>';
+
+// O SDK carrega enterprise.js sem `?render=` e usa widget invisível, então
+// `execute(siteKey)` só funciona com um script carregado à parte:
+await new Promise(ok => {
+  const s = document.createElement('script');
+  s.src = `https://www.google.com/recaptcha/enterprise.js?render=${siteKey}`;
+  s.onload = ok; document.head.appendChild(s);
+});
+const t = await grecaptcha.enterprise.execute(siteKey, { action: 'fire_base' });
+const r = await fetch(
+  `https://content-firebaseappcheck.googleapis.com/v1/projects/<projectId>/apps/${appId}:exchangeRecaptchaEnterpriseToken?key=${apiKey}`,
+  { method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ recaptcha_enterprise_token: t }) }
+);
+console.log(r.status, await r.json());
+```
+
+Leitura do resultado:
+
+| Resposta | Significado |
+| --- | --- |
+| `200` + `token` + `ttl` | Registro e chave batem — App Check está de pé. |
+| `403 App attestation failed` | Chave do bundle ≠ chave registrada em App Check → Apps (ou chave de outro projeto). |
+| `403` com "requests to this API are blocked" | Firebase App Check API fora da lista de APIs permitidas da Browser key (ver §7.2). |
+
+Duas armadilhas ao validar:
+
+- **O throttle é por navegador.** Depois de um 403 o SDK se bloqueia por 24h; a janela normal segue
+  mostrando `appCheck/throttled` mesmo com tudo já corrigido. Valide em janela anônima, ou apague o
+  IndexedDB `firebase-app-check-database` e recarregue. Sucesso não loga nada — a ausência de erro
+  novo no console **é** o sinal de que funcionou.
+- **O percentual demora a subir.** Ele é média de uma janela recente, então precisa de tráfego novo
+  para diluir os dias de requisições sem verificação. E requisição ao Firestore só acontece com o
+  usuário logado: abrir a tela de login não move o número.
+
 ### 7.4. Importação de treino por PDF (`ANTHROPIC_API_KEY`)
 
 `api/parse-workout-pdf.js` lê um PDF de ficha com a API da Anthropic (modelo `claude-opus-4-8`) e

--- a/docs/app-check.md
+++ b/docs/app-check.md
@@ -62,6 +62,42 @@ As categorias principais no Firebase Console sao:
 
 Durante o monitoramento, essas categorias servem para diagnostico. Elas nao devem disparar bloqueio automatico.
 
+## Diagnostico: Verificadas Presas em 0%
+
+De 21/07 a 07/08/2026 o Cloud Firestore ficou em 0% verificadas e 100% sem verificacao. O numero
+parado parece "ainda ha pouco trafego", mas nesse caso era falha: o App Check nunca emitiu um token.
+
+O sinal esta no console do navegador em producao:
+
+```
+@firebase/app-check: AppCheck: 403 error.
+Attempts allowed again after 01d:00m:00s (appCheck/initial-throttle)
+```
+
+A causa foi um par de chaves reCAPTCHA Enterprise no mesmo projeto: o bundle usava `vitalita-appcheck`
+enquanto o registro em **App Check > Apps** apontava para `vitalita-web-app-check`, orfa de uma
+tentativa anterior. O Firebase recebia um atestado assinado pela chave errada e respondia
+`App attestation failed`. A correcao foi alinhar o registro com a chave do bundle, sem redeploy.
+
+Ordem de investigacao quando o percentual nao sai do zero:
+
+1. Confirme que o SDK inicializa: `typeof window.grecaptcha` deve ser `"object"` e
+   `document.querySelector('.grecaptcha-badge')` deve existir. Se nao, o problema e a variavel de
+   ambiente ou o redeploy, nao o registro.
+2. Compare a site key do bundle com a registrada em **App Check > Apps** (clique na linha do app).
+   Divergencia entre as duas e a causa mais provavel do `App attestation failed`.
+3. Confirme que a chave existe no projeto em **Google Cloud > Seguranca > reCAPTCHA Enterprise**. O
+   ID da chave e a propria site key.
+4. Se a resposta do 403 disser que as requisicoes para a API estao bloqueadas, o problema e a lista
+   de APIs permitidas da Browser key, nao o App Check.
+
+O procedimento de troca manual de token, que diagnostica isso em segundos sem esperar o throttle de
+24 horas, esta na secao 7.3 do `MANUAL_TECNICO.md`.
+
+Ao validar a correcao, lembre que o throttle de 24 horas e por navegador: use janela anonima ou
+apague o IndexedDB `firebase-app-check-database`. Sucesso nao gera log, entao a ausencia de erro novo
+no console e o sinal de que funcionou.
+
 ## Desenvolvimento Local
 
 O provider de debug deve ser usado somente quando for necessario testar App Check localmente:


### PR DESCRIPTION
Só documentação — a correção em si foi feita no Firebase Console em 07/08/2026, sem mudança de código.

## O que aconteceu

De 21/07 a 07/08/2026 o Cloud Firestore apareceu como **0% verificadas / 100% sem verificação** em App Check → APIs. Isso foi lido como "ainda tem pouco tráfego", e por isso a decisão do enforcement vinha sendo adiada.

Não era pouco tráfego: o App Check **nunca emitiu um token**. O console de produção mostrava

```
@firebase/app-check: AppCheck: 403 error.
Attempts allowed again after 01d:00m:00s (appCheck/initial-throttle)
```

**Causa:** duas chaves reCAPTCHA Enterprise no projeto `app-treino-17bbf`.

| Chave | Onde estava | Situação |
| --- | --- | --- |
| `vitalita-appcheck` | no bundle de produção | correta, mas rejeitada |
| `vitalita-web-app-check` | no registro em App Check → Apps | órfã, de uma tentativa de 16/07 que só vivia no ambiente Preview |

O Firebase recebia um atestado assinado pela chave do bundle e comparava com a registrada. Resultado: `App attestation failed`, e o SDK se auto-bloqueando por 24h a cada tentativa.

**Correção:** apontar o registro para a chave do bundle. Não precisou de redeploy — a `VITE_FIREBASE_APP_CHECK_SITE_KEY` em produção já estava certa.

## Como foi confirmado

Um token reCAPTCHA real trocado na mão no endpoint do App Check, direto do console do navegador em produção:

- antes da correção: `403 App attestation failed`
- depois: `200`, com token e `ttl: 3600s`
- e o app em produção parou de logar erro de App Check após limpar o IndexedDB e recarregar

## O que este PR adiciona

- **`MANUAL_TECNICO.md` §7.3** — o incidente, o procedimento de troca manual do token (diagnostica em segundos, sem esperar o throttle de 24h) e uma tabela que separa "chave trocada" de "Firebase App Check API fora da lista de APIs permitidas da Browser key". Inclui o detalhe de que o SDK carrega `enterprise.js` sem `?render=` e usa widget invisível, então `execute(siteKey)` só funciona com um script carregado à parte — o que confunde na hora de reproduzir na mão.
- **`docs/app-check.md`** — seção de diagnóstico com a ordem de investigação em 4 passos, apontando para o §7.3 para o procedimento completo. Mantido o estilo sem acentos do arquivo.

Ficam registradas as duas armadilhas que atrapalham a validação:

- **o throttle é por navegador** — depois de um 403 a janela normal segue mostrando `appCheck/throttled` mesmo com tudo corrigido; valide em anônima ou apague o IndexedDB `firebase-app-check-database`;
- **sucesso não gera log** — a ausência de erro novo no console é o sinal.

## Fora do escopo

O enforcement **continua desligado**, como deve ser: o percentual ainda vai levar dias para subir, porque é média de janela recente e precisa diluir duas semanas de requisições sem verificação. A chave órfã `vitalita-web-app-check` também segue lá, para apagar só depois de confirmar o percentual subindo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)