### PR TITLE
feat: expõe falha do token do App Check em painel de diagnóstico

### DIFF
--- a/MANUAL_TECNICO.md
+++ b/MANUAL_TECNICO.md
@@ -226,7 +226,17 @@ um atestado assinado por uma chave que não era a esperada e respondia `App atte
 Corrigido em 07/08/2026 apontando o registro para a chave do bundle. Não exigiu redeploy — o bundle
 já tinha a chave certa.
 
-**Como diagnosticar isso em segundos**, sem depender do throttle de 24h do SDK: no console do
+**Primeira parada:** abra o app com `?debug=appcheck` na URL. Um painel no rodapé mostra se o token
+está sendo emitido (`ativo`), se falhou (`falhando (<código>)`) ou se o App Check nem está ligado
+(`desligado (sem site key)`), com o histórico de falhas. Funciona no PWA do iPhone, sem cabo nem
+console — que é justamente onde o incidente passou despercebido. `?debug=off` desliga. O painel de
+push do descanso abre do mesmo jeito, com `?debug=push`.
+
+O estado vem de `src/services/appCheckDiagnostics.js`, alimentado por uma verificação de token que
+`appCheckService.js` dispara **sem bloquear o boot**. Ela existe porque a inicialização do SDK passa
+normalmente mesmo quando a emissão do token falha — era exatamente esse o buraco.
+
+**Para diagnosticar direto na origem**, sem depender do throttle de 24h do SDK: no console do
 navegador em produção, gere um token real e troque na mão.
 
 ```js

--- a/docs/app-check.md
+++ b/docs/app-check.md
@@ -79,7 +79,29 @@ enquanto o registro em **App Check > Apps** apontava para `vitalita-web-app-chec
 tentativa anterior. O Firebase recebia um atestado assinado pela chave errada e respondia
 `App attestation failed`. A correcao foi alinhar o registro com a chave do bundle, sem redeploy.
 
-Ordem de investigacao quando o percentual nao sai do zero:
+### Painel no proprio app
+
+Abrir a URL com `?debug=appcheck` liga um painel fixo no rodape com o estado do token. Ele existe
+porque o Sentry fica desligado em Production por decisao (ver `observability.md`) e o PWA instalado
+no iPhone nao tem console acessivel. A flag persiste em `localStorage`, entao sobrevive a navegacao
+e ao app aberto pela tela de inicio; `?debug=off` desliga (e vale tambem para o painel de push, que
+abre com `?debug=push`).
+
+Estados possiveis:
+
+| Estado | Significado |
+| --- | --- |
+| `ativo` | Token emitido com sucesso na ultima verificacao. |
+| `falhando (<codigo>)` | O SDK inicializou mas nao conseguiu o token. E o caso do incidente. |
+| `desligado (sem site key)` | Variavel de ambiente ausente ou build de desenvolvimento. Nao e quebra. |
+
+O painel tambem lista o historico de falhas. Sucesso repetido nao entra na lista de proposito: com
+20 posicoes, registrar todo boot bem-sucedido empurraria para fora justamente a falha que se quer
+enxergar.
+
+### Ordem de investigacao
+
+Quando o percentual nao sai do zero:
 
 1. Confirme que o SDK inicializa: `typeof window.grecaptcha` deve ser `"object"` e
    `document.querySelector('.grecaptcha-badge')` deve existir. Se nao, o problema e a variavel de

--- a/src/components/AppCheckDebugPanel.jsx
+++ b/src/components/AppCheckDebugPanel.jsx
@@ -1,0 +1,125 @@
+/**
+ * AppCheckDebugPanel.jsx
+ * Painel de diagnóstico do App Check. Mostra se o token está sendo emitido e o
+ * histórico de falhas, para conferir num aparelho real — o Sentry é desligado
+ * em produção por decisão (docs/observability.md) e um PWA de iPhone não tem
+ * console à mão.
+ *
+ * Oculto por padrão: abre com `?debug=appcheck` na URL e fecha no ✕ (ou com
+ * `?debug=off`, que desliga também o painel de push). Sem afordância visível em
+ * produção — o painel só aparece para quem souber o parâmetro.
+ */
+import React, { useEffect, useState } from 'react';
+import { useDebugPanelFlag } from '../hooks/useDebugPanelFlag';
+import { getAppCheckLog, getAppCheckStatus, clearAppCheckLog } from '../services/appCheckDiagnostics';
+import { isAppCheckMonitoringEnabled } from '../services/appCheckService';
+
+/**
+ * "Desligado" e "falhando" são estados diferentes e a distinção é o ponto do
+ * painel: sem site key o App Check nem tenta, e ler isso como quebra manda o
+ * diagnóstico para o lado errado.
+ */
+function describeState(status) {
+    // `mostraHorario` fica falso quando não há verificação corrente: o status
+    // sobrevive no storage, e exibir o horário de uma checagem de outro build
+    // faria parecer que o App Check acabou de rodar.
+    if (!isAppCheckMonitoringEnabled()) {
+        return { label: 'desligado (sem site key)', color: '#94a3b8', mostraHorario: false };
+    }
+    if (!status) {
+        return { label: 'verificando...', color: '#94a3b8', mostraHorario: false };
+    }
+    if (status.ok) {
+        return { label: 'ativo', color: '#86efac', mostraHorario: true };
+    }
+    return { label: `falhando (${status.code || 'sem código'})`, color: '#fca5a5', mostraHorario: true };
+}
+
+export function AppCheckDebugPanel() {
+    const [enabled, disable] = useDebugPanelFlag('appcheck');
+    const [status, setStatus] = useState(null);
+    const [log, setLog] = useState([]);
+
+    useEffect(() => {
+        if (!enabled) return undefined;
+        const refresh = () => {
+            setStatus(getAppCheckStatus());
+            setLog(getAppCheckLog());
+        };
+        refresh();
+        const id = setInterval(refresh, 1000);
+        return () => clearInterval(id);
+    }, [enabled]);
+
+    if (!enabled) return null;
+
+    const state = describeState(status);
+
+    const box = {
+        position: 'fixed',
+        left: 8,
+        right: 8,
+        bottom: 8,
+        zIndex: 2147483647,
+        maxHeight: '45vh',
+        overflowY: 'auto',
+        background: 'rgba(2,6,23,0.96)',
+        color: '#e2e8f0',
+        border: '1px solid #334155',
+        borderRadius: 12,
+        padding: 10,
+        font: '11px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace'
+    };
+
+    const button = {
+        background: '#1e293b',
+        color: '#e2e8f0',
+        border: '1px solid #334155',
+        borderRadius: 6,
+        padding: '2px 8px'
+    };
+
+    return (
+        <div style={box}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 6 }}>
+                <strong>app check debug</strong>
+                <div style={{ display: 'flex', gap: 6 }}>
+                    <button onClick={() => { clearAppCheckLog(); setLog([]); }} style={button}>
+                        limpar
+                    </button>
+                    <button onClick={disable} aria-label="Fechar diagnóstico" style={{ ...button, padding: '2px 10px' }}>
+                        ✕
+                    </button>
+                </div>
+            </div>
+
+            <div style={{ marginBottom: 6, color: state.color }}>
+                token: {state.label}
+                {state.mostraHorario && status?.checkedAt
+                    && ` · verificado ${new Date(status.checkedAt).toLocaleTimeString('pt-BR')}`}
+            </div>
+
+            {status && !status.ok && status.message && (
+                <div style={{ marginBottom: 6, color: '#fca5a5', wordBreak: 'break-word' }}>
+                    {status.message}
+                </div>
+            )}
+
+            {log.length === 0 ? (
+                <div style={{ color: '#64748b' }}>sem falhas registradas</div>
+            ) : (
+                log.map((entry, i) => (
+                    <div key={i} style={{ borderTop: '1px solid #1e293b', paddingTop: 4, marginTop: 4 }}>
+                        <span style={{ color: '#64748b' }}>{new Date(entry.t).toLocaleString('pt-BR')}</span>
+                        {' · '}
+                        <span style={{ color: entry.stage === 'token:recuperado' ? '#86efac' : '#fca5a5' }}>
+                            {entry.stage}
+                        </span>
+                        {entry.code && ` · ${entry.code}`}
+                        {entry.repeticoes > 1 && ` · ${entry.repeticoes}x`}
+                    </div>
+                ))
+            )}
+        </div>
+    );
+}

--- a/src/hooks/useDebugPanelFlag.js
+++ b/src/hooks/useDebugPanelFlag.js
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+
+/**
+ * Flag "grudenta" dos painéis de diagnóstico: `?debug=<nome>` liga e o estado
+ * persiste em `localStorage`; `?debug=off` desliga.
+ *
+ * A persistência não é conveniência — é requisito. O PWA instalado na tela de
+ * início abre sem barra de endereço, então não há como redigitar o parâmetro; a
+ * flag também precisa sobreviver aos redirects de auth (ex.: /login) e à
+ * navegação entre rotas.
+ *
+ * Cada painel guarda a própria chave, então `?debug=off` desliga todos os que
+ * estiverem montados.
+ *
+ * @param {string} name Valor esperado em `?debug=` (ex.: 'appcheck').
+ * @returns {[boolean, () => void]} Estado e função para desligar.
+ */
+export function useDebugPanelFlag(name) {
+    const storageKey = `vitalita:debug:${name}`;
+
+    const read = () => {
+        if (typeof window === 'undefined') return false;
+        try {
+            const param = new URLSearchParams(window.location.search).get('debug');
+            if (param === name) {
+                localStorage.setItem(storageKey, '1');
+                return true;
+            }
+            if (param === 'off') {
+                localStorage.removeItem(storageKey);
+                return false;
+            }
+            return localStorage.getItem(storageKey) === '1';
+        } catch {
+            return false;
+        }
+    };
+
+    const [enabled, setEnabled] = useState(read);
+
+    const disable = () => {
+        try {
+            localStorage.removeItem(storageKey);
+        } catch {
+            // Sem storage (modo privado/quota): fechar em memória já basta.
+        }
+        setEnabled(false);
+    };
+
+    return [enabled, disable];
+}

--- a/src/hooks/useDebugPanelFlag.test.js
+++ b/src/hooks/useDebugPanelFlag.test.js
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useDebugPanelFlag } from './useDebugPanelFlag';
+
+function setSearch(search) {
+    window.history.replaceState({}, '', `/${search}`);
+}
+
+describe('useDebugPanelFlag', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        setSearch('');
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        localStorage.clear();
+    });
+
+    it('fica desligado sem o parâmetro', () => {
+        const { result } = renderHook(() => useDebugPanelFlag('appcheck'));
+        expect(result.current[0]).toBe(false);
+    });
+
+    it('liga com ?debug=<nome>', () => {
+        setSearch('?debug=appcheck');
+        const { result } = renderHook(() => useDebugPanelFlag('appcheck'));
+        expect(result.current[0]).toBe(true);
+    });
+
+    it('ignora o parâmetro de outro painel', () => {
+        setSearch('?debug=push');
+        const { result } = renderHook(() => useDebugPanelFlag('appcheck'));
+        expect(result.current[0]).toBe(false);
+    });
+
+    // O PWA instalado abre sem barra de endereço: sem persistir, não haveria
+    // como reabrir o painel no aparelho.
+    it('persiste depois que o parâmetro some da URL', () => {
+        setSearch('?debug=appcheck');
+        renderHook(() => useDebugPanelFlag('appcheck'));
+
+        setSearch('');
+        const { result } = renderHook(() => useDebugPanelFlag('appcheck'));
+        expect(result.current[0]).toBe(true);
+    });
+
+    it('desliga com ?debug=off', () => {
+        setSearch('?debug=appcheck');
+        renderHook(() => useDebugPanelFlag('appcheck'));
+
+        setSearch('?debug=off');
+        const { result } = renderHook(() => useDebugPanelFlag('appcheck'));
+        expect(result.current[0]).toBe(false);
+
+        setSearch('');
+        const depois = renderHook(() => useDebugPanelFlag('appcheck'));
+        expect(depois.result.current[0]).toBe(false);
+    });
+
+    it('desliga pela função devolvida e não volta no próximo render', () => {
+        setSearch('?debug=appcheck');
+        const { result } = renderHook(() => useDebugPanelFlag('appcheck'));
+
+        act(() => result.current[1]());
+        expect(result.current[0]).toBe(false);
+
+        setSearch('');
+        const depois = renderHook(() => useDebugPanelFlag('appcheck'));
+        expect(depois.result.current[0]).toBe(false);
+    });
+
+    it('não lança quando o localStorage falha', () => {
+        vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+            throw new Error('sem storage');
+        });
+
+        const { result } = renderHook(() => useDebugPanelFlag('appcheck'));
+        expect(result.current[0]).toBe(false);
+    });
+});

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -15,6 +15,7 @@ import { initPushDiagnostics } from './services/pushDiagnostics';
 import { SpeedInsightsLoader } from './components/SpeedInsightsLoader';
 import { ObservabilityTracker } from './components/ObservabilityTracker';
 import { PushDebugPanel } from './components/PushDebugPanel';
+import { AppCheckDebugPanel } from './components/AppCheckDebugPanel';
 import {
     initializeAppCheckMonitoring,
     isAppCheckMonitoringEnabled
@@ -31,6 +32,7 @@ function renderApplication() {
                     <ObservabilityTracker />
                     <App />
                     <PushDebugPanel />
+                    <AppCheckDebugPanel />
                     <SpeedInsightsLoader />
                 </BrowserRouter>
             </AuthProvider>

--- a/src/services/appCheckDiagnostics.js
+++ b/src/services/appCheckDiagnostics.js
@@ -1,0 +1,115 @@
+/**
+ * appCheckDiagnostics.js
+ * Estado e log leve do token do App Check, para diagnosticar em produção — onde
+ * o Sentry é desligado por decisão (ver docs/observability.md) e um PWA de
+ * iPhone não tem console à mão.
+ *
+ * Existe por causa do incidente de 21/07 a 07/08/2026: a troca do token
+ * devolvia 403 e o SDK só emitia um `console.warn`, então a quebra passou duas
+ * semanas despercebida. Ver MANUAL_TECNICO.md §7.3.
+ *
+ * Tudo aqui é "melhor esforço" e nunca pode lançar: diagnóstico jamais deve
+ * quebrar o boot do app. Roda apenas no contexto da janela (usa localStorage).
+ */
+
+const STATUS_KEY = 'vitalita:appCheckStatus';
+const LOG_KEY = 'vitalita:appCheckLog';
+const MAX_ENTRIES = 20;
+
+function hasStorage() {
+    return typeof window !== 'undefined' && typeof localStorage !== 'undefined';
+}
+
+function safeParse(raw, fallback) {
+    try {
+        const parsed = JSON.parse(raw);
+        return parsed ?? fallback;
+    } catch {
+        return fallback;
+    }
+}
+
+/** Estado da última verificação, ou `null` se nunca houve uma. */
+export function getAppCheckStatus() {
+    if (!hasStorage()) return null;
+    try {
+        const raw = localStorage.getItem(STATUS_KEY);
+        return raw ? safeParse(raw, null) : null;
+    } catch {
+        return null;
+    }
+}
+
+/** Eventos registrados (mais antigo → mais recente). */
+export function getAppCheckLog() {
+    if (!hasStorage()) return [];
+    try {
+        const parsed = safeParse(localStorage.getItem(LOG_KEY), []);
+        return Array.isArray(parsed) ? parsed : [];
+    } catch {
+        return [];
+    }
+}
+
+export function clearAppCheckLog() {
+    if (!hasStorage()) return;
+    try {
+        localStorage.removeItem(LOG_KEY);
+    } catch {
+        // Sem storage (modo privado/quota): diagnóstico é opcional.
+    }
+}
+
+/**
+ * Grava o resultado da verificação do token.
+ *
+ * O status é sobrescrito a cada boot, mas o log só recebe entrada quando algo
+ * muda de figura: uma falha, ou a volta de falha para sucesso. Registrar todo
+ * sucesso encheria as 20 posições em poucos dias de uso e empurraria para fora
+ * justamente a falha que se quer enxergar.
+ *
+ * @param {{ ok: boolean, code?: string, message?: string }} result
+ */
+export function recordAppCheckStatus({ ok, code, message } = {}) {
+    if (!hasStorage()) return;
+
+    try {
+        const previous = getAppCheckStatus();
+        const status = {
+            ok: Boolean(ok),
+            code: code || null,
+            message: message || null,
+            checkedAt: new Date().toISOString()
+        };
+
+        localStorage.setItem(STATUS_KEY, JSON.stringify(status));
+
+        const recuperou = status.ok && previous && previous.ok === false;
+        if (status.ok && !recuperou) return;
+
+        const stage = status.ok ? 'token:recuperado' : 'token:erro';
+        const log = getAppCheckLog();
+        const ultima = log[log.length - 1];
+
+        // O SDK repete a mesma falha a cada poucos segundos. Sem agrupar,
+        // 20 entradas idênticas se acumulam em dois minutos e empurram para
+        // fora o começo do problema — que é a informação que interessa.
+        if (ultima && ultima.stage === stage && ultima.code === status.code) {
+            ultima.repeticoes = (ultima.repeticoes || 1) + 1;
+            ultima.ultimaT = status.checkedAt;
+        } else {
+            log.push({
+                t: status.checkedAt,
+                stage,
+                code: status.code,
+                message: status.message,
+                repeticoes: 1
+            });
+        }
+
+        while (log.length > MAX_ENTRIES) log.shift();
+        localStorage.setItem(LOG_KEY, JSON.stringify(log));
+    } catch {
+        // Sem storage (modo privado/quota): diagnóstico é opcional.
+    }
+}

--- a/src/services/appCheckDiagnostics.test.js
+++ b/src/services/appCheckDiagnostics.test.js
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    clearAppCheckLog,
+    getAppCheckLog,
+    getAppCheckStatus,
+    recordAppCheckStatus
+} from './appCheckDiagnostics';
+
+describe('appCheckDiagnostics', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        localStorage.clear();
+    });
+
+    it('grava o status da última verificação', () => {
+        recordAppCheckStatus({ ok: false, code: 'appCheck/fetch-status-error', message: '403' });
+
+        const status = getAppCheckStatus();
+        expect(status.ok).toBe(false);
+        expect(status.code).toBe('appCheck/fetch-status-error');
+        expect(status.message).toBe('403');
+        expect(status.checkedAt).toBeTruthy();
+    });
+
+    it('devolve null quando nunca houve verificação', () => {
+        expect(getAppCheckStatus()).toBeNull();
+        expect(getAppCheckLog()).toEqual([]);
+    });
+
+    // O log existe para mostrar falha; sucesso repetido a cada boot empurraria
+    // a falha para fora das 20 posições.
+    it('não registra no log quando o sucesso apenas se repete', () => {
+        recordAppCheckStatus({ ok: true });
+        recordAppCheckStatus({ ok: true });
+        recordAppCheckStatus({ ok: true });
+
+        expect(getAppCheckStatus().ok).toBe(true);
+        expect(getAppCheckLog()).toEqual([]);
+    });
+
+    it('registra cada falha de código diferente', () => {
+        recordAppCheckStatus({ ok: false, code: 'appCheck/throttled' });
+        recordAppCheckStatus({ ok: false, code: 'appCheck/fetch-status-error' });
+
+        const log = getAppCheckLog();
+        expect(log).toHaveLength(2);
+        expect(log.map(e => e.stage)).toEqual(['token:erro', 'token:erro']);
+        expect(log[1].code).toBe('appCheck/fetch-status-error');
+    });
+
+    // O SDK repete a mesma falha a cada poucos segundos: sem agrupar, o começo
+    // do problema seria empurrado para fora do log em dois minutos.
+    it('agrupa repetições da mesma falha preservando o horário do início', () => {
+        recordAppCheckStatus({ ok: false, code: 'appCheck/recaptcha-error' });
+        const primeira = getAppCheckLog()[0].t;
+
+        recordAppCheckStatus({ ok: false, code: 'appCheck/recaptcha-error' });
+        recordAppCheckStatus({ ok: false, code: 'appCheck/recaptcha-error' });
+
+        const log = getAppCheckLog();
+        expect(log).toHaveLength(1);
+        expect(log[0].repeticoes).toBe(3);
+        expect(log[0].t).toBe(primeira);
+        expect(log[0].ultimaT).toBeTruthy();
+    });
+
+    it('abre entrada nova quando o código da falha muda', () => {
+        recordAppCheckStatus({ ok: false, code: 'appCheck/recaptcha-error' });
+        recordAppCheckStatus({ ok: false, code: 'appCheck/recaptcha-error' });
+        recordAppCheckStatus({ ok: false, code: 'appCheck/throttled' });
+
+        const log = getAppCheckLog();
+        expect(log).toHaveLength(2);
+        expect(log[0].repeticoes).toBe(2);
+        expect(log[1].code).toBe('appCheck/throttled');
+    });
+
+    it('registra a volta de falha para sucesso', () => {
+        recordAppCheckStatus({ ok: false, code: 'appCheck/throttled' });
+        recordAppCheckStatus({ ok: true });
+
+        const log = getAppCheckLog();
+        expect(log).toHaveLength(2);
+        expect(log[1].stage).toBe('token:recuperado');
+
+        // Recuperado uma vez, os sucessos seguintes voltam a ser silenciosos.
+        recordAppCheckStatus({ ok: true });
+        expect(getAppCheckLog()).toHaveLength(2);
+    });
+
+    it('mantém o log circular em 20 entradas', () => {
+        for (let i = 0; i < 25; i += 1) {
+            recordAppCheckStatus({ ok: false, code: `erro-${i}` });
+        }
+
+        const log = getAppCheckLog();
+        expect(log).toHaveLength(20);
+        expect(log[0].code).toBe('erro-5');
+        expect(log[19].code).toBe('erro-24');
+    });
+
+    it('limpa o log sem apagar o status', () => {
+        recordAppCheckStatus({ ok: false, code: 'appCheck/throttled' });
+        clearAppCheckLog();
+
+        expect(getAppCheckLog()).toEqual([]);
+        expect(getAppCheckStatus().ok).toBe(false);
+    });
+
+    // Diagnóstico nunca pode quebrar o boot — nem em modo privado/quota cheia.
+    it('não lança quando o localStorage falha', () => {
+        vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+            throw new Error('quota exceeded');
+        });
+
+        expect(() => recordAppCheckStatus({ ok: false, code: 'x' })).not.toThrow();
+    });
+
+    it('ignora conteúdo corrompido no storage', () => {
+        localStorage.setItem('vitalita:appCheckLog', 'não é json');
+        localStorage.setItem('vitalita:appCheckStatus', '{quebrado');
+
+        expect(getAppCheckLog()).toEqual([]);
+        expect(getAppCheckStatus()).toBeNull();
+    });
+});

--- a/src/services/appCheckService.js
+++ b/src/services/appCheckService.js
@@ -1,6 +1,7 @@
 import { app } from '../firebaseApp';
 import { getAppCheckRuntimeConfig } from '../utils/appCheck';
 import { captureTechnicalError } from './observabilityService';
+import { recordAppCheckStatus } from './appCheckDiagnostics';
 
 const runtimeConfig = getAppCheckRuntimeConfig({
     siteKey: import.meta.env.VITE_FIREBASE_APP_CHECK_SITE_KEY,
@@ -15,6 +16,34 @@ export function isAppCheckMonitoringEnabled() {
     return runtimeConfig.enabled;
 }
 
+/**
+ * Confirma que o token é realmente emitido, e não só que o SDK inicializou.
+ *
+ * Essa distinção é o motivo desta função existir: no incidente de 21/07 a
+ * 07/08/2026 a inicialização passava normalmente e a falha (403) só aparecia na
+ * troca do token, onde o SDK apenas emite `console.warn`. Ver MANUAL_TECNICO.md §7.3.
+ *
+ * Nunca lança e nunca é aguardada — falha de diagnóstico não pode virar falha
+ * de boot.
+ */
+function verifyToken(getToken, appCheck) {
+    if (typeof getToken !== 'function') return;
+
+    try {
+        Promise.resolve(getToken(appCheck))
+            .then(() => recordAppCheckStatus({ ok: true }))
+            .catch((error) => {
+                recordAppCheckStatus({ ok: false, code: error?.code, message: error?.message });
+                captureTechnicalError(error, {
+                    operation: 'app_check_token_failed',
+                    source: 'app_check'
+                });
+            });
+    } catch (error) {
+        recordAppCheckStatus({ ok: false, code: error?.code, message: error?.message });
+    }
+}
+
 export async function initializeAppCheckMonitoring() {
     if (!runtimeConfig.enabled) return null;
 
@@ -24,11 +53,21 @@ export async function initializeAppCheckMonitoring() {
         }
 
         appCheckPromise = import('firebase/app-check')
-            .then(({ initializeAppCheck, ReCaptchaEnterpriseProvider }) => initializeAppCheck(app, {
-                provider: new ReCaptchaEnterpriseProvider(runtimeConfig.siteKey),
-                isTokenAutoRefreshEnabled: true
-            }))
+            .then(({ initializeAppCheck, ReCaptchaEnterpriseProvider, getToken }) => {
+                const appCheck = initializeAppCheck(app, {
+                    provider: new ReCaptchaEnterpriseProvider(runtimeConfig.siteKey),
+                    isTokenAutoRefreshEnabled: true
+                });
+
+                // Intencionalmente sem `await`: `main.jsx` espera esta promise
+                // antes de renderizar, e encadear a busca de token aqui
+                // atrasaria o primeiro render pelo tempo do reCAPTCHA + rede.
+                verifyToken(getToken, appCheck);
+
+                return appCheck;
+            })
             .catch((error) => {
+                recordAppCheckStatus({ ok: false, code: error?.code, message: error?.message });
                 captureTechnicalError(error, {
                     operation: 'app_check_init_failed',
                     source: 'app_check'

--- a/src/services/appCheckService.test.js
+++ b/src/services/appCheckService.test.js
@@ -3,6 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
     captureTechnicalError: vi.fn(),
     initializeAppCheck: vi.fn(() => ({ type: 'app-check' })),
+    getToken: vi.fn(() => Promise.resolve({ token: 'app-check-token' })),
+    recordAppCheckStatus: vi.fn(),
     provider: vi.fn(function ReCaptchaEnterpriseProvider(siteKey) {
         this.siteKey = siteKey;
     })
@@ -12,15 +14,22 @@ vi.mock('../firebaseApp', () => ({ app: { name: 'test-app' } }));
 vi.mock('./observabilityService', () => ({
     captureTechnicalError: mocks.captureTechnicalError
 }));
+vi.mock('./appCheckDiagnostics', () => ({
+    recordAppCheckStatus: mocks.recordAppCheckStatus
+}));
 vi.mock('firebase/app-check', () => ({
     initializeAppCheck: mocks.initializeAppCheck,
-    ReCaptchaEnterpriseProvider: mocks.provider
+    ReCaptchaEnterpriseProvider: mocks.provider,
+    getToken: mocks.getToken
 }));
+
+const flush = () => new Promise(resolve => setTimeout(resolve, 0));
 
 describe('appCheckService', () => {
     beforeEach(() => {
         vi.resetModules();
         vi.clearAllMocks();
+        mocks.getToken.mockResolvedValue({ token: 'app-check-token' });
         vi.stubEnv('VITE_FIREBASE_APP_CHECK_DEBUG', 'false');
         delete globalThis.FIREBASE_APPCHECK_DEBUG_TOKEN;
     });
@@ -66,6 +75,71 @@ describe('appCheckService', () => {
         expect(globalThis.FIREBASE_APPCHECK_DEBUG_TOKEN).toBe(true);
     });
 
+    it('grava sucesso quando o token é emitido', async () => {
+        vi.stubEnv('PROD', true);
+        vi.stubEnv('VITE_FIREBASE_APP_CHECK_SITE_KEY', 'public-site-key');
+        const service = await import('./appCheckService');
+
+        await service.initializeAppCheckMonitoring();
+        await flush();
+
+        expect(mocks.getToken).toHaveBeenCalledWith({ type: 'app-check' });
+        expect(mocks.recordAppCheckStatus).toHaveBeenCalledWith({ ok: true });
+        expect(mocks.captureTechnicalError).not.toHaveBeenCalled();
+    });
+
+    // O buraco que este trabalho fecha: a inicialização passava e a falha só
+    // aparecia aqui, como console.warn que ninguém vê.
+    it('reporta falha na obtenção do token, que a inicialização não pega', async () => {
+        const error = Object.assign(new Error('403'), { code: 'appCheck/fetch-status-error' });
+        mocks.getToken.mockRejectedValueOnce(error);
+        vi.stubEnv('PROD', true);
+        vi.stubEnv('VITE_FIREBASE_APP_CHECK_SITE_KEY', 'public-site-key');
+        const service = await import('./appCheckService');
+
+        await expect(service.initializeAppCheckMonitoring()).resolves.toEqual({ type: 'app-check' });
+        await flush();
+
+        expect(mocks.recordAppCheckStatus).toHaveBeenCalledWith({
+            ok: false,
+            code: 'appCheck/fetch-status-error',
+            message: '403'
+        });
+        expect(mocks.captureTechnicalError).toHaveBeenCalledWith(error, {
+            operation: 'app_check_token_failed',
+            source: 'app_check'
+        });
+    });
+
+    // `main.jsx` dá await nesta promise antes de renderizar: encadear o getToken
+    // aqui atrasaria o primeiro render pelo tempo do reCAPTCHA + rede.
+    it('resolve sem esperar a verificação do token', async () => {
+        let liberarToken;
+        mocks.getToken.mockImplementationOnce(() => new Promise(resolve => { liberarToken = resolve; }));
+        vi.stubEnv('PROD', true);
+        vi.stubEnv('VITE_FIREBASE_APP_CHECK_SITE_KEY', 'public-site-key');
+        const service = await import('./appCheckService');
+
+        await expect(service.initializeAppCheckMonitoring()).resolves.toEqual({ type: 'app-check' });
+        expect(mocks.recordAppCheckStatus).not.toHaveBeenCalled();
+
+        liberarToken({ token: 'app-check-token' });
+        await flush();
+        expect(mocks.recordAppCheckStatus).toHaveBeenCalledWith({ ok: true });
+    });
+
+    it('não verifica token quando o App Check está desligado', async () => {
+        vi.stubEnv('PROD', true);
+        vi.stubEnv('VITE_FIREBASE_APP_CHECK_SITE_KEY', '');
+        const service = await import('./appCheckService');
+
+        await service.initializeAppCheckMonitoring();
+        await flush();
+
+        expect(mocks.getToken).not.toHaveBeenCalled();
+        expect(mocks.recordAppCheckStatus).not.toHaveBeenCalled();
+    });
+
     it('reports initialization errors without rejecting application startup', async () => {
         const error = new Error('provider unavailable');
         mocks.initializeAppCheck.mockImplementationOnce(() => {
@@ -79,6 +153,11 @@ describe('appCheckService', () => {
         expect(mocks.captureTechnicalError).toHaveBeenCalledWith(error, {
             operation: 'app_check_init_failed',
             source: 'app_check'
+        });
+        expect(mocks.recordAppCheckStatus).toHaveBeenCalledWith({
+            ok: false,
+            code: undefined,
+            message: 'provider unavailable'
         });
     });
 });


### PR DESCRIPTION
Fecha o buraco de observabilidade que deixou o incidente do App Check passar duas semanas despercebido. **Não liga enforcement.**

## O problema

`appCheckService.js` reportava apenas falha de **inicialização**. O `403 App attestation failed` acontecia depois, na busca do token, onde o SDK só emite um `console.warn` — invisível num PWA de iPhone. Resultado: verificadas cravadas em 0% de 21/07 a 07/08/2026, lido como "ainda tem pouco tráfego".

Com enforcement ligado, isso teria sido queda total e silenciosa.

## Por que não é só mandar para o Sentry

[docs/observability.md](docs/observability.md) registra decisão de 14/07/2026: **Sentry roda só em Preview; Production não deve ter `VITE_SENTRY_DSN`**. Reportar só ao Sentry não cobriria justamente onde a falha aconteceu.

O sinal de produção vai para um painel no próprio app, seguindo o padrão que o projeto já usa para o push do descanso (`PushDebugPanel` + `pushDiagnostics`), criado exatamente para "diagnosticar num aparelho real, sem depender de cabo/console". O `captureTechnicalError` continua sendo chamado — cobre o Preview.

## O que entra

- **`appCheckDiagnostics.js`** — status corrente + log circular de 20 posições. Duas decisões de ruído: sucesso repetido não entra no log, e repetições da mesma falha são agrupadas com contador. A segunda veio da verificação: o SDK repete o erro a cada poucos segundos e, sem agrupar, as 20 posições enchiam em dois minutos, empurrando para fora o começo do problema — que é a informação que interessa.
- **`appCheckService.js`** — verifica a emissão do token reusando o `getToken` do import dinâmico de `firebase/app-check` que já existia (a exceção proposital à regra de não importar Firebase dinamicamente fica onde já estava). A verificação roda **sem bloquear o boot**: `main.jsx` dá `await` na inicialização antes de renderizar, e encadear a busca de token ali atrasaria o primeiro render pelo tempo do reCAPTCHA + rede. Há teste dedicado para essa regressão.
- **`?debug=appcheck`** — painel com estado, horário da última verificação e histórico de falhas. `useDebugPanelFlag` encapsula a flag grudenta em `localStorage`, necessária porque o PWA instalado abre sem barra de endereço. `?debug=off` desliga.
- **Docs** — `MANUAL_TECNICO.md` §7.3 aponta o painel como primeira parada, antes do procedimento manual de troca de token; `docs/app-check.md` ganha a tabela de estados. Aproveitei para documentar o `?debug=push`, que só existia num comentário de código.

O `PushDebugPanel` **não** foi refatorado para usar o hook: não tem teste nenhum e foi validado em aparelho real. Como cada painel limpa a própria chave ao ver `?debug=off`, o comportamento fica consistente sem tocar nele.

## Verificação

`npm run lint`, 369 testes, 12 das Functions e build — todos passando.

Testado em **build de produção** (`npm run preview`), nos quatro estados:

| Cenário | Painel |
| --- | --- |
| Build sem site key | `desligado (sem site key)` |
| Site key inválida | `falhando (appCheck/recaptcha-error)` |
| Site key real a partir de localhost | `falhando (appCheck/initial-throttle)` |
| Status ok | `ativo`, em verde |

Também confirmado que o painel não aparece sem a flag e que `?debug=off` limpa a persistência.

Uma limitação honesta: o estado `ativo` foi verificado injetando o status, porque `localhost:4173` não está na lista de domínios da chave reCAPTCHA e não consegue emitir token. O caminho ponta a ponta do sucesso só é observável em produção — que é, aliás, mais um dado útil que a verificação produziu.

Falta a validação no iPhone com o PWA instalado, que é onde o painel precisa funcionar de verdade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)