### PR TITLE
feat: barra de aviso descendo do topo, no lugar do sonner

### DIFF
--- a/MANUAL_TECNICO.md
+++ b/MANUAL_TECNICO.md
@@ -27,7 +27,7 @@ O **Vitalità** é uma aplicação Single Page Application (SPA) construída com
 - **[Tailwind CSS v4](https://tailwindcss.com/):** Framework de utilitários CSS para estilização rápida e consistente.
 - **[Framer Motion](https://www.framer.com/motion/):** Biblioteca para animações complexas e transições de layout.
 - **[Lucide React](https://lucide.dev/):** Coleção de ícones vetoriais leves.
-- **[Sonner](https://sonner.emilkowal.ski/):** Componente de notificações (Toast) elegante e performático.
+- **`TopBanner` (componente próprio):** Barra de aviso full-bleed que desce do topo, alimentada pelo store de módulo `notifyStore`. Substituiu a biblioteca Sonner, que saiu do projeto.
 
 ### Gerenciamento de Estado e Dados
 - **Context API (React):** Gerenciamento de estado global para Autenticação (`AuthContext`) e Sessão de Treino (`WorkoutContext`).

--- a/docs/superpowers/plans/2026-08-12-banner-aviso-topo.md
+++ b/docs/superpowers/plans/2026-08-12-banner-aviso-topo.md
@@ -41,7 +41,30 @@ Ela usa duas opções que o store não previa. Decisão do usuário:
   segue: sem ação, `AUTO_DISMISS_MS`; com ação e sem `duration`, não some sozinha.
   A sugestão de bi-set passa `8000` e mantém o comportamento de hoje — é sugestão
   opcional, não erro, e ignorá-la deve bastar para ela sair de cena. O "Tentar
-  Novamente" do perfil continua sem `duration`, esperando toque.
+  Novamente" do perfil continua sem `duration`, esperando toque. **(Revertido pela
+  Emenda 2 — ver abaixo.)**
+
+## Emenda 2 — decidida na revisão final (13/08/2026)
+
+A regra "com ação, espera toque" foi desenhada olhando o aviso isolado. A revisão
+final da branch mostrou a consequência que ninguém tinha visto: como a barra vive
+na raiz autenticada e não tem X, swipe nem `dismiss` na desmontagem, o aviso de
+falha ao carregar o perfil ficava **permanente e sem forma de fechar**, acompanhando
+o usuário para Home, Treinos, Histórico e execução, por cima de tudo em `z-[10000]`.
+Bastava abrir o Perfil offline uma vez para ficar com uma faixa vermelha fixa no
+topo do app inteiro. O `sonner` não tinha esse problema porque aquela chamada
+passava `duration: 5000` mesmo tendo botão.
+
+Decisão do usuário: **devolver o `duration: 5000`** à chamada de `useProfileData`.
+Isso restaura a paridade com o comportamento anterior à migração e resolve de uma
+vez três coisas — a permanência, o vazamento do aviso entre telas, e o aviso
+sobrevivendo ao logout com um `onClick` preso a um hook já desmontado.
+
+Efeito colateral registrado: a deduplicação por `id` que o `sonner` fazia nessa
+chamada **não** tem substituto no store — o early-return de dedup exige
+`!action && !current.action`, e esta é a única chamada com ação. Quem evita o
+incômodo de repetição aqui é o `duration`, não a dedup. Os comentários de
+`useProfileData.js` e `notifyStore.js` afirmavam o contrário e foram corrigidos.
 
 Isso reabre `notifyStore` e `TopBanner` (Tarefas 1 e 2) numa tarefa 5a, executada
 antes de fechar a Tarefa 5.

--- a/docs/superpowers/plans/2026-08-12-banner-aviso-topo.md
+++ b/docs/superpowers/plans/2026-08-12-banner-aviso-topo.md
@@ -1,0 +1,985 @@
+# Barra de aviso descendo do topo — plano de implementação
+
+> **Para agentes:** SUB-SKILL OBRIGATÓRIA: use `superpowers:subagent-driven-development` (recomendado) ou `superpowers:executing-plans` para executar tarefa por tarefa. Os passos usam checkbox (`- [ ]`) para acompanhamento.
+
+**Objetivo:** substituir o toast do `sonner` por uma barra própria que desce do topo, full-bleed, usada por todos os avisos do app — e passar a confirmar o salvamento de ficha no caminho normal.
+
+**Arquitetura:** um store de módulo (`notifyStore`) guarda o aviso atual e cuida do ciclo de vida dele; um componente (`TopBanner`) lê esse store com `useSyncExternalStore` e desenha a barra com framer-motion. O store ser um módulo, e não contexto React, é requisito: dois emissores ficam fora da árvore React. O `sonner` sai do projeto.
+
+**Stack:** React 19, framer-motion 12, lucide-react, Tailwind, Vitest + @testing-library/react (jsdom).
+
+**Spec:** [docs/superpowers/specs/2026-08-12-banner-aviso-topo-design.md](../specs/2026-08-12-banner-aviso-topo-design.md)
+
+## Restrições globais
+
+- Node 24 + npm 11. Em shell não-interativo o gerenciador de versão não carrega; use `fnm exec --using=24 -- <comando>` quando a versão importar. Nunca rode `npm install` que reescreva o `package-lock.json` num npm de major diferente.
+- Português em comentários, mensagens de commit e textos de UI. Conventional Commits (`feat:`, `fix:`, `docs:`, `chore:`).
+- Nunca importe pacote do Firebase dinamicamente (`await import('firebase/...')`) — quebra o boot em produção. Não se aplica ao `sonner`, mas os imports dinâmicos dele estão sendo removidos por este plano.
+- O CI reprova por lint. Sequência completa antes de fechar:
+  `npm run lint && npm test -- --run && npm --prefix functions test && npm run build`
+- Um teste isolado: `npm test -- --run src/utils/notifyStore.test.js`
+- Portas de dev são fixas (5175 dev, 4173 preview) por causa da restrição de referrer da API key. Não altere.
+
+## Desvio consciente do spec
+
+O spec diz que o `TopBanner` "agenda o auto-dismiss". **O timer fica no store, não no componente.** Motivo: com o timer no store, as regras de tempo ("some em 3s", "com ação não some") são testáveis em JavaScript puro, sem depender do ciclo de animação do framer-motion dentro do jsdom — que é justamente onde teste de componente fica frágil. O componente vira uma view pura. Nada mais muda no comportamento descrito.
+
+## Estrutura de arquivos
+
+**Criar:**
+- `src/utils/notifyStore.js` — estado do aviso atual, API imperativa (`notify.*`), fila de um, regra de `id`, timer de auto-dismiss.
+- `src/utils/notifyStore.test.js`
+- `src/components/design-system/TopBanner.jsx` — a barra: posição, cores, animação, acessibilidade.
+- `src/components/design-system/TopBanner.test.jsx`
+
+**Modificar:**
+- `src/AppAuthed.jsx` — monta `TopBanner`; remove `SonnerToaster`, o `React.lazy` dele e o gate `shouldRenderToaster`.
+- `src/services/workoutService.js` e `src/pages/HomeDashboard.jsx` — removem o helper `showToastError` e o `await import('sonner')`.
+- `src/services/workoutService.test.js` — troca o mock de `sonner` pelo do `notifyStore`.
+- 9 arquivos de UI — troca de import e prefixo (tabela na Tarefa 5).
+- `src/pages/CreateWorkoutPage.jsx` — ganha o aviso que falta ao salvar ficha.
+- `package.json` — remove `sonner`.
+
+---
+
+### Tarefa 1: store dos avisos
+
+**Arquivos:**
+- Criar: `src/utils/notifyStore.js`
+- Teste: `src/utils/notifyStore.test.js`
+
+**Interfaces:**
+- Consome: nada.
+- Produz: `notify.success(message, options?)`, `notify.error(...)`, `notify.info(...)`, `notify.dismiss()` — todos síncronos, retornam o `id` (número) do aviso; `subscribeToNotify(listener) => unsubscribe`; `getNotifySnapshot() => { id, type, message, action } | null`; `resetNotifyStore()`; constante `AUTO_DISMISS_MS = 3000`. `options` aceita só `{ action: { label, onClick } }`. `type` é `'success' | 'error' | 'info'`.
+
+- [ ] **Passo 1: escrever os testes que falham**
+
+```javascript
+// src/utils/notifyStore.test.js
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+    notify,
+    subscribeToNotify,
+    getNotifySnapshot,
+    resetNotifyStore,
+    AUTO_DISMISS_MS
+} from './notifyStore';
+
+describe('notifyStore', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        resetNotifyStore();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('guarda o aviso e notifica quem assinou', () => {
+        const listener = vi.fn();
+        subscribeToNotify(listener);
+
+        notify.success('Treino salvo.');
+
+        expect(listener).toHaveBeenCalled();
+        expect(getNotifySnapshot()).toMatchObject({ type: 'success', message: 'Treino salvo.' });
+    });
+
+    it('cancela a assinatura', () => {
+        const listener = vi.fn();
+        const unsubscribe = subscribeToNotify(listener);
+        unsubscribe();
+
+        notify.info('Qualquer coisa.');
+
+        expect(listener).not.toHaveBeenCalled();
+    });
+
+    // Fila de um: empilhar barras full-bleed cobriria a tela.
+    it('aviso novo substitui o anterior', () => {
+        notify.success('Treino salvo.');
+        notify.error('Erro ao salvar treino.');
+
+        expect(getNotifySnapshot()).toMatchObject({ type: 'error', message: 'Erro ao salvar treino.' });
+    });
+
+    // O id é a chave de remount do componente: sem id novo, duas mensagens
+    // em sequência trocariam o texto sem refazer a descida.
+    it('gera id novo a cada aviso diferente', () => {
+        const primeiro = notify.success('Treino salvo.');
+        const segundo = notify.success('Treino duplicado.');
+
+        expect(segundo).not.toBe(primeiro);
+    });
+
+    it('aviso idêntico ao que está na tela não gera id novo', () => {
+        const primeiro = notify.error('Erro ao carregar treinos.');
+        const repetido = notify.error('Erro ao carregar treinos.');
+
+        expect(repetido).toBe(primeiro);
+    });
+
+    it('mesma mensagem em tipo diferente gera id novo', () => {
+        const primeiro = notify.info('Pronto.');
+        const segundo = notify.success('Pronto.');
+
+        expect(segundo).not.toBe(primeiro);
+    });
+
+    it('some sozinho depois da duração', () => {
+        notify.success('Treino salvo.');
+
+        vi.advanceTimersByTime(AUTO_DISMISS_MS);
+
+        expect(getNotifySnapshot()).toBeNull();
+    });
+
+    it('o relógio do aviso novo recomeça do zero', () => {
+        notify.success('Treino salvo.');
+        vi.advanceTimersByTime(AUTO_DISMISS_MS - 500);
+        notify.success('Treino duplicado.');
+
+        vi.advanceTimersByTime(AUTO_DISMISS_MS - 500);
+        expect(getNotifySnapshot()).not.toBeNull();
+
+        vi.advanceTimersByTime(500);
+        expect(getNotifySnapshot()).toBeNull();
+    });
+
+    // Sumir em 3s levaria o botão embora antes de o usuário decidir.
+    it('com ação, não some sozinho', () => {
+        notify.error('Erro ao carregar dados.', {
+            action: { label: 'Tentar Novamente', onClick: vi.fn() }
+        });
+
+        vi.advanceTimersByTime(AUTO_DISMISS_MS * 3);
+
+        expect(getNotifySnapshot()).toMatchObject({ message: 'Erro ao carregar dados.' });
+        expect(getNotifySnapshot().action.label).toBe('Tentar Novamente');
+    });
+
+    it('dismiss limpa na hora', () => {
+        notify.success('Treino salvo.');
+
+        notify.dismiss();
+
+        expect(getNotifySnapshot()).toBeNull();
+    });
+
+    it('dismiss não deixa o timer antigo derrubar um aviso posterior', () => {
+        notify.success('Treino salvo.');
+        notify.dismiss();
+        notify.info('Outro aviso.');
+
+        vi.advanceTimersByTime(AUTO_DISMISS_MS - 1);
+
+        expect(getNotifySnapshot()).toMatchObject({ message: 'Outro aviso.' });
+    });
+});
+```
+
+- [ ] **Passo 2: rodar e confirmar que falha**
+
+Rodar: `npm test -- --run src/utils/notifyStore.test.js`
+Esperado: FAIL — `Failed to resolve import "./notifyStore"`.
+
+- [ ] **Passo 3: implementar o store**
+
+```javascript
+// src/utils/notifyStore.js
+/**
+ * notifyStore.js
+ * Estado dos avisos do app — a barra que desce do topo (`TopBanner`).
+ *
+ * É um módulo, e não um contexto React, por requisito e não por estilo:
+ * `workoutService` e `HomeDashboard` emitem erro de fora da árvore React.
+ * A API imperativa (`notify.success(...)`) é a mesma forma que o `sonner`
+ * expunha, então os pontos de chamada não mudam de formato.
+ */
+
+export const AUTO_DISMISS_MS = 3000;
+
+const listeners = new Set();
+
+let current = null;
+let nextId = 1;
+let timerId = null;
+
+function emit() {
+    listeners.forEach(listener => listener());
+}
+
+function clearTimer() {
+    if (timerId !== null) {
+        clearTimeout(timerId);
+        timerId = null;
+    }
+}
+
+function push(type, message, options = {}) {
+    const action = options.action || null;
+
+    // Aviso idêntico ao que já está na tela mantém o id: sem isso a barra
+    // refaria a descida por cima dela mesma. Substitui a deduplicação por
+    // `id` que o sonner fazia em useProfileData.
+    if (current && current.type === type && current.message === message && !action && !current.action) {
+        return current.id;
+    }
+
+    clearTimer();
+    current = { id: nextId++, type, message, action };
+
+    // Com ação, a barra espera toque — ver AUTO_DISMISS_MS no spec.
+    if (!action) {
+        timerId = setTimeout(() => {
+            timerId = null;
+            current = null;
+            emit();
+        }, AUTO_DISMISS_MS);
+    }
+
+    emit();
+    return current.id;
+}
+
+export const notify = {
+    success: (message, options) => push('success', message, options),
+    error: (message, options) => push('error', message, options),
+    info: (message, options) => push('info', message, options),
+    dismiss: () => {
+        clearTimer();
+        if (current !== null) {
+            current = null;
+            emit();
+        }
+    }
+};
+
+export function subscribeToNotify(listener) {
+    listeners.add(listener);
+    return () => {
+        listeners.delete(listener);
+    };
+}
+
+export function getNotifySnapshot() {
+    return current;
+}
+
+/** Só para testes: zera o estado entre casos. */
+export function resetNotifyStore() {
+    clearTimer();
+    current = null;
+    nextId = 1;
+}
+```
+
+- [ ] **Passo 4: rodar e confirmar que passa**
+
+Rodar: `npm test -- --run src/utils/notifyStore.test.js`
+Esperado: PASS, 11 testes.
+
+- [ ] **Passo 5: commitar**
+
+```bash
+git add src/utils/notifyStore.js src/utils/notifyStore.test.js
+git commit -m "feat: store dos avisos com fila de um e auto-dismiss"
+```
+
+---
+
+### Tarefa 2: a barra
+
+**Arquivos:**
+- Criar: `src/components/design-system/TopBanner.jsx`
+- Teste: `src/components/design-system/TopBanner.test.jsx`
+
+**Interfaces:**
+- Consome: `subscribeToNotify`, `getNotifySnapshot`, `notify.dismiss` de `src/utils/notifyStore.js`.
+- Produz: `export function TopBanner()` — componente sem props. Renderiza `data-testid="top-banner"` e `data-type` com o tipo do aviso.
+
+- [ ] **Passo 1: escrever os testes que falham**
+
+```jsx
+// src/components/design-system/TopBanner.test.jsx
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { TopBanner } from './TopBanner';
+import { notify, resetNotifyStore, getNotifySnapshot } from '../../utils/notifyStore';
+
+describe('TopBanner', () => {
+    beforeEach(() => {
+        resetNotifyStore();
+    });
+
+    afterEach(() => {
+        resetNotifyStore();
+    });
+
+    it('não renderiza nada sem aviso', () => {
+        render(<TopBanner />);
+
+        expect(screen.queryByTestId('top-banner')).not.toBeInTheDocument();
+    });
+
+    it('mostra a mensagem quando o aviso chega', () => {
+        render(<TopBanner />);
+
+        act(() => { notify.success('Treino salvo.'); });
+
+        expect(screen.getByTestId('top-banner')).toBeInTheDocument();
+        expect(screen.getByText('Treino salvo.')).toBeInTheDocument();
+    });
+
+    it('mostra o aviso que já estava no store antes da montagem', () => {
+        notify.success('Treino salvo.');
+
+        render(<TopBanner />);
+
+        expect(screen.getByText('Treino salvo.')).toBeInTheDocument();
+    });
+
+    it.each([
+        ['success', 'bg-emerald-600'],
+        ['error', 'bg-red-600'],
+        ['info', 'bg-blue-600']
+    ])('usa a cor do tipo %s', (tipo, classe) => {
+        render(<TopBanner />);
+
+        act(() => { notify[tipo]('Mensagem.'); });
+
+        const barra = screen.getByTestId('top-banner');
+        expect(barra).toHaveAttribute('data-type', tipo);
+        expect(barra.className).toContain(classe);
+    });
+
+    // A cor precisa alcançar o pixel 0: é isso que faz o texto cair na faixa
+    // abaixo do relógio em vez de atrás dele.
+    it('ancora no topo, de borda a borda', () => {
+        render(<TopBanner />);
+
+        act(() => { notify.success('Treino salvo.'); });
+
+        expect(screen.getByTestId('top-banner').className).toContain('top-0');
+        expect(screen.getByTestId('top-banner').className).toContain('inset-x-0');
+    });
+
+    // Sem botão, a barra não precisa de toque nenhum — e é isso que permite
+    // ela ficar acima dos modais de z-9999 sem roubar toque.
+    it('não intercepta toque quando não tem ação', () => {
+        render(<TopBanner />);
+
+        act(() => { notify.success('Treino salvo.'); });
+
+        expect(screen.getByTestId('top-banner').className).toContain('pointer-events-none');
+    });
+
+    it('anuncia erro como alert e sucesso como status', () => {
+        render(<TopBanner />);
+
+        act(() => { notify.error('Erro ao salvar treino.'); });
+        expect(screen.getByRole('alert')).toHaveAttribute('aria-live', 'assertive');
+
+        act(() => { notify.success('Treino salvo.'); });
+        expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'polite');
+    });
+
+    it('renderiza o botão da ação e o deixa clicável', () => {
+        render(<TopBanner />);
+
+        act(() => {
+            notify.error('Erro ao carregar dados.', {
+                action: { label: 'Tentar Novamente', onClick: vi.fn() }
+            });
+        });
+
+        const botao = screen.getByRole('button', { name: 'Tentar Novamente' });
+        expect(botao.className).toContain('pointer-events-auto');
+    });
+
+    it('clique na ação dispara o onClick e fecha a barra', () => {
+        const onClick = vi.fn();
+        render(<TopBanner />);
+
+        act(() => {
+            notify.error('Erro ao carregar dados.', { action: { label: 'Tentar Novamente', onClick } });
+        });
+
+        act(() => {
+            screen.getByRole('button', { name: 'Tentar Novamente' }).click();
+        });
+
+        expect(onClick).toHaveBeenCalledTimes(1);
+        expect(getNotifySnapshot()).toBeNull();
+    });
+});
+```
+
+- [ ] **Passo 2: rodar e confirmar que falha**
+
+Rodar: `npm test -- --run src/components/design-system/TopBanner.test.jsx`
+Esperado: FAIL — `Failed to resolve import "./TopBanner"`.
+
+- [ ] **Passo 3: implementar a barra**
+
+```jsx
+// src/components/design-system/TopBanner.jsx
+/**
+ * TopBanner.jsx
+ * Barra de aviso que desce do topo — o único formato de aviso do app.
+ *
+ * Ela pinta de `top: 0` até abaixo da status bar (`pt-[env(safe-area-inset-top)]`)
+ * e põe o conteúdo na faixa sob o relógio. Isso é o oposto do defeito que #51/#53
+ * corrigiram: o aviso antigo era um card curto ancorado a `top-6`, inteiramente
+ * dentro da zona da status bar, e sumia sem ser lido.
+ *
+ * `pointer-events-none` no wrapper: sem botão, a barra não recebe toque nenhum,
+ * e por isso pode ficar em z-10000 — acima dos modais de z-9999 (NumericKeypad,
+ * PremiumAlert) — sem risco de roubar um toque. Só o botão de ação, quando
+ * existe, volta a `pointer-events-auto`.
+ *
+ * O timer do auto-dismiss mora no `notifyStore`, não aqui: as regras de tempo
+ * ficam testáveis sem depender do ciclo de animação dentro do jsdom.
+ */
+import { useSyncExternalStore } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { CheckCircle2, AlertCircle } from 'lucide-react';
+import { notify, subscribeToNotify, getNotifySnapshot } from '../../utils/notifyStore';
+
+const backgrounds = {
+    success: 'bg-emerald-600',
+    error: 'bg-red-600',
+    info: 'bg-blue-600'
+};
+
+const icons = {
+    success: CheckCircle2,
+    error: AlertCircle,
+    info: AlertCircle
+};
+
+export function TopBanner() {
+    const current = useSyncExternalStore(subscribeToNotify, getNotifySnapshot, () => null);
+
+    const isError = current?.type === 'error';
+    const Icon = current ? (icons[current.type] || AlertCircle) : null;
+
+    function handleAction() {
+        const onClick = current?.action?.onClick;
+        notify.dismiss();
+        if (typeof onClick === 'function') onClick();
+    }
+
+    return (
+        <AnimatePresence>
+            {current && (
+                <motion.div
+                    key={current.id}
+                    initial={{ y: '-100%' }}
+                    animate={{ y: 0 }}
+                    exit={{ y: '-100%', transition: { duration: 0.2, ease: 'easeIn' } }}
+                    transition={{ duration: 0.26, ease: 'easeOut' }}
+                    role={isError ? 'alert' : 'status'}
+                    aria-live={isError ? 'assertive' : 'polite'}
+                    data-testid="top-banner"
+                    data-type={current.type}
+                    className={`fixed inset-x-0 top-0 z-[10000] pointer-events-none pt-[env(safe-area-inset-top)] text-white shadow-lg ${backgrounds[current.type] || backgrounds.info}`}
+                >
+                    <div className="flex items-center gap-3 px-5 py-3">
+                        <Icon size={20} className="shrink-0" />
+                        <span className="flex-1 font-bold text-sm">{current.message}</span>
+                        {current.action && (
+                            <button
+                                type="button"
+                                onClick={handleAction}
+                                className="pointer-events-auto shrink-0 rounded-full bg-white/20 px-3 py-1 text-sm font-bold hover:bg-white/30 transition-colors"
+                            >
+                                {current.action.label}
+                            </button>
+                        )}
+                    </div>
+                </motion.div>
+            )}
+        </AnimatePresence>
+    );
+}
+```
+
+- [ ] **Passo 4: rodar e confirmar que passa**
+
+Rodar: `npm test -- --run src/components/design-system/TopBanner.test.jsx`
+Esperado: PASS.
+
+Se `it.each` reclamar de `notify[tipo]` inexistente, confira se o store exporta os três métodos (`success`, `error`, `info`).
+
+- [ ] **Passo 5: commitar**
+
+```bash
+git add src/components/design-system/TopBanner.jsx src/components/design-system/TopBanner.test.jsx
+git commit -m "feat: barra de aviso full-bleed descendo do topo"
+```
+
+---
+
+### Tarefa 3: montar a barra e tirar o Toaster do sonner
+
+**Arquivos:**
+- Modificar: `src/AppAuthed.jsx` (linhas 26, 40, 121, 146-158 e 445-467)
+
+**Interfaces:**
+- Consome: `TopBanner` da Tarefa 2.
+- Produz: nada para tarefas seguintes.
+
+Não há teste unitário aqui — `AppAuthed` não tem suíte própria. A verificação é lint + build, e a visual fica na Tarefa 7.
+
+**Atenção aos números de linha:** todos se referem ao arquivo original. Como os passos removem linhas de cima para baixo, cada remoção desloca as seguintes — localize cada trecho pelo conteúdo citado, não pelo número.
+
+- [ ] **Passo 1: adicionar o import**
+
+Depois de `import { MotionPreferences } from './components/common/MotionPreferences';` (linha 11), acrescentar:
+
+```jsx
+import { TopBanner } from './components/design-system/TopBanner';
+```
+
+Import estático, e não `React.lazy`: o componente é pequeno, o framer-motion já está no bundle, e o aviso precisa existir desde o primeiro render — um erro de carregamento pode disparar antes de qualquer `requestIdleCallback`.
+
+- [ ] **Passo 2: remover o lazy do sonner**
+
+Apagar a linha 26:
+
+```jsx
+const loadSonnerToaster = () => import('sonner').then(module => ({ default: module.Toaster }));
+```
+
+E a linha 40:
+
+```jsx
+const SonnerToaster = React.lazy(loadSonnerToaster);
+```
+
+- [ ] **Passo 3: remover o gate `shouldRenderToaster`**
+
+Apagar a linha 121:
+
+```jsx
+const [shouldRenderToaster, setShouldRenderToaster] = useState(false);
+```
+
+E o efeito inteiro que começa na linha 146:
+
+```jsx
+    useEffect(() => {
+        if (typeof window === 'undefined') return undefined;
+
+        const scheduleToaster = () => setShouldRenderToaster(true);
+
+        if ('requestIdleCallback' in window) {
+            const idleId = window.requestIdleCallback(scheduleToaster, { timeout: 1500 });
+            return () => window.cancelIdleCallback(idleId);
+        }
+
+        const timeoutId = window.setTimeout(scheduleToaster, 700);
+        return () => window.clearTimeout(timeoutId);
+    }, []);
+```
+
+- [ ] **Passo 4: trocar o bloco do Toaster pela barra**
+
+Substituir o comentário e o bloco condicional (linhas 445-467) por:
+
+```jsx
+            {/*
+              * A barra pinta de `top: 0` até abaixo da status bar e põe o texto
+              * na faixa sob o relógio. Não é o aviso "voltando pro topo": o que
+              * sumia atrás da status bar em #51/#53 era um card curto ancorado
+              * a `top-6`, inteiramente dentro daquela zona.
+              *
+              * Fica na raiz autenticada de propósito — salvar uma ficha volta
+              * pra lista no mesmo tique, e o aviso precisa sobreviver à
+              * navegação.
+              */}
+            <TopBanner />
+```
+
+- [ ] **Passo 5: verificar que `Suspense` e `useState` continuam usados**
+
+Rodar: `npm run lint`
+Esperado: sem erro. Se o ESLint acusar import não usado de `React`, `Suspense` ou `useState`, é porque este era o último uso — remova só o que ele apontar. (Ambos são usados em outros pontos do arquivo; o esperado é nada mudar nos imports.)
+
+- [ ] **Passo 6: build**
+
+Rodar: `npm run build`
+Esperado: sucesso. O `sonner` ainda aparece no bundle nesta etapa — os outros arquivos ainda o importam.
+
+- [ ] **Passo 7: commitar**
+
+```bash
+git add src/AppAuthed.jsx
+git commit -m "feat: monta a barra de aviso no lugar do Toaster do sonner"
+```
+
+---
+
+### Tarefa 4: migrar os emissores de fora do React
+
+**Arquivos:**
+- Modificar: `src/services/workoutService.js` (linhas 12-24, 110, 350, 352, 506, 544)
+- Modificar: `src/pages/HomeDashboard.jsx` (linhas 92-103, 236, 241, 299)
+- Modificar: `src/services/workoutService.test.js` (linhas 4, 6-10)
+
+**Interfaces:**
+- Consome: `notify` da Tarefa 1.
+- Produz: nada para tarefas seguintes.
+
+- [ ] **Passo 1: trocar o mock no teste existente**
+
+Em `src/services/workoutService.test.js`, substituir a linha 4:
+
+```javascript
+import { toast } from 'sonner';
+```
+
+por:
+
+```javascript
+import { notify } from '../utils/notifyStore';
+```
+
+E o bloco das linhas 6-10:
+
+```javascript
+vi.mock('sonner', () => ({
+    toast: {
+        error: vi.fn()
+    }
+}));
+```
+
+por:
+
+```javascript
+vi.mock('../utils/notifyStore', () => ({
+    notify: {
+        error: vi.fn()
+    }
+}));
+```
+
+Depois, no corpo do arquivo, trocar toda ocorrência de `toast.error` por `notify.error`.
+
+- [ ] **Passo 2: rodar e confirmar que falha**
+
+Rodar: `npm test -- --run src/services/workoutService.test.js`
+Esperado: FAIL — as asserções sobre `notify.error` não são satisfeitas, porque o service ainda chama o `sonner` pelo import dinâmico (que o mock não intercepta).
+
+- [ ] **Passo 3: migrar o `workoutService`**
+
+Remover as linhas 12-24 (o `let sonnerPromise;` e a função `showToastError` inteira) e acrescentar, junto dos imports do topo:
+
+```javascript
+import { notify } from '../utils/notifyStore';
+```
+
+Depois trocar as cinco chamadas — todas perdem o `await`, porque `notify.error` é síncrono:
+
+| Linha | De | Para |
+|---|---|---|
+| 110 | `await showToastError("Erro ao carregar treinos. Verifique sua conexão.");` | `notify.error("Erro ao carregar treinos. Verifique sua conexão.");` |
+| 350 | `await showToastError("Erro de índice. Verifique o console.");` | `notify.error("Erro de índice. Verifique o console.");` |
+| 352 | `await showToastError("Erro ao carregar histórico.");` | `notify.error("Erro ao carregar histórico.");` |
+| 506 | `await showToastError("Erro ao buscar exercícios. Verifique sua conexão.");` | `notify.error("Erro ao buscar exercícios. Verifique sua conexão.");` |
+| 544 | `await showToastError("Erro ao salvar sessão de cardio.");` | `notify.error("Erro ao salvar sessão de cardio.");` |
+
+O `try/catch` silencioso que envolvia o import dinâmico some junto: `notify.error` é uma escrita em memória e não tem como falhar de um jeito que precise ser mascarado.
+
+- [ ] **Passo 4: rodar e confirmar que passa**
+
+Rodar: `npm test -- --run src/services/workoutService.test.js`
+Esperado: PASS.
+
+- [ ] **Passo 5: migrar o `HomeDashboard`**
+
+Remover as linhas 92-103 (`let toastPromise;` e a função `showToastError`) e acrescentar, junto dos imports do topo:
+
+```javascript
+import { notify } from '../utils/notifyStore';
+```
+
+Trocar as três chamadas, sem `await`:
+
+| Linha | De | Para |
+|---|---|---|
+| 236 | `await showToastError("Card de compartilhamento indisponível.");` | `notify.error("Card de compartilhamento indisponível.");` |
+| 241 | `await showToastError("O compartilhamento requer conexão segura. Use HTTPS ou localhost.");` | `notify.error("O compartilhamento requer conexão segura. Use HTTPS ou localhost.");` |
+| 299 | `await showToastError("Erro ao gerar imagem de compartilhamento.");` | `notify.error("Erro ao gerar imagem de compartilhamento.");` |
+
+- [ ] **Passo 6: confirmar que nenhum import dinâmico de sonner sobrou**
+
+Rodar: `grep -rn "import('sonner')" src`
+Esperado: nenhuma saída.
+
+- [ ] **Passo 7: lint e suíte**
+
+Rodar: `npm run lint && npm test -- --run`
+Esperado: PASS.
+
+- [ ] **Passo 8: commitar**
+
+```bash
+git add src/services/workoutService.js src/services/workoutService.test.js src/pages/HomeDashboard.jsx
+git commit -m "refactor: emissores fora do React usam o notifyStore direto"
+```
+
+---
+
+### Tarefa 5: migrar os 9 arquivos de UI
+
+**Arquivos:**
+
+| Modificar | Chamadas |
+|---|---|
+| `src/pages/ProfilePage.jsx` | 10 |
+| `src/pages/WorkoutsPage.jsx` | 9 |
+| `src/pages/CreateWorkoutPage.jsx` | 6 |
+| `src/pages/TrainerDashboard.jsx` | 4 |
+| `src/components/AddCardioModal.jsx` | 3 |
+| `src/components/history/WorkoutDetailsModal.jsx` | 3 |
+| `src/components/PwaUpdatePrompt.jsx` | 2 |
+| `src/components/achievements/AchievementUnlockedModal.jsx` | 1 |
+| `src/hooks/profile/useProfileData.js` | 1 |
+
+**Interfaces:**
+- Consome: `notify` da Tarefa 1.
+- Produz: nada para tarefas seguintes.
+
+- [ ] **Passo 1: trocar import e prefixo nos 8 arquivos mecânicos**
+
+Em cada um dos oito primeiros da tabela (todos menos `useProfileData.js`), trocar:
+
+```javascript
+import { toast } from 'sonner';
+```
+
+pelo caminho relativo correto do `notifyStore`:
+
+- `src/pages/*.jsx` → `import { notify } from '../utils/notifyStore';`
+- `src/components/*.jsx` → `import { notify } from '../utils/notifyStore';`
+- `src/components/history/*.jsx` e `src/components/achievements/*.jsx` → `import { notify } from '../../utils/notifyStore';`
+
+Depois trocar `toast.success(` → `notify.success(`, `toast.error(` → `notify.error(`, `toast.info(` → `notify.info(` em cada arquivo. Nenhuma dessas 38 chamadas passa segundo argumento, então são substituições diretas.
+
+- [ ] **Passo 2: migrar o único caso com ação**
+
+Em `src/hooks/profile/useProfileData.js`, trocar a linha 2:
+
+```javascript
+import { toast } from 'sonner';
+```
+
+por:
+
+```javascript
+import { notify } from '../../utils/notifyStore';
+```
+
+E substituir a chamada das linhas 57-68:
+
+```javascript
+            // Only show toast if not already showing one (simple check or just replace)
+            toast.error("Erro ao carregar dados. Verifique sua conexão.", {
+                id: 'profile-fetch-error', // ID prevents duplicates
+                action: {
+                    label: 'Tentar Novamente',
+                    onClick: () => {
+                        fetchingRef.current = false; // Allow retry
+                        fetchProfileData();
+                    }
+                },
+                duration: 5000
+            });
+```
+
+por:
+
+```javascript
+            // Único aviso do app que espera toque: com ação, a barra não sobe
+            // sozinha — sumir em 3s levaria o "Tentar Novamente" embora antes de
+            // o usuário decidir. A deduplicação que o `id` fazia no sonner agora
+            // é regra do notifyStore (aviso idêntico não reinicia a barra).
+            notify.error("Erro ao carregar dados. Verifique sua conexão.", {
+                action: {
+                    label: 'Tentar Novamente',
+                    onClick: () => {
+                        fetchingRef.current = false; // Allow retry
+                        fetchProfileData();
+                    }
+                }
+            });
+```
+
+- [ ] **Passo 3: confirmar que o sonner sumiu do código**
+
+Rodar: `grep -rn "sonner" src`
+Esperado: nenhuma saída.
+
+- [ ] **Passo 4: lint e suíte**
+
+Rodar: `npm run lint && npm test -- --run`
+Esperado: PASS.
+
+- [ ] **Passo 5: commitar**
+
+```bash
+git add src/pages src/components src/hooks
+git commit -m "refactor: migra os avisos do sonner para o notifyStore"
+```
+
+---
+
+### Tarefa 6: aviso ao salvar ficha e remoção da dependência
+
+**Arquivos:**
+- Modificar: `src/pages/CreateWorkoutPage.jsx` (linha 384)
+- Modificar: `package.json`
+
+**Interfaces:**
+- Consome: `notify` (já importado na Tarefa 5).
+- Produz: nada.
+
+- [ ] **Passo 1: adicionar o aviso que falta**
+
+Em `src/pages/CreateWorkoutPage.jsx`, dentro do `handleSave`, logo após o bloco `if (importQueue && ...)` que já termina em `return`, a última linha do `try` é:
+
+```jsx
+            onBack();
+```
+
+Trocar por:
+
+```jsx
+            // Caminho normal: até aqui salvava e voltava pra lista em silêncio.
+            // A barra vive na raiz autenticada, então o aviso sobrevive ao
+            // `onBack()` e aparece já sobre a lista.
+            notify.success('Treino salvo.');
+            onBack();
+```
+
+- [ ] **Passo 2: conferir no app rodando**
+
+Rodar: `npm run dev` e abrir http://localhost:5175
+Salvar uma ficha e confirmar que a barra verde desce sobre a lista de treinos.
+
+Se a tela pedir login e não houver credencial à mão, pule este passo — a Tarefa 7 cobre a verificação visual sem autenticação.
+
+- [ ] **Passo 3: remover o sonner do package.json**
+
+Apagar a linha `"sonner": "^2.0.7",` das dependências.
+
+Depois rodar, **com o Node do projeto**:
+
+```bash
+fnm exec --using=24 -- npm install
+```
+
+Confirmar que só `package.json` e `package-lock.json` mudaram, e que o `node -v` do comando é 24.x. O lockfile precisa ser regravado pelo npm 11 — npm 10 e npm 11 discordam sobre entradas aninhadas e o CI usa `npm ci` estrito.
+
+- [ ] **Passo 4: sequência completa do CI**
+
+Rodar:
+
+```bash
+npm run lint && npm test -- --run && npm --prefix functions test && npm run build
+```
+
+Esperado: tudo PASS.
+
+- [ ] **Passo 5: commitar**
+
+```bash
+git add src/pages/CreateWorkoutPage.jsx package.json package-lock.json
+git commit -m "feat: confirma o salvamento de ficha e remove o sonner"
+```
+
+---
+
+### Tarefa 7: verificação visual
+
+**Arquivos:**
+- Criar (temporário): `banner-preview.html` e `src/bannerPreview.jsx`
+- Apagar os dois ao fim da tarefa.
+
+**Interfaces:**
+- Consome: `TopBanner` e `notify`.
+- Produz: nada — nenhum arquivo sobrevive à tarefa.
+
+A barra só existe em tela autenticada e nenhum ambiente que o agente abre autentica. O caminho é um entry point temporário do Vite que renderiza só o componente.
+
+- [ ] **Passo 1: criar o entry point temporário**
+
+`src/bannerPreview.jsx`:
+
+```jsx
+import { createRoot } from 'react-dom/client';
+import { TopBanner } from './components/design-system/TopBanner';
+import { notify } from './utils/notifyStore';
+import './index.css';
+
+function Preview() {
+    return (
+        <div style={{ minHeight: '100vh', background: '#0f172a', padding: '40vh 24px', display: 'flex', gap: 12, flexWrap: 'wrap', justifyContent: 'center' }}>
+            <TopBanner />
+            <button id="btn-success" onClick={() => notify.success('Treino salvo.')}>sucesso</button>
+            <button id="btn-error" onClick={() => notify.error('Erro ao salvar treino.')}>erro</button>
+            <button id="btn-info" onClick={() => notify.info('Finalize ou descarte o treino antes de atualizar o app.')}>info</button>
+            <button id="btn-action" onClick={() => notify.error('Erro ao carregar dados. Verifique sua conexão.', { action: { label: 'Tentar Novamente', onClick: () => {} } })}>com ação</button>
+        </div>
+    );
+}
+
+createRoot(document.getElementById('root')).render(<Preview />);
+```
+
+`banner-preview.html`, na raiz do projeto:
+
+```html
+<!doctype html>
+<html lang="pt-BR">
+  <head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1.0" /><title>Preview da barra</title></head>
+  <body><div id="root"></div><script type="module" src="/src/bannerPreview.jsx"></script></body>
+</html>
+```
+
+- [ ] **Passo 2: subir o dev server e abrir o preview**
+
+Usar `preview_start` com a config do `.claude/launch.json` e navegar para `http://localhost:5175/banner-preview.html`.
+
+- [ ] **Passo 3: conferir cada tipo**
+
+Para cada botão: clicar, tirar screenshot, e conferir por DOM que `[data-testid="top-banner"]` existe com o `data-type` certo e que `getBoundingClientRect().top === 0` e `.left === 0`.
+
+Conferir também que o de sucesso some sozinho depois de ~3s e que o "com ação" **não** some.
+
+- [ ] **Passo 4: conferir o console**
+
+Sem erro nem aviso do React (especialmente sobre `useSyncExternalStore` ou chave duplicada no `AnimatePresence`).
+
+- [ ] **Passo 5: apagar os arquivos temporários**
+
+```bash
+rm banner-preview.html src/bannerPreview.jsx
+```
+
+Rodar `git status` e confirmar que a árvore está limpa.
+
+- [ ] **Passo 6: registrar o que fica para o iPhone**
+
+`env(safe-area-inset-top)` não reproduz no desktop. A conferência da faixa colorida sob o relógio e da altura da barra no iPhone fica para o usuário, e deve ser dita explicitamente no fechamento — não afirmar que o visual está validado em mobile.
+
+---
+
+## Fora de escopo
+
+- O `Toast` próprio da tela de execução (`src/components/design-system/Toast.jsx`), usado só no erro de validação em `WorkoutExecutionPage.jsx:266`. A proximidade dele com os campos de peso/repetições é o valor dele; virar barra desfaria #51.
+- O `SyncStatusBadge` ("Salvo agora") do Modo Foco — status contínuo, não aviso pontual.
+- Empilhamento de múltiplos avisos, swipe para dispensar, pausa do timer com a aba oculta.

--- a/docs/superpowers/plans/2026-08-12-banner-aviso-topo.md
+++ b/docs/superpowers/plans/2026-08-12-banner-aviso-topo.md
@@ -24,6 +24,28 @@
 
 O spec diz que o `TopBanner` "agenda o auto-dismiss". **O timer fica no store, não no componente.** Motivo: com o timer no store, as regras de tempo ("some em 3s", "com ação não some") são testáveis em JavaScript puro, sem depender do ciclo de animação do framer-motion dentro do jsdom — que é justamente onde teste de componente fica frágil. O componente vira uma view pura. Nada mais muda no comportamento descrito.
 
+## Emenda 1 — descoberta durante a execução (12/08/2026)
+
+A contagem de 39 chamadas foi feita com `grep "toast\."` e por isso **perdeu uma
+chamada sem método**: `toast('Bi-set é executado em dupla', { description, action,
+duration: 8000 })` em `CreateWorkoutPage.jsx:333` — a sugestão de agrupar quando o
+usuário salva um exercício marcado como "Bi-set" sem encadeá-lo com o anterior.
+São 40 chamadas, e `CreateWorkoutPage.jsx` tem 7, não 6.
+
+Ela usa duas opções que o store não previa. Decisão do usuário:
+
+- **`description` entra** como opção do store e segunda linha da barra (título em
+  negrito, explicação abaixo em corpo menor). Serve avisos futuros que precisem
+  explicar, não só este.
+- **`duration` entra** como opção, permitida inclusive junto de `action`. O padrão
+  segue: sem ação, `AUTO_DISMISS_MS`; com ação e sem `duration`, não some sozinha.
+  A sugestão de bi-set passa `8000` e mantém o comportamento de hoje — é sugestão
+  opcional, não erro, e ignorá-la deve bastar para ela sair de cena. O "Tentar
+  Novamente" do perfil continua sem `duration`, esperando toque.
+
+Isso reabre `notifyStore` e `TopBanner` (Tarefas 1 e 2) numa tarefa 5a, executada
+antes de fechar a Tarefa 5.
+
 ## Estrutura de arquivos
 
 **Criar:**

--- a/docs/superpowers/specs/2026-08-12-banner-aviso-topo-design.md
+++ b/docs/superpowers/specs/2026-08-12-banner-aviso-topo-design.md
@@ -1,0 +1,146 @@
+# Barra de aviso descendo do topo, no lugar do toast do sonner
+
+## Problema
+
+O aviso de confirmação do app hoje é um toast do `sonner` ancorado a `42vh`, que cai opticamente no centro da tela (`AppAuthed.jsx:459`). Esse posicionamento foi a solução de #51/#53 para um defeito real: ancorado no topo, o aviso ficava atrás da status bar do iPhone e o usuário o via sumir sem ler.
+
+Resolveu o sumiço, mas o resultado é um bloco solto no meio da tela, sem relação com a interface em volta. O usuário pediu outro formato: uma **barra que desce do topo**, de borda a borda, no molde dos banners de sistema — verde quando confirma que o treino foi salvo.
+
+Há também um buraco de comportamento independente do visual: **salvar uma ficha pelo caminho normal não avisa nada**. `CreateWorkoutPage.jsx:384` chama `onBack()` direto e volta pra lista em silêncio. O verde "Treino salvo" só dispara na fila de importação por PDF (`CreateWorkoutPage.jsx:381`), entre um treino e o próximo.
+
+## Objetivo
+
+Substituir o `sonner` por um componente próprio de barra superior, usado por **todos** os avisos do app (sucesso, erro e informativo), e passar a confirmar o salvamento de ficha no caminho normal.
+
+## Por que barra no topo não reintroduz o defeito de #51/#53
+
+Não é o aviso voltando pro topo. A barra pinta de `top: 0` até abaixo da status bar — a cor ocupa a área do relógio e da bateria, e o **conteúdo** (ícone e texto) fica na faixa logo abaixo deles. O que escondia o aviso antigo era ele ser um card curto ancorado a `top-6`, inteiramente dentro da zona da status bar. Referência visual fornecida pelo usuário: banner amarelo full-bleed com o relógio do iOS por cima da cor.
+
+## Decisão de arquitetura
+
+Duas abordagens foram avaliadas:
+
+**A — manter o `sonner` como motor e trocar só a aparência** via `toast.custom()` e reconfiguração do `Toaster`. Ganha fila, timers, `aria-live` e pausa no hover de graça.
+
+**B — componente próprio, `sonner` sai da árvore.** (escolhida)
+
+Escolhida a B. O motivo é específico desta mudança: chegar a full-bleed até o pixel 0 exige vencer o CSS do `sonner` (`--width`, padding do container, `width` do `li`), e #53 já registrou que sobrescrever o CSS do pacote briga com a animação de `transform` que ele aplica. Aqui a animação de descida **é** o pedido central, então herdar essa briga é herdar o risco no ponto errado. De quebra sai uma dependência do bundle e o chunk lazy dela.
+
+Custo aceito: fila e acessibilidade passam a ser código do projeto. Mitigado por escopo mínimo — fila de um.
+
+## Arquitetura
+
+Três peças.
+
+### `src/utils/notifyStore.js`
+
+Store de módulo, sem React. Expõe `subscribe(fn)`, `getSnapshot()` e a API imperativa:
+
+```js
+notify.success(message, options?)
+notify.error(message, options?)
+notify.info(message, options?)
+notify.dismiss()
+```
+
+`options` aceita apenas `action: { label, onClick }` (ver "Aviso com ação" abaixo).
+
+**Fila de um:** aviso novo substitui o anterior. O app nunca dispara dois simultâneos, e empilhar barras full-bleed cobriria a tela.
+
+**`id` incremental por aviso.** É a chave de remount do componente: sem ela, duas mensagens em sequência trocariam o texto sem refazer a descida. Regra complementar: aviso com **mesmo tipo e mesma mensagem** do que já está na tela não gera `id` novo e não reinicia a animação — é o que substitui a deduplicação por `id` que o `sonner` fazia em `useProfileData.js:58`.
+
+Ser módulo, e não contexto React, é requisito e não estilo: `workoutService.js:13` e `HomeDashboard.jsx:92` emitem erro de fora da árvore React e hoje fazem `await import('sonner')` só para isso. Ambos passam a importar `notify` estaticamente e chamar direto.
+
+### `src/components/design-system/TopBanner.jsx`
+
+Lê o store com `useSyncExternalStore`, anima com framer-motion e agenda o auto-dismiss.
+
+**Posição e forma.** `fixed inset-x-0 top-0`, com `pt-[env(safe-area-inset-top)]` mais uma linha de conteúdo. Ícone (`CheckCircle2` / `AlertCircle`) e mensagem em negrito, alinhados à esquerda. Sem botão de fechar.
+
+**Cores.** Seguem a convenção que o app já usa em `Toast.jsx:13`: `emerald-600` para sucesso, `red-600` para erro, `blue-600` para info, texto branco. Como a barra carrega o próprio fundo, funciona nos temas claro e escuro — o `theme="dark"` fixo que o `sonner` exigia deixa de existir.
+
+**`pointer-events-none` no wrapper.** Sem botão, a barra não precisa receber toque nenhum. Isso dissolve a disputa de `z-index`: ela vai para `z-[10000]`, acima dos modais de 9999 (`NumericKeypad.jsx:44`, `PremiumAlert.jsx:43`), sem risco de roubar um toque. No caso com ação, só o botão recebe `pointer-events-auto`.
+
+**Animação.** Desce de `y: -100%` até `0` em ~260ms, ease-out; permanece 3s; recolhe em ~200ms, ease-in. Movimento reduzido já é tratado globalmente por `MotionPreferences.jsx:10` (`MotionConfig reducedMotion="user"`), sem tratamento específico aqui.
+
+**Acessibilidade por tipo.** Sucesso e info em `role="status"` / `aria-live="polite"`; erro em `role="alert"` / `aria-live="assertive"`, para não competir com a leitura em curso quando é apenas confirmação.
+
+### Montagem em `AppAuthed.jsx`
+
+`TopBanner` ocupa o lugar do `SonnerToaster`. Saem junto o `React.lazy(loadSonnerToaster)` e o gate `shouldRenderToaster` / `requestIdleCallback` (`AppAuthed.jsx:121` e `:146`) — existiam para adiar o chunk do `sonner`; o componente próprio é pequeno e o framer-motion já está carregado.
+
+Ficar montado na raiz autenticada é o que faz o aviso **sobreviver à navegação**, necessário porque salvar uma ficha volta pra lista no mesmo tique.
+
+O comentário atual sobre o `offset` de `42vh` sai; no lugar entra o registro de por que a barra é full-bleed, para a lição de #51/#53 não se perder.
+
+## Aviso com ação
+
+`useProfileData.js:58` é o único aviso com botão de verdade: um "Tentar Novamente" que refaz o carregamento do perfil. Não cabe numa barra `pointer-events-none`, e descartá-lo seria perder função.
+
+A barra passa a aceitar ação opcional: `notify.error(msg, { action: { label, onClick } })` renderiza um botão à direita — a mesma posição do "Upgrade" na referência visual, então o formato já comporta.
+
+**Quando há ação, a barra não sobe sozinha.** Sumir em 3s levaria o retry embora antes de o usuário decidir. É o único caso que espera toque; o `onClick` executa e fecha a barra.
+
+## Migração
+
+39 chamadas em 9 arquivos, todas mecânicas (troca do import e do prefixo `toast.` → `notify.`), exceto a de `useProfileData.js`, coberta acima.
+
+| Arquivo | Chamadas |
+|---|---|
+| `src/pages/ProfilePage.jsx` | 10 |
+| `src/pages/WorkoutsPage.jsx` | 9 |
+| `src/pages/CreateWorkoutPage.jsx` | 6 |
+| `src/pages/TrainerDashboard.jsx` | 4 |
+| `src/components/AddCardioModal.jsx` | 3 |
+| `src/components/history/WorkoutDetailsModal.jsx` | 3 |
+| `src/components/PwaUpdatePrompt.jsx` | 2 |
+| `src/components/achievements/AchievementUnlockedModal.jsx` | 1 |
+| `src/hooks/profile/useProfileData.js` | 1 |
+
+Mais os dois emissores de fora do React, que perdem o `await import('sonner')` e o helper `showToastError` inteiro:
+
+- `src/services/workoutService.js:13`
+- `src/pages/HomeDashboard.jsx:92`
+
+E a remoção de `sonner` do `package.json`.
+
+## Aviso novo ao salvar ficha
+
+`CreateWorkoutPage.jsx:384` passa a chamar `notify.success('Treino salvo.')` antes de `onBack()`, fechando o silêncio do caminho normal. O aviso da fila de importação (`:381`) continua com o texto atual, que informa qual treino vem a seguir.
+
+## Arquivos afetados
+
+- `src/utils/notifyStore.js` — **novo**: store, API imperativa, fila de um, regra de `id`.
+- `src/components/design-system/TopBanner.jsx` — **novo**: a barra.
+- `src/AppAuthed.jsx` — troca `SonnerToaster` por `TopBanner`; remove `loadSonnerToaster`, `SonnerToaster`, `shouldRenderToaster` e o efeito de `requestIdleCallback`; atualiza o comentário de posicionamento.
+- `src/services/workoutService.js` — remove `showToastError` e o import dinâmico; chama `notify.error`.
+- `src/pages/HomeDashboard.jsx` — idem.
+- `src/hooks/profile/useProfileData.js` — migra para `notify.error` com `action`.
+- Os 8 demais arquivos da tabela de migração — troca de import e prefixo.
+- `package.json` — remove `sonner`.
+
+## Testes
+
+`src/utils/notifyStore.test.js` — **novo**: substituição pela fila de um; `id` incremental; aviso idêntico não reinicia; `dismiss`.
+
+`src/components/design-system/TopBanner.test.jsx` — **novo**: mensagem e cor por tipo; `role`/`aria-live` por tipo; some após 3s (fake timers); **não** some sozinha quando tem ação; clique na ação dispara o `onClick` e fecha.
+
+`src/services/workoutService.test.js` — o `vi.mock('sonner')` (`:6`) vira mock do `notifyStore`; simplifica, porque o import deixa de ser dinâmico.
+
+## Validação
+
+Sequência do CI antes de commitar:
+
+```bash
+npm run lint && npm test -- --run && npm --prefix functions test && npm run build
+```
+
+**Visual.** A barra só existe em tela autenticada e nenhum ambiente que o agente abre autentica. Verificação por entry point temporário do Vite renderizando `TopBanner` isolado nos três tipos e no caso com ação, medindo por DOM e conferindo a descida em screenshot; o entry point é removido depois.
+
+`env(safe-area-inset-top)` não reproduz no desktop — a conferência da faixa sob o relógio fica para o iPhone, com o usuário.
+
+## Fora de escopo
+
+- O `Toast` próprio da tela de execução (`src/components/design-system/Toast.jsx`), usado só para o erro de validação em `WorkoutExecutionPage.jsx:266`. Ele aponta para o campo de peso/repetições que a mensagem manda corrigir, e essa proximidade é o valor dele — virar barra no topo desfaria #51.
+- O `SyncStatusBadge` ("Salvo agora") do Modo Foco, que é status contínuo de sincronização, não aviso pontual.
+- Empilhamento de múltiplos avisos, gesto de swipe para dispensar e pausa do timer com a aba oculta.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.12.0",
         "recharts": "^3.6.0",
-        "sonner": "^2.0.7",
         "web-push": "^3.6.7"
       },
       "devDependencies": {
@@ -18700,16 +18699,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/sonner": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
-      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
-        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.12.0",
     "recharts": "^3.6.0",
-    "sonner": "^2.0.7",
     "web-push": "^3.6.7"
   },
   "devDependencies": {

--- a/src/AppAuthed.jsx
+++ b/src/AppAuthed.jsx
@@ -9,6 +9,7 @@ import { ProtectedRoute } from './components/ProtectedRoute';
 import { useAuth } from './AuthContext';
 import { WorkoutProvider, useWorkout } from './context/WorkoutContext';
 import { MotionPreferences } from './components/common/MotionPreferences';
+import { TopBanner } from './components/design-system/TopBanner';
 import { safeGetItem, safeRemoveItem, safeGetJSON, safeSetJSON } from './utils/storage';
 
 // Carregamento Lazy de Páginas
@@ -23,7 +24,6 @@ const loadTrainerDashboard = () => import('./pages/TrainerDashboard').then(modul
 const loadPrivacyPolicyPage = () => import('./pages/PrivacyPolicyPage');
 const loadTermsOfUsePage = () => import('./pages/TermsOfUsePage');
 const loadBottomNavEnhanced = () => import('./BottomNavEnhanced').then(module => ({ default: module.BottomNavEnhanced }));
-const loadSonnerToaster = () => import('sonner').then(module => ({ default: module.Toaster }));
 const loadPwaUpdatePrompt = () => import('./components/PwaUpdatePrompt').then(module => ({ default: module.PwaUpdatePrompt }));
 
 const HomeDashboard = React.lazy(loadHomeDashboard);
@@ -37,7 +37,6 @@ const TrainerDashboard = React.lazy(loadTrainerDashboard);
 const PrivacyPolicyPage = React.lazy(loadPrivacyPolicyPage);
 const TermsOfUsePage = React.lazy(loadTermsOfUsePage);
 const BottomNavEnhanced = React.lazy(loadBottomNavEnhanced);
-const SonnerToaster = React.lazy(loadSonnerToaster);
 const PwaUpdatePrompt = React.lazy(loadPwaUpdatePrompt);
 
 const NAV_TRANSITIONS_STORAGE_KEY = 'vitalita_nav_transitions_v1';
@@ -118,7 +117,6 @@ function AppAuthedContent() {
     const { user, authLoading, logout } = useAuth();
     const { startWorkout } = useWorkout();
     const [isTrainer, setIsTrainer] = useState(false);
-    const [shouldRenderToaster, setShouldRenderToaster] = useState(false);
     const navigate = useNavigate();
     const location = useLocation();
     const userId = user?.uid;
@@ -142,20 +140,6 @@ function AppAuthedContent() {
 
         checkTrainerStatus();
     }, [userId]);
-
-    useEffect(() => {
-        if (typeof window === 'undefined') return undefined;
-
-        const scheduleToaster = () => setShouldRenderToaster(true);
-
-        if ('requestIdleCallback' in window) {
-            const idleId = window.requestIdleCallback(scheduleToaster, { timeout: 1500 });
-            return () => window.cancelIdleCallback(idleId);
-        }
-
-        const timeoutId = window.setTimeout(scheduleToaster, 700);
-        return () => window.clearTimeout(timeoutId);
-    }, []);
 
     useEffect(() => {
         if (!userId || typeof window === 'undefined' || typeof navigator === 'undefined') return undefined;
@@ -443,28 +427,16 @@ function AppAuthedContent() {
             </div>
 
             {/*
-              * `theme="dark"`: sem isso o sonner usa o tema claro por padrão, e o
-              * aviso saía num bloco quase branco no meio de um app todo escuro.
+              * A barra pinta de `top: 0` até abaixo da status bar e põe o texto
+              * na faixa sob o relógio. Não é o aviso "voltando pro topo": o que
+              * sumia atrás da status bar em #51/#53 era um card curto ancorado
+              * a `top-6`, inteiramente dentro daquela zona.
               *
-              * `offset` no eixo Y: ancorado no topo, o aviso ficava atrás da status
-              * bar do iPhone e chegava a cobrir o título da tela. `42vh` ancora a
-              * borda de cima e cai opticamente no centro — é a API pública do
-              * sonner, preferida a sobrescrever CSS porque o pacote anima
-              * `transform` no eixo X e uma sobrescrita brigaria com isso.
-              * Objeto parcial: o sonner completa os lados omitidos com os padrões
-              * dele (24px no desktop, 16px no mobile).
+              * Fica na raiz autenticada de propósito — salvar uma ficha volta
+              * pra lista no mesmo tique, e o aviso precisa sobreviver à
+              * navegação.
               */}
-            {shouldRenderToaster && (
-                <Suspense fallback={null}>
-                    <SonnerToaster
-                        richColors
-                        theme="dark"
-                        position="top-center"
-                        offset={{ top: '42vh' }}
-                        mobileOffset={{ top: '42vh' }}
-                    />
-                </Suspense>
-            )}
+            <TopBanner />
 
             {user && (
                 <Suspense fallback={null}>

--- a/src/components/AddCardioModal.jsx
+++ b/src/components/AddCardioModal.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Activity, Clock, Navigation, Flame, X, Check } from 'lucide-react';
 import { Button } from './design-system/Button';
 import { workoutService } from '../services/workoutService';
-import { toast } from 'sonner';
+import { notify } from '../utils/notifyStore';
 
 export function AddCardioModal({ isOpen, onClose, user }) {
     const [activityType, setActivityType] = useState('Corrida');
@@ -24,7 +24,7 @@ export function AddCardioModal({ isOpen, onClose, user }) {
 
     const handleSave = async () => {
         if (!durationMin || durationMin <= 0) {
-            toast.error('Informe a duração do exercício.');
+            notify.error('Informe a duração do exercício.');
             return;
         }
 
@@ -38,11 +38,11 @@ export function AddCardioModal({ isOpen, onClose, user }) {
                 calories: parseInt(calories, 10) || 0,
                 notes
             });
-            toast.success('Cardio registrado com sucesso!');
+            notify.success('Cardio registrado com sucesso!');
             onClose();
         } catch (error) {
             console.error('AddCardio error:', error);
-            toast.error('Erro ao registrar cardio.');
+            notify.error('Erro ao registrar cardio.');
         } finally {
             setIsSaving(false);
         }

--- a/src/components/PwaUpdatePrompt.jsx
+++ b/src/components/PwaUpdatePrompt.jsx
@@ -3,7 +3,7 @@ import { RefreshCw, ShieldCheck, Wifi } from 'lucide-react';
 import { useRegisterSW } from 'virtual:pwa-register/react';
 import { useWorkout } from '../context/WorkoutContext';
 import { Button } from './design-system/Button';
-import { toast } from 'sonner';
+import { notify } from '../utils/notifyStore';
 
 export function PwaUpdatePrompt() {
     const { activeWorkoutId } = useWorkout();
@@ -21,7 +21,7 @@ export function PwaUpdatePrompt() {
 
     useEffect(() => {
         if (!offlineReady) return;
-        toast.success('Vitalità pronto para uso offline.');
+        notify.success('Vitalità pronto para uso offline.');
         setOfflineReady(false);
     }, [offlineReady, setOfflineReady]);
 
@@ -32,7 +32,7 @@ export function PwaUpdatePrompt() {
 
     const handleUpdate = () => {
         if (hasActiveWorkout) {
-            toast.info('Finalize ou descarte o treino antes de atualizar o app.');
+            notify.info('Finalize ou descarte o treino antes de atualizar o app.');
             return;
         }
         updateServiceWorker(true);

--- a/src/components/achievements/AchievementUnlockedModal.jsx
+++ b/src/components/achievements/AchievementUnlockedModal.jsx
@@ -2,7 +2,7 @@ import React, { useRef, useState } from 'react';
 import { VitalitaGlassCard } from './VitalitaGlassCard';
 import { Share2 } from 'lucide-react';
 import { Button } from '../design-system/Button';
-import { toast } from 'sonner';
+import { notify } from '../../utils/notifyStore';
 
 // Lazy load for performance
 
@@ -49,7 +49,7 @@ export function AchievementUnlockedModal({ achievements, onClose }) {
             }
         } catch (err) {
             console.error(err);
-            toast.error(`Erro ao gerar card: ${err.message}`);
+            notify.error(`Erro ao gerar card: ${err.message}`);
         } finally {
             setSharing(false);
         }

--- a/src/components/design-system/Toast.jsx
+++ b/src/components/design-system/Toast.jsx
@@ -27,8 +27,12 @@ export function Toast({ message, type = 'error', onClose, duration = 3000 }) {
     // ele cai logo acima dos campos de peso/repetições da tela de execução —
     // aponta para o campo que a mensagem manda corrigir, sem cobri-lo.
     //
-    // Só este Toast mudou; os toasts do `sonner` (o verde de "salvo" e os avisos
-    // do resto do app) continuam no topo, por decisão do usuário em 31/07/2026.
+    // Só este Toast é centralizado. Os demais avisos do app (o verde de "salvo"
+    // e os erros do resto das telas) vivem no `TopBanner`, a barra full-bleed que
+    // desce do topo. Este componente ficou de fora daquela migração justamente
+    // pelo motivo acima: ele precisa aparecer junto dos campos de peso/repetições
+    // para apontar o campo que a mensagem manda corrigir — no topo perderia essa
+    // relação com o campo.
     //
     // O eixo X usa `inset-x-4 mx-auto w-fit`, e não `left-1/2 -translate-x-1/2`:
     // com `left-1/2` o elemento começa na metade da tela e só tem metade da

--- a/src/components/design-system/TopBanner.jsx
+++ b/src/components/design-system/TopBanner.jsx
@@ -61,7 +61,15 @@ export function TopBanner() {
                 >
                     <div className="flex items-center gap-3 px-5 py-3">
                         <Icon size={20} className="shrink-0" />
-                        <span className="flex-1 font-bold text-sm">{current.message}</span>
+                        {/* Coluna única para message + description: mesma coluna do
+                            título, à esquerda do botão de ação. Sem description, o
+                            `<span>` sobra sozinho e o layout não muda em nada. */}
+                        <div className="flex flex-1 flex-col items-start">
+                            <span className="font-bold text-sm">{current.message}</span>
+                            {current.description && (
+                                <span className="text-xs text-white/90">{current.description}</span>
+                            )}
+                        </div>
                         {current.action && (
                             <button
                                 type="button"

--- a/src/components/design-system/TopBanner.jsx
+++ b/src/components/design-system/TopBanner.jsx
@@ -14,6 +14,13 @@
  *
  * O timer do auto-dismiss mora no `notifyStore`, não aqui: as regras de tempo
  * ficam testáveis sem depender do ciclo de animação dentro do jsdom.
+ *
+ * `mode="wait"` no `AnimatePresence`: no modo padrão (`sync`) a troca de um
+ * aviso por outro deixa as duas barras montadas por ~200ms, ambas em
+ * `fixed inset-x-0 top-0 z-[10000]` — uma subindo e a outra descendo pelo mesmo
+ * espaço. Acontece de verdade ao salvar ficha ("Treino salvo." → `onBack()` →
+ * a lista monta → `getTemplates` falha → erro). O custo é a barra nova esperar
+ * a saída da anterior, que é justamente o comportamento desejado.
  */
 import { useSyncExternalStore } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
@@ -45,7 +52,7 @@ export function TopBanner() {
     }
 
     return (
-        <AnimatePresence>
+        <AnimatePresence mode="wait">
             {current && (
                 <motion.div
                     key={current.id}

--- a/src/components/design-system/TopBanner.jsx
+++ b/src/components/design-system/TopBanner.jsx
@@ -1,0 +1,79 @@
+/**
+ * TopBanner.jsx
+ * Barra de aviso que desce do topo — o único formato de aviso do app.
+ *
+ * Ela pinta de `top: 0` até abaixo da status bar (`pt-[env(safe-area-inset-top)]`)
+ * e põe o conteúdo na faixa sob o relógio. Isso é o oposto do defeito que #51/#53
+ * corrigiram: o aviso antigo era um card curto ancorado a `top-6`, inteiramente
+ * dentro da zona da status bar, e sumia sem ser lido.
+ *
+ * `pointer-events-none` no wrapper: sem botão, a barra não recebe toque nenhum,
+ * e por isso pode ficar em z-10000 — acima dos modais de z-9999 (NumericKeypad,
+ * PremiumAlert) — sem risco de roubar um toque. Só o botão de ação, quando
+ * existe, volta a `pointer-events-auto`.
+ *
+ * O timer do auto-dismiss mora no `notifyStore`, não aqui: as regras de tempo
+ * ficam testáveis sem depender do ciclo de animação dentro do jsdom.
+ */
+import { useSyncExternalStore } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { CheckCircle2, AlertCircle } from 'lucide-react';
+import { notify, subscribeToNotify, getNotifySnapshot } from '../../utils/notifyStore';
+
+const backgrounds = {
+    success: 'bg-emerald-600',
+    error: 'bg-red-600',
+    info: 'bg-blue-600'
+};
+
+const icons = {
+    success: CheckCircle2,
+    error: AlertCircle,
+    info: AlertCircle
+};
+
+export function TopBanner() {
+    const current = useSyncExternalStore(subscribeToNotify, getNotifySnapshot, () => null);
+
+    const isError = current?.type === 'error';
+    const Icon = current ? (icons[current.type] || AlertCircle) : null;
+
+    function handleAction() {
+        const onClick = current?.action?.onClick;
+        notify.dismiss();
+        if (typeof onClick === 'function') onClick();
+    }
+
+    return (
+        <AnimatePresence>
+            {current && (
+                <motion.div
+                    key={current.id}
+                    initial={{ y: '-100%' }}
+                    animate={{ y: 0 }}
+                    exit={{ y: '-100%', transition: { duration: 0.2, ease: 'easeIn' } }}
+                    transition={{ duration: 0.26, ease: 'easeOut' }}
+                    role={isError ? 'alert' : 'status'}
+                    aria-live={isError ? 'assertive' : 'polite'}
+                    data-testid="top-banner"
+                    data-type={current.type}
+                    className={`fixed inset-x-0 top-0 z-[10000] pointer-events-none pt-[env(safe-area-inset-top)] text-white shadow-lg ${backgrounds[current.type] || backgrounds.info}`}
+                >
+                    <div className="flex items-center gap-3 px-5 py-3">
+                        <Icon size={20} className="shrink-0" />
+                        <span className="flex-1 font-bold text-sm">{current.message}</span>
+                        {current.action && (
+                            <button
+                                type="button"
+                                onClick={handleAction}
+                                className="pointer-events-auto shrink-0 rounded-full bg-white/20 px-3 py-1 text-sm font-bold hover:bg-white/30 transition-colors"
+                            >
+                                {current.action.label}
+                            </button>
+                        )}
+                    </div>
+                </motion.div>
+            )}
+        </AnimatePresence>
+    );
+}

--- a/src/components/design-system/TopBanner.test.jsx
+++ b/src/components/design-system/TopBanner.test.jsx
@@ -80,6 +80,34 @@ describe('TopBanner', () => {
         expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'polite');
     });
 
+    // Emenda 5a: aviso de bi-set em CreateWorkoutPage tem título e explicação.
+    it('mostra a description como segunda linha, abaixo da message', () => {
+        render(<TopBanner />);
+
+        act(() => {
+            notify.info('Bi-set é executado em dupla', {
+                description: 'Agrupar com "Supino" para alternar as séries na execução?'
+            });
+        });
+
+        expect(screen.getByText('Bi-set é executado em dupla')).toBeInTheDocument();
+        expect(
+            screen.getByText('Agrupar com "Supino" para alternar as séries na execução?')
+        ).toBeInTheDocument();
+
+        const barra = screen.getByTestId('top-banner');
+        expect(barra.querySelectorAll('span').length).toBe(2);
+    });
+
+    it('sem description, a barra continua com uma linha só', () => {
+        render(<TopBanner />);
+
+        act(() => { notify.success('Treino salvo.'); });
+
+        const barra = screen.getByTestId('top-banner');
+        expect(barra.querySelectorAll('span').length).toBe(1);
+    });
+
     it('renderiza o botão da ação e o deixa clicável', () => {
         render(<TopBanner />);
 

--- a/src/components/design-system/TopBanner.test.jsx
+++ b/src/components/design-system/TopBanner.test.jsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { TopBanner } from './TopBanner';
+import { notify, resetNotifyStore, getNotifySnapshot } from '../../utils/notifyStore';
+
+describe('TopBanner', () => {
+    beforeEach(() => {
+        resetNotifyStore();
+    });
+
+    afterEach(() => {
+        resetNotifyStore();
+    });
+
+    it('não renderiza nada sem aviso', () => {
+        render(<TopBanner />);
+
+        expect(screen.queryByTestId('top-banner')).not.toBeInTheDocument();
+    });
+
+    it('mostra a mensagem quando o aviso chega', () => {
+        render(<TopBanner />);
+
+        act(() => { notify.success('Treino salvo.'); });
+
+        expect(screen.getByTestId('top-banner')).toBeInTheDocument();
+        expect(screen.getByText('Treino salvo.')).toBeInTheDocument();
+    });
+
+    it('mostra o aviso que já estava no store antes da montagem', () => {
+        notify.success('Treino salvo.');
+
+        render(<TopBanner />);
+
+        expect(screen.getByText('Treino salvo.')).toBeInTheDocument();
+    });
+
+    it.each([
+        ['success', 'bg-emerald-600'],
+        ['error', 'bg-red-600'],
+        ['info', 'bg-blue-600']
+    ])('usa a cor do tipo %s', (tipo, classe) => {
+        render(<TopBanner />);
+
+        act(() => { notify[tipo]('Mensagem.'); });
+
+        const barra = screen.getByTestId('top-banner');
+        expect(barra).toHaveAttribute('data-type', tipo);
+        expect(barra.className).toContain(classe);
+    });
+
+    // A cor precisa alcançar o pixel 0: é isso que faz o texto cair na faixa
+    // abaixo do relógio em vez de atrás dele.
+    it('ancora no topo, de borda a borda', () => {
+        render(<TopBanner />);
+
+        act(() => { notify.success('Treino salvo.'); });
+
+        expect(screen.getByTestId('top-banner').className).toContain('top-0');
+        expect(screen.getByTestId('top-banner').className).toContain('inset-x-0');
+    });
+
+    // Sem botão, a barra não precisa de toque nenhum — e é isso que permite
+    // ela ficar acima dos modais de z-9999 sem roubar toque.
+    it('não intercepta toque quando não tem ação', () => {
+        render(<TopBanner />);
+
+        act(() => { notify.success('Treino salvo.'); });
+
+        expect(screen.getByTestId('top-banner').className).toContain('pointer-events-none');
+    });
+
+    it('anuncia erro como alert e sucesso como status', () => {
+        render(<TopBanner />);
+
+        act(() => { notify.error('Erro ao salvar treino.'); });
+        expect(screen.getByRole('alert')).toHaveAttribute('aria-live', 'assertive');
+
+        act(() => { notify.success('Treino salvo.'); });
+        expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'polite');
+    });
+
+    it('renderiza o botão da ação e o deixa clicável', () => {
+        render(<TopBanner />);
+
+        act(() => {
+            notify.error('Erro ao carregar dados.', {
+                action: { label: 'Tentar Novamente', onClick: vi.fn() }
+            });
+        });
+
+        const botao = screen.getByRole('button', { name: 'Tentar Novamente' });
+        expect(botao.className).toContain('pointer-events-auto');
+    });
+
+    it('clique na ação dispara o onClick e fecha a barra', () => {
+        const onClick = vi.fn();
+        render(<TopBanner />);
+
+        act(() => {
+            notify.error('Erro ao carregar dados.', { action: { label: 'Tentar Novamente', onClick } });
+        });
+
+        act(() => {
+            screen.getByRole('button', { name: 'Tentar Novamente' }).click();
+        });
+
+        expect(onClick).toHaveBeenCalledTimes(1);
+        expect(getNotifySnapshot()).toBeNull();
+    });
+});

--- a/src/components/design-system/TopBanner.test.jsx
+++ b/src/components/design-system/TopBanner.test.jsx
@@ -108,4 +108,26 @@ describe('TopBanner', () => {
         expect(onClick).toHaveBeenCalledTimes(1);
         expect(getNotifySnapshot()).toBeNull();
     });
+
+    // Sensível à ordem: se `handleAction` chamasse `onClick()` antes de
+    // `notify.dismiss()`, o `dismiss()` que roda depois apagaria o aviso novo
+    // que o onClick acabou de criar (caso de "Tentar Novamente" terminando em
+    // `notify.success(...)`). `dismiss()` precisa rodar primeiro.
+    it('limpa o aviso anterior antes de disparar o onClick, não depois', () => {
+        const onClick = vi.fn(() => notify.success('Reconectado.'));
+        render(<TopBanner />);
+
+        act(() => {
+            notify.error('Erro ao carregar dados.', { action: { label: 'Tentar Novamente', onClick } });
+        });
+
+        act(() => {
+            screen.getByRole('button', { name: 'Tentar Novamente' }).click();
+        });
+
+        expect(onClick).toHaveBeenCalledTimes(1);
+        expect(getNotifySnapshot()).toEqual(
+            expect.objectContaining({ type: 'success', message: 'Reconectado.' })
+        );
+    });
 });

--- a/src/components/design-system/TopBanner.test.jsx
+++ b/src/components/design-system/TopBanner.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { render, screen, act } from '@testing-library/react';
+import { render, screen, act, waitFor } from '@testing-library/react';
 import { TopBanner } from './TopBanner';
 import { notify, resetNotifyStore, getNotifySnapshot } from '../../utils/notifyStore';
 
@@ -70,14 +70,22 @@ describe('TopBanner', () => {
         expect(screen.getByTestId('top-banner').className).toContain('pointer-events-none');
     });
 
-    it('anuncia erro como alert e sucesso como status', () => {
+    // Assíncrono por causa do `mode="wait"` do AnimatePresence: a barra nova só
+    // é montada depois que a anterior termina de sair, então esperar a troca é
+    // parte do comportamento, não flakiness. O `findByRole` faz esse papel sem
+    // depender de tempo fixo.
+    it('anuncia erro como alert e sucesso como status', async () => {
         render(<TopBanner />);
 
         act(() => { notify.error('Erro ao salvar treino.'); });
-        expect(screen.getByRole('alert')).toHaveAttribute('aria-live', 'assertive');
+        expect(await screen.findByRole('alert')).toHaveAttribute('aria-live', 'assertive');
 
         act(() => { notify.success('Treino salvo.'); });
-        expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'polite');
+        expect(await screen.findByRole('status')).toHaveAttribute('aria-live', 'polite');
+
+        // A barra de erro não pode continuar montada junto com a de sucesso —
+        // duas barras full-bleed em z-10000 se sobreporiam.
+        await waitFor(() => expect(screen.queryByRole('alert')).not.toBeInTheDocument());
     });
 
     // Emenda 5a: aviso de bi-set em CreateWorkoutPage tem título e explicação.

--- a/src/components/history/WorkoutDetailsModal.jsx
+++ b/src/components/history/WorkoutDetailsModal.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef } from 'react';
 import { X, Calendar, Clock, Dumbbell, TrendingUp, Notebook, Share2, Activity, Navigation, Flame } from 'lucide-react';
 import { ShareableWorkoutCard } from '../sharing/ShareableWorkoutCard';
-import { toast } from 'sonner';
+import { notify } from '../../utils/notifyStore';
 
 export function WorkoutDetailsModal({ session, onClose, user }) {
     const shareCardRef = useRef(null);
@@ -72,12 +72,12 @@ export function WorkoutDetailsModal({ session, onClose, user }) {
     const handleShare = async () => {
         if (sharing) return;
         if (!shareCardRef.current) {
-            toast.error("Card de compartilhamento indisponível.");
+            notify.error("Card de compartilhamento indisponível.");
             return;
         }
 
         if (!window.isSecureContext) {
-            toast.error("O compartilhamento requer conexão segura. Use HTTPS ou localhost.");
+            notify.error("O compartilhamento requer conexão segura. Use HTTPS ou localhost.");
             return;
         }
 
@@ -135,7 +135,7 @@ export function WorkoutDetailsModal({ session, onClose, user }) {
             URL.revokeObjectURL(blobUrl);
         } catch (err) {
             console.error("Error sharing:", err);
-            toast.error("Erro ao gerar imagem de compartilhamento.");
+            notify.error("Erro ao gerar imagem de compartilhamento.");
         } finally {
             setSharing(false);
         }

--- a/src/hooks/profile/useProfileData.js
+++ b/src/hooks/profile/useProfileData.js
@@ -54,11 +54,19 @@ export function useProfileData(user) {
         } catch (err) {
             console.error("Error fetching profile (or timeout):", err);
 
-            // Único aviso do app que espera toque: com ação, a barra não sobe
-            // sozinha — sumir em 3s levaria o "Tentar Novamente" embora antes de
-            // o usuário decidir. A deduplicação que o `id` fazia no sonner agora
-            // é regra do notifyStore (aviso idêntico não reinicia a barra).
+            // O `id` que o sonner usava aqui para deduplicar saiu junto com o
+            // pacote, e a deduplicação do notifyStore não cobre este caso: o
+            // early-return dela exige `!action && !current.action`, e este aviso
+            // tem ação. O que evita o incômodo de repetição é o `duration`.
+            //
+            // O `duration: 5000` é o mesmo tempo de antes da migração e precisa
+            // ser explícito: sem ele o store não arma timer nenhum quando há
+            // ação, e a barra — que vive na raiz autenticada e não tem botão de
+            // fechar — acompanharia o usuário por todas as telas. Os 5s dão
+            // folga sobre os 3s padrão para o usuário decidir sobre o
+            // "Tentar Novamente" antes de a barra sair de cena sozinha.
             notify.error("Erro ao carregar dados. Verifique sua conexão.", {
+                duration: 5000,
                 action: {
                     label: 'Tentar Novamente',
                     onClick: () => {

--- a/src/hooks/profile/useProfileData.js
+++ b/src/hooks/profile/useProfileData.js
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { toast } from 'sonner';
+import { notify } from '../../utils/notifyStore';
 
 /**
  * Carrega o perfil do usuário (com timeout de segurança e retry via toast),
@@ -54,17 +54,18 @@ export function useProfileData(user) {
         } catch (err) {
             console.error("Error fetching profile (or timeout):", err);
 
-            // Only show toast if not already showing one (simple check or just replace)
-            toast.error("Erro ao carregar dados. Verifique sua conexão.", {
-                id: 'profile-fetch-error', // ID prevents duplicates
+            // Único aviso do app que espera toque: com ação, a barra não sobe
+            // sozinha — sumir em 3s levaria o "Tentar Novamente" embora antes de
+            // o usuário decidir. A deduplicação que o `id` fazia no sonner agora
+            // é regra do notifyStore (aviso idêntico não reinicia a barra).
+            notify.error("Erro ao carregar dados. Verifique sua conexão.", {
                 action: {
                     label: 'Tentar Novamente',
                     onClick: () => {
                         fetchingRef.current = false; // Allow retry
                         fetchProfileData();
                     }
-                },
-                duration: 5000
+                }
             });
 
             // Fallback: mostrar o que temos (dados de auth)

--- a/src/pages/CreateWorkoutPage.jsx
+++ b/src/pages/CreateWorkoutPage.jsx
@@ -10,7 +10,7 @@ import { toggleGroupWithPrevious, normalizeGroups, computeGroupSegments, groupLa
 import { Button } from '../components/design-system/Button';
 import { EmptyState } from '../components/design-system/EmptyState';
 import { PageHeader } from '../components/design-system/PageHeader';
-import { toast } from 'sonner';
+import { notify } from '../utils/notifyStore';
 import { Reorder, useDragControls } from 'framer-motion';
 
 const muscleGroups = [
@@ -186,12 +186,12 @@ export default function CreateWorkoutPage({ user }) {
             setImportQueue({ workouts, index: 0 });
             loadWorkoutIntoForm(workouts[0]);
             if (workouts.length > 1) {
-                toast.success(`${workouts.length} treinos encontrados. Revise o 1º e salve — os próximos aparecem em seguida.`);
+                notify.success(`${workouts.length} treinos encontrados. Revise o 1º e salve — os próximos aparecem em seguida.`);
             } else {
-                toast.success(`Treino importado (${workouts[0].exercises.length} exercícios). Revise antes de salvar.`);
+                notify.success(`Treino importado (${workouts[0].exercises.length} exercícios). Revise antes de salvar.`);
             }
         } catch (err) {
-            toast.error(err.message || 'Não foi possível importar o PDF.');
+            notify.error(err.message || 'Não foi possível importar o PDF.');
         } finally {
             setImportingPdf(false);
         }
@@ -330,7 +330,7 @@ export default function CreateWorkoutPage({ user }) {
         const previous = list[idx - 1];
         if (current.groupId && current.groupId === previous.groupId) return;
 
-        toast('Bi-set é executado em dupla', {
+        notify.info('Bi-set é executado em dupla', {
             description: `Agrupar com "${previous.name}" para alternar as séries na execução?`,
             action: {
                 label: 'Agrupar',
@@ -342,7 +342,7 @@ export default function CreateWorkoutPage({ user }) {
 
     async function handleSave() {
         if (!workoutName || exercises.length === 0) {
-            toast.error("Informe um nome e adicione pelo menos um exercício.");
+            notify.error("Informe um nome e adicione pelo menos um exercício.");
             return;
         }
 
@@ -378,13 +378,13 @@ export default function CreateWorkoutPage({ user }) {
                 setImportQueue({ ...importQueue, index: nextIndex });
                 loadWorkoutIntoForm(importQueue.workouts[nextIndex]);
                 setLoading(false);
-                toast.success(`Treino salvo. Revise o próximo (${nextIndex + 1} de ${importQueue.workouts.length}).`);
+                notify.success(`Treino salvo. Revise o próximo (${nextIndex + 1} de ${importQueue.workouts.length}).`);
                 return;
             }
             onBack();
         } catch (err) {
             console.error(err);
-            toast.error("Erro ao salvar treino.");
+            notify.error("Erro ao salvar treino.");
         } finally {
             setLoading(false);
         }

--- a/src/pages/CreateWorkoutPage.jsx
+++ b/src/pages/CreateWorkoutPage.jsx
@@ -381,6 +381,10 @@ export default function CreateWorkoutPage({ user }) {
                 notify.success(`Treino salvo. Revise o próximo (${nextIndex + 1} de ${importQueue.workouts.length}).`);
                 return;
             }
+            // Caminho normal: até aqui salvava e voltava pra lista em silêncio.
+            // A barra vive na raiz autenticada, então o aviso sobrevive ao
+            // `onBack()` e aparece já sobre a lista.
+            notify.success('Treino salvo.');
             onBack();
         } catch (err) {
             console.error(err);

--- a/src/pages/HomeDashboard.jsx
+++ b/src/pages/HomeDashboard.jsx
@@ -41,6 +41,7 @@ import { safeGetJSON, safeSetJSON, safeRemoveItem } from '../utils/storage';
 import { achievementsCatalog } from '../data/achievementsCatalog';
 import { evaluateAchievements, calculateStats } from '../utils/evaluateAchievements';
 import { AddCardioModal } from '../components/AddCardioModal';
+import { notify } from '../utils/notifyStore';
 
 const HOME_DASHBOARD_CACHE_VERSION = 1;
 
@@ -88,19 +89,6 @@ const MOTIVATIONAL_QUOTES = [
 ];
 
 const HOME_DASHBOARD_CACHE_TTL_MS = 30 * 60 * 1000;
-
-let toastPromise;
-async function showToastError(message) {
-    try {
-        if (!toastPromise) {
-            toastPromise = import('sonner');
-        }
-        const { toast } = await toastPromise;
-        toast.error(message);
-    } catch {
-        // Evita que falhas de UI escondam o erro original.
-    }
-}
 
 function getHomeDashboardCacheKey(userId) {
     return `home_dashboard_snapshot_v${HOME_DASHBOARD_CACHE_VERSION}_${userId}`;
@@ -233,12 +221,12 @@ export function HomeDashboard({
     const handleShareQuote = async () => {
         if (sharingQuote) return;
         if (!shareQuoteRef.current) {
-            await showToastError("Card de compartilhamento indisponível.");
+            notify.error("Card de compartilhamento indisponível.");
             return;
         }
 
         if (!window.isSecureContext) {
-            await showToastError("O compartilhamento requer conexão segura. Use HTTPS ou localhost.");
+            notify.error("O compartilhamento requer conexão segura. Use HTTPS ou localhost.");
             return;
         }
 
@@ -296,7 +284,7 @@ export function HomeDashboard({
             URL.revokeObjectURL(blobUrl);
         } catch (err) {
             console.error("Error sharing:", err);
-            await showToastError("Erro ao gerar imagem de compartilhamento.");
+            notify.error("Erro ao gerar imagem de compartilhamento.");
         } finally {
             setSharingQuote(false);
         }

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------------
 import React, { useState } from 'react';
-import { toast } from 'sonner';
+import { notify } from '../utils/notifyStore';
 
 import { Loader2, LogOut, Users } from 'lucide-react';
 import { getStoredTheme, setTheme, THEMES } from '../utils/theme';
@@ -43,15 +43,15 @@ export default function ProfilePage({ user, onLogout, onNavigateToHistory, onNav
         try {
             const { userService } = await import('../services/userService');
             await userService.linkTrainer(user.uid, inviteCode);
-            toast.success("Personal vinculado com sucesso!");
+            notify.success("Personal vinculado com sucesso!");
             setShowLinkTrainer(false);
             setInviteCode('');
         } catch (err) {
             console.error(err);
-            if (err.message === "PERSONAL_NOT_FOUND") toast.error("Convite inválido ou expirado.");
-            else if (err.message === "ALREADY_LINKED") toast.error("Você já está vinculado a este personal.");
-            else if (err.message === "LINK_TRAINER_FAILED") toast.error("Não foi possível vincular. Verifique o código ou se o vínculo já existe.");
-            else toast.error("Erro ao vincular.");
+            if (err.message === "PERSONAL_NOT_FOUND") notify.error("Convite inválido ou expirado.");
+            else if (err.message === "ALREADY_LINKED") notify.error("Você já está vinculado a este personal.");
+            else if (err.message === "LINK_TRAINER_FAILED") notify.error("Não foi possível vincular. Verifique o código ou se o vínculo já existe.");
+            else notify.error("Erro ao vincular.");
         } finally {
             setLinking(false);
         }
@@ -77,7 +77,7 @@ export default function ProfilePage({ user, onLogout, onNavigateToHistory, onNav
         // Validação de Email
         const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
         if (!emailRegex.test(profile.email)) {
-            toast.error("Por favor, insira um email válido.");
+            notify.error("Por favor, insira um email válido.");
             return;
         }
 
@@ -89,10 +89,10 @@ export default function ProfilePage({ user, onLogout, onNavigateToHistory, onNav
                 updatedAt: new Date().toISOString()
             });
             setShowEditModal(false);
-            toast.success("Perfil atualizado.");
+            notify.success("Perfil atualizado.");
         } catch (err) {
             console.error("Error saving profile:", err);
-            toast.error("Erro ao salvar perfil.");
+            notify.error("Erro ao salvar perfil.");
         } finally {
             setSaving(false);
         }
@@ -106,10 +106,10 @@ export default function ProfilePage({ user, onLogout, onNavigateToHistory, onNav
             const { privacyExportService } = await import('../services/privacyExportService');
             const exportPayload = await privacyExportService.buildUserDataExport(user);
             const fileName = privacyExportService.downloadJson(exportPayload);
-            toast.success(`Exportação criada: ${fileName}`);
+            notify.success(`Exportação criada: ${fileName}`);
         } catch (err) {
             console.error('Error exporting user data:', err);
-            toast.error('Não foi possível exportar seus dados agora.');
+            notify.error('Não foi possível exportar seus dados agora.');
         } finally {
             setExportingData(false);
         }

--- a/src/pages/TrainerDashboard.jsx
+++ b/src/pages/TrainerDashboard.jsx
@@ -7,7 +7,7 @@ import { EmptyState } from '../components/design-system/EmptyState';
 import { PageHeader } from '../components/design-system/PageHeader';
 import { PremiumCard } from '../components/design-system/PremiumCard';
 import { SectionHeader } from '../components/design-system/SectionHeader';
-import { toast } from 'sonner';
+import { notify } from '../utils/notifyStore';
 
 import HistoryPage from './HistoryPage';
 import WorkoutsPage from './WorkoutsPage';
@@ -104,7 +104,7 @@ export function TrainerDashboard({ user, onBack, onNavigateToCreateWorkout }) {
             setInviteCode(newInvite?.code || '');
         } catch (error) {
             console.error("Error creating trainer invite:", error);
-            toast.error("Erro ao gerar convite.");
+            notify.error("Erro ao gerar convite.");
         } finally {
             setInviteLoading(false);
         }
@@ -117,12 +117,12 @@ export function TrainerDashboard({ user, onBack, onNavigateToCreateWorkout }) {
             const { userService } = await import('../services/userService');
             await userService.unlinkTrainer(studentPendingUnlink.id, user.uid);
             await fetchStudents();
-            toast.success("Aluno desvinculado.");
+            notify.success("Aluno desvinculado.");
             setSelectedStudent(null);
             setStudentPendingUnlink(null);
         } catch (error) {
             console.error(error);
-            toast.error("Erro ao desvincular aluno.");
+            notify.error("Erro ao desvincular aluno.");
         } finally {
             setUnlinking(false);
         }
@@ -241,7 +241,7 @@ export function TrainerDashboard({ user, onBack, onNavigateToCreateWorkout }) {
                                 user={selectedStudent}
                                 isTrainerMode={true}
                                 onNavigateToCreate={handleNavigateToCreate}
-                                onNavigateToWorkout={() => toast.info("Modo visualização de Personal: execução desabilitada.")}
+                                onNavigateToWorkout={() => notify.info("Modo visualização de Personal: execução desabilitada.")}
                             />
                         </div>
                     ) : (

--- a/src/pages/WorkoutsPage.jsx
+++ b/src/pages/WorkoutsPage.jsx
@@ -36,7 +36,7 @@ import { nextDisplayOrder, normalizeActiveWorkoutOrder, sortWorkoutTemplates } f
 import { buildCopyName, copyInsertIndex, isCopyName } from '../utils/workoutCopyName';
 import { countBySourceFilter, matchesSourceFilter } from '../utils/workoutSourceFilter';
 import { SourceFilterChips } from '../components/workout/SourceFilterChips';
-import { toast } from 'sonner';
+import { notify } from '../utils/notifyStore';
 const ExerciseCard = React.lazy(() => import('../components/workout/ExerciseCard').then(module => ({ default: module.ExerciseCard })));
 const EditExerciseModal = React.lazy(() => import('../components/workout/EditExerciseModal').then(module => ({ default: module.EditExerciseModal })));
 
@@ -120,10 +120,10 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
                 }
             );
             await loadWorkouts(true);
-            toast.success('Treino adicionado às suas fichas.');
+            notify.success('Treino adicionado às suas fichas.');
             setIsLibraryOpen(false);
         } catch (err) {
-            toast.error(err.message || 'Erro ao adicionar o treino.');
+            notify.error(err.message || 'Erro ao adicionar o treino.');
         } finally {
             setCloningStarterId(null);
         }
@@ -193,7 +193,7 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
             await workoutService.saveTemplateOrder(normalized);
         } catch (error) {
             console.error('Erro ao salvar ordem dos treinos:', error);
-            toast.error('Não foi possível salvar a nova ordem.');
+            notify.error('Não foi possível salvar a nova ordem.');
 
             try {
                 const { workoutService } = await import('../services/workoutService');
@@ -265,7 +265,7 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
         };
 
         setWorkouts(prev => [...prev, copy]);
-        toast.success("Treino duplicado.");
+        notify.success("Treino duplicado.");
 
         // Reordenar é um extra: se falhar, a cópia continua existindo no fim da
         // lista — não vale desfazer a duplicação nem alarmar o usuário.
@@ -295,7 +295,7 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
             try {
                 await duplicateWorkout(workout);
             } catch (err) {
-                toast.error(err.message || "Erro ao duplicar treino.");
+                notify.error(err.message || "Erro ao duplicar treino.");
             }
         } else if (action === 'edit') {
             onNavigateToCreate(workout);
@@ -306,9 +306,9 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
                 await workoutService.setTemplateArchived(workout.id, isArchived);
 
                 setWorkouts(prev => prev.map(w => w.id === workout.id ? { ...w, isArchived } : w));
-                toast.success(isArchived ? "Treino arquivado." : "Treino desarquivado.");
+                notify.success(isArchived ? "Treino arquivado." : "Treino desarquivado.");
             } catch (err) {
-                toast.error(err.message || (isArchived ? "Erro ao arquivar treino." : "Erro ao desarquivar treino."));
+                notify.error(err.message || (isArchived ? "Erro ao arquivar treino." : "Erro ao desarquivar treino."));
             }
         }
     };
@@ -321,10 +321,10 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
             await workoutService.deleteTemplate(workoutPendingDelete.id);
 
             setWorkouts(prev => prev.filter(w => w.id !== workoutPendingDelete.id));
-            toast.success("Treino excluído.");
+            notify.success("Treino excluído.");
             setWorkoutPendingDelete(null);
         } catch (err) {
-            toast.error(err.message || "Erro ao excluir treino.");
+            notify.error(err.message || "Erro ao excluir treino.");
         } finally {
             setDeletingWorkout(false);
         }

--- a/src/services/workoutService.js
+++ b/src/services/workoutService.js
@@ -1,5 +1,6 @@
 import { getFirestoreDeps } from '../firebaseDb';
 import { sortWorkoutTemplates } from '../utils/workoutTemplateOrder';
+import { notify } from '../utils/notifyStore';
 
 const TEMPLATES_COLLECTION = 'workout_templates';
 const SESSIONS_COLLECTION = 'workout_sessions';
@@ -9,19 +10,6 @@ export const SESSION_LIMITS = {
     profileStats: 300,
     achievementCheck: 300
 };
-
-let sonnerPromise;
-async function showToastError(message) {
-    try {
-        if (!sonnerPromise) {
-            sonnerPromise = import('sonner');
-        }
-        const { toast } = await sonnerPromise;
-        toast.error(message);
-    } catch {
-        // Silencia falha de toast para não mascarar erro principal.
-    }
-}
 
 // Cache em memória
 let templatesCache = {
@@ -107,7 +95,7 @@ export const workoutService = {
             return sorted;
         } catch (error) {
             console.error("Error fetching templates:", error);
-            await showToastError("Erro ao carregar treinos. Verifique sua conexão.");
+            notify.error("Erro ao carregar treinos. Verifique sua conexão.");
             throw error;
         }
     },
@@ -347,9 +335,9 @@ export const workoutService = {
             console.error("Error fetching history:", error);
             if (error.code === 'failed-precondition') {
                 console.warn("🔥 FIRESTORE INDEX MISSING! Open this link to create it:", error.message);
-                await showToastError("Erro de índice. Verifique o console.");
+                notify.error("Erro de índice. Verifique o console.");
             } else {
-                await showToastError("Erro ao carregar histórico.");
+                notify.error("Erro ao carregar histórico.");
             }
             throw error;
         }
@@ -503,7 +491,7 @@ export const workoutService = {
 
         } catch (error) {
             console.error("Error searching exercises:", error);
-            await showToastError("Erro ao buscar exercícios. Verifique sua conexão.");
+            notify.error("Erro ao buscar exercícios. Verifique sua conexão.");
             return [];
         }
     },
@@ -541,7 +529,7 @@ export const workoutService = {
             return docRef.id;
         } catch (error) {
             console.error("Error saving cardio session:", error);
-            await showToastError("Erro ao salvar sessão de cardio.");
+            notify.error("Erro ao salvar sessão de cardio.");
             throw error;
         }
     }

--- a/src/services/workoutService.test.js
+++ b/src/services/workoutService.test.js
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { workoutService } from './workoutService';
 import { collection, getDocs, onSnapshot, query, where, startAfter, orderBy, limit, doc, getDoc, writeBatch } from 'firebase/firestore';
-import { toast } from 'sonner';
+import { notify } from '../utils/notifyStore';
 
-vi.mock('sonner', () => ({
-    toast: {
+vi.mock('../utils/notifyStore', () => ({
+    notify: {
         error: vi.fn()
     }
 }));
@@ -141,7 +141,7 @@ describe('workoutService', () => {
 
             try {
                 await expect(workoutService.getTemplates(mockUserId)).rejects.toThrow('Network Error');
-                expect(toast.error).toHaveBeenCalledWith('Erro ao carregar treinos. Verifique sua conexão.');
+                expect(notify.error).toHaveBeenCalledWith('Erro ao carregar treinos. Verifique sua conexão.');
             } finally {
                 consoleSpy.mockRestore();
             }
@@ -256,7 +256,7 @@ describe('workoutService', () => {
                     workoutService.getHistory(mockUserId, 'Template A')
                 ).rejects.toThrow('missing index');
 
-                expect(toast.error).toHaveBeenCalledWith('Erro de índice. Verifique o console.');
+                expect(notify.error).toHaveBeenCalledWith('Erro de índice. Verifique o console.');
             } finally {
                 consoleSpy.mockRestore();
             }
@@ -272,7 +272,7 @@ describe('workoutService', () => {
                     workoutService.getHistory(mockUserId, 'Template A')
                 ).rejects.toThrow('boom');
 
-                expect(toast.error).toHaveBeenCalledWith('Erro ao carregar histórico.');
+                expect(notify.error).toHaveBeenCalledWith('Erro ao carregar histórico.');
             } finally {
                 consoleSpy.mockRestore();
             }

--- a/src/utils/notifyStore.js
+++ b/src/utils/notifyStore.js
@@ -35,9 +35,17 @@ function push(type, message, options = {}) {
     const duration = options.duration;
 
     // Aviso idêntico ao que já está na tela mantém o id: sem isso a barra
-    // refaria a descida por cima dela mesma. Substitui a deduplicação por
-    // `id` que o sonner fazia em useProfileData. Leva a description em
-    // conta: mesma mensagem com explicação diferente é um aviso diferente.
+    // refaria a descida por cima dela mesma. Leva a description em conta:
+    // mesma mensagem com explicação diferente é um aviso diferente.
+    //
+    // A regra vale só para avisos SEM ação — a condição exige
+    // `!action && !current.action`. Aviso com botão nunca é deduplicado aqui,
+    // e o único do app é o de `useProfileData`; lá a repetição é resolvida
+    // pelo `duration: 5000`, que faz a barra sair de cena sozinha.
+    //
+    // Como o early-return acontece antes do `clearTimer()`, o aviso repetido
+    // também não rearma o relógio: ele some no prazo do primeiro
+    // (ver notifyStore.test.js).
     if (
         current &&
         current.type === type &&

--- a/src/utils/notifyStore.js
+++ b/src/utils/notifyStore.js
@@ -29,24 +29,40 @@ function clearTimer() {
 
 function push(type, message, options = {}) {
     const action = options.action || null;
+    // `null`, não `undefined`: mantém a forma do snapshot estável mesmo
+    // quando ninguém passa description (ver Tarefa 5a).
+    const description = options.description ?? null;
+    const duration = options.duration;
 
     // Aviso idêntico ao que já está na tela mantém o id: sem isso a barra
     // refaria a descida por cima dela mesma. Substitui a deduplicação por
-    // `id` que o sonner fazia em useProfileData.
-    if (current && current.type === type && current.message === message && !action && !current.action) {
+    // `id` que o sonner fazia em useProfileData. Leva a description em
+    // conta: mesma mensagem com explicação diferente é um aviso diferente.
+    if (
+        current &&
+        current.type === type &&
+        current.message === message &&
+        current.description === description &&
+        !action &&
+        !current.action
+    ) {
         return current.id;
     }
 
     clearTimer();
-    current = { id: nextId++, type, message, action };
+    current = { id: nextId++, type, message, description, action };
 
-    // Com ação, a barra espera toque — ver AUTO_DISMISS_MS no spec.
-    if (!action) {
+    // `duration` explícito manda mesmo com ação — é o caso do aviso de
+    // bi-set em CreateWorkoutPage, que tem botão e ainda assim some em 8s.
+    // Sem `duration`: some em AUTO_DISMISS_MS se não há ação, ou espera o
+    // toque se há (como antes desta emenda).
+    const dismissDelay = duration ?? (action ? null : AUTO_DISMISS_MS);
+    if (dismissDelay !== null) {
         timerId = setTimeout(() => {
             timerId = null;
             current = null;
             emit();
-        }, AUTO_DISMISS_MS);
+        }, dismissDelay);
     }
 
     emit();

--- a/src/utils/notifyStore.js
+++ b/src/utils/notifyStore.js
@@ -1,0 +1,85 @@
+/**
+ * notifyStore.js
+ * Estado dos avisos do app — a barra que desce do topo (`TopBanner`).
+ *
+ * É um módulo, e não um contexto React, por requisito e não por estilo:
+ * `workoutService` e `HomeDashboard` emitem erro de fora da árvore React.
+ * A API imperativa (`notify.success(...)`) é a mesma forma que o `sonner`
+ * expunha, então os pontos de chamada não mudam de formato.
+ */
+
+export const AUTO_DISMISS_MS = 3000;
+
+const listeners = new Set();
+
+let current = null;
+let nextId = 1;
+let timerId = null;
+
+function emit() {
+    listeners.forEach(listener => listener());
+}
+
+function clearTimer() {
+    if (timerId !== null) {
+        clearTimeout(timerId);
+        timerId = null;
+    }
+}
+
+function push(type, message, options = {}) {
+    const action = options.action || null;
+
+    // Aviso idêntico ao que já está na tela mantém o id: sem isso a barra
+    // refaria a descida por cima dela mesma. Substitui a deduplicação por
+    // `id` que o sonner fazia em useProfileData.
+    if (current && current.type === type && current.message === message && !action && !current.action) {
+        return current.id;
+    }
+
+    clearTimer();
+    current = { id: nextId++, type, message, action };
+
+    // Com ação, a barra espera toque — ver AUTO_DISMISS_MS no spec.
+    if (!action) {
+        timerId = setTimeout(() => {
+            timerId = null;
+            current = null;
+            emit();
+        }, AUTO_DISMISS_MS);
+    }
+
+    emit();
+    return current.id;
+}
+
+export const notify = {
+    success: (message, options) => push('success', message, options),
+    error: (message, options) => push('error', message, options),
+    info: (message, options) => push('info', message, options),
+    dismiss: () => {
+        clearTimer();
+        if (current !== null) {
+            current = null;
+            emit();
+        }
+    }
+};
+
+export function subscribeToNotify(listener) {
+    listeners.add(listener);
+    return () => {
+        listeners.delete(listener);
+    };
+}
+
+export function getNotifySnapshot() {
+    return current;
+}
+
+/** Só para testes: zera o estado entre casos. */
+export function resetNotifyStore() {
+    clearTimer();
+    current = null;
+    nextId = 1;
+}

--- a/src/utils/notifyStore.test.js
+++ b/src/utils/notifyStore.test.js
@@ -109,12 +109,41 @@ describe('notifyStore', () => {
     });
 
     it('dismiss não deixa o timer antigo derrubar um aviso posterior', () => {
+        const listener = vi.fn();
+        subscribeToNotify(listener);
+
+        // Timer 1 dispararia em AUTO_DISMISS_MS
         notify.success('Treino salvo.');
+        expect(listener).toHaveBeenCalledTimes(1);
+
+        // Avançar até perto do disparo
+        vi.advanceTimersByTime(AUTO_DISMISS_MS - 500);
+
+        // Descartar: deve limpar o timer 1
         notify.dismiss();
+        expect(listener).toHaveBeenCalledTimes(2);
+
+        // Avançar 500ms: passa o ponto onde Timer 1 teria disparado
+        // Se dismiss() limpou corretamente, Timer 1 NÃO dispara
+        // Se dismiss() não limpou, Timer 1 dispara e chama listener
+        vi.advanceTimersByTime(500);
+
+        // Se dismiss() limpou corretamente, ainda em 2 chamadas
+        // Se dismiss() não limpou, será 3 (Timer 1 dispara)
+        expect(listener).toHaveBeenCalledTimes(2);
+
+        // Agora criar novo aviso
         notify.info('Outro aviso.');
+        expect(listener).toHaveBeenCalledTimes(3);
 
-        vi.advanceTimersByTime(AUTO_DISMISS_MS - 1);
-
+        // Timer 2 deve estar de pé
         expect(getNotifySnapshot()).toMatchObject({ message: 'Outro aviso.' });
+
+        // Avançar para Timer 2 disparar
+        vi.advanceTimersByTime(AUTO_DISMISS_MS);
+
+        // Timer 2 dispara e chama listener
+        expect(listener).toHaveBeenCalledTimes(4);
+        expect(getNotifySnapshot()).toBeNull();
     });
 });

--- a/src/utils/notifyStore.test.js
+++ b/src/utils/notifyStore.test.js
@@ -61,6 +61,25 @@ describe('notifyStore', () => {
         expect(repetido).toBe(primeiro);
     });
 
+    // O early-return da deduplicação acontece ANTES do `clearTimer()`: aviso
+    // repetido não rearma o relógio, some no prazo do primeiro. Sem isso, uma
+    // tela que reemite o mesmo erro a cada render manteria a barra viva para
+    // sempre, empurrando o auto-dismiss adiante indefinidamente.
+    it('aviso repetido não rearma o relógio do primeiro', () => {
+        notify.error('Erro ao carregar treinos.');
+
+        vi.advanceTimersByTime(AUTO_DISMISS_MS - 500);
+        notify.error('Erro ao carregar treinos.');
+
+        // Ainda de pé: falta o resto do prazo do PRIMEIRO aviso.
+        expect(getNotifySnapshot()).not.toBeNull();
+
+        vi.advanceTimersByTime(500);
+
+        // Sumiu no prazo do primeiro, não do repetido.
+        expect(getNotifySnapshot()).toBeNull();
+    });
+
     it('mesma mensagem em tipo diferente gera id novo', () => {
         const primeiro = notify.info('Pronto.');
         const segundo = notify.success('Pronto.');
@@ -98,6 +117,19 @@ describe('notifyStore', () => {
 
         expect(getNotifySnapshot()).toMatchObject({ message: 'Erro ao carregar dados.' });
         expect(getNotifySnapshot().action.label).toBe('Tentar Novamente');
+    });
+
+    // `useSyncExternalStore` compara os snapshots por identidade (`Object.is`)
+    // a cada render: se `getNotifySnapshot()` devolvesse um objeto novo a cada
+    // chamada, o React concluiria que o store mudou toda vez e entraria em loop
+    // infinito de render ("The result of getSnapshot should be cached").
+    // Por isso o store guarda `current` e devolve a mesma referência.
+    it('devolve a mesma referência de snapshot enquanto nada muda', () => {
+        expect(getNotifySnapshot()).toBe(getNotifySnapshot());
+
+        notify.success('Treino salvo.');
+
+        expect(getNotifySnapshot()).toBe(getNotifySnapshot());
     });
 
     it('dismiss limpa na hora', () => {

--- a/src/utils/notifyStore.test.js
+++ b/src/utils/notifyStore.test.js
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+    notify,
+    subscribeToNotify,
+    getNotifySnapshot,
+    resetNotifyStore,
+    AUTO_DISMISS_MS
+} from './notifyStore';
+
+describe('notifyStore', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        resetNotifyStore();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('guarda o aviso e notifica quem assinou', () => {
+        const listener = vi.fn();
+        subscribeToNotify(listener);
+
+        notify.success('Treino salvo.');
+
+        expect(listener).toHaveBeenCalled();
+        expect(getNotifySnapshot()).toMatchObject({ type: 'success', message: 'Treino salvo.' });
+    });
+
+    it('cancela a assinatura', () => {
+        const listener = vi.fn();
+        const unsubscribe = subscribeToNotify(listener);
+        unsubscribe();
+
+        notify.info('Qualquer coisa.');
+
+        expect(listener).not.toHaveBeenCalled();
+    });
+
+    // Fila de um: empilhar barras full-bleed cobriria a tela.
+    it('aviso novo substitui o anterior', () => {
+        notify.success('Treino salvo.');
+        notify.error('Erro ao salvar treino.');
+
+        expect(getNotifySnapshot()).toMatchObject({ type: 'error', message: 'Erro ao salvar treino.' });
+    });
+
+    // O id é a chave de remount do componente: sem id novo, duas mensagens
+    // em sequência trocariam o texto sem refazer a descida.
+    it('gera id novo a cada aviso diferente', () => {
+        const primeiro = notify.success('Treino salvo.');
+        const segundo = notify.success('Treino duplicado.');
+
+        expect(segundo).not.toBe(primeiro);
+    });
+
+    it('aviso idêntico ao que está na tela não gera id novo', () => {
+        const primeiro = notify.error('Erro ao carregar treinos.');
+        const repetido = notify.error('Erro ao carregar treinos.');
+
+        expect(repetido).toBe(primeiro);
+    });
+
+    it('mesma mensagem em tipo diferente gera id novo', () => {
+        const primeiro = notify.info('Pronto.');
+        const segundo = notify.success('Pronto.');
+
+        expect(segundo).not.toBe(primeiro);
+    });
+
+    it('some sozinho depois da duração', () => {
+        notify.success('Treino salvo.');
+
+        vi.advanceTimersByTime(AUTO_DISMISS_MS);
+
+        expect(getNotifySnapshot()).toBeNull();
+    });
+
+    it('o relógio do aviso novo recomeça do zero', () => {
+        notify.success('Treino salvo.');
+        vi.advanceTimersByTime(AUTO_DISMISS_MS - 500);
+        notify.success('Treino duplicado.');
+
+        vi.advanceTimersByTime(AUTO_DISMISS_MS - 500);
+        expect(getNotifySnapshot()).not.toBeNull();
+
+        vi.advanceTimersByTime(500);
+        expect(getNotifySnapshot()).toBeNull();
+    });
+
+    // Sumir em 3s levaria o botão embora antes de o usuário decidir.
+    it('com ação, não some sozinho', () => {
+        notify.error('Erro ao carregar dados.', {
+            action: { label: 'Tentar Novamente', onClick: vi.fn() }
+        });
+
+        vi.advanceTimersByTime(AUTO_DISMISS_MS * 3);
+
+        expect(getNotifySnapshot()).toMatchObject({ message: 'Erro ao carregar dados.' });
+        expect(getNotifySnapshot().action.label).toBe('Tentar Novamente');
+    });
+
+    it('dismiss limpa na hora', () => {
+        notify.success('Treino salvo.');
+
+        notify.dismiss();
+
+        expect(getNotifySnapshot()).toBeNull();
+    });
+
+    it('dismiss não deixa o timer antigo derrubar um aviso posterior', () => {
+        notify.success('Treino salvo.');
+        notify.dismiss();
+        notify.info('Outro aviso.');
+
+        vi.advanceTimersByTime(AUTO_DISMISS_MS - 1);
+
+        expect(getNotifySnapshot()).toMatchObject({ message: 'Outro aviso.' });
+    });
+});

--- a/src/utils/notifyStore.test.js
+++ b/src/utils/notifyStore.test.js
@@ -108,6 +108,45 @@ describe('notifyStore', () => {
         expect(getNotifySnapshot()).toBeNull();
     });
 
+    // A emenda 5a: CreateWorkoutPage precisa de uma segunda linha e de um
+    // tempo de vida próprio para o aviso de bi-set (ver notifyStore.js).
+    it('guarda a description no snapshot; ausente vira null', () => {
+        notify.info('Aviso.');
+        expect(getNotifySnapshot()).toMatchObject({ description: null });
+
+        resetNotifyStore();
+        notify.info('Aviso.', { description: 'Detalhe.' });
+        expect(getNotifySnapshot()).toMatchObject({ description: 'Detalhe.' });
+    });
+
+    it('mesma mensagem com description diferente gera id novo', () => {
+        const primeiro = notify.info('Aviso.', { description: 'Um.' });
+        const segundo = notify.info('Aviso.', { description: 'Dois.' });
+
+        expect(segundo).not.toBe(primeiro);
+    });
+
+    // O caso que motivou a emenda: aviso de bi-set tem botão e precisa
+    // mesmo assim sumir sozinho em 8s.
+    it('duration explícito é respeitado mesmo com action', () => {
+        notify.info('Bi-set é executado em dupla', {
+            action: { label: 'Agrupar', onClick: vi.fn() },
+            duration: 8000
+        });
+
+        vi.advanceTimersByTime(8000);
+
+        expect(getNotifySnapshot()).toBeNull();
+    });
+
+    it('duration explícito é respeitado sem action', () => {
+        notify.success('Treino salvo.', { duration: 500 });
+
+        vi.advanceTimersByTime(500);
+
+        expect(getNotifySnapshot()).toBeNull();
+    });
+
     it('dismiss não deixa o timer antigo derrubar um aviso posterior', () => {
         const listener = vi.fn();
         subscribeToNotify(listener);

--- a/vite.config.js
+++ b/vite.config.js
@@ -87,7 +87,6 @@ export default defineConfig(({ mode }) => {
           if (packageId.startsWith('recharts/')) return 'vendor-recharts'
           if (packageId.startsWith('victory-vendor/') || packageId.startsWith('d3-')) return 'vendor-chart-vendor'
           if (packageId.startsWith('lucide-react/')) return 'vendor-lucide'
-          if (packageId.startsWith('sonner/')) return 'vendor-sonner'
 
           return undefined
         },


### PR DESCRIPTION
Substitui o toast do `sonner` — hoje ancorado a `42vh`, no centro da tela — por uma barra própria, full-bleed, que desce do topo e serve **todos** os avisos do app: verde para sucesso, vermelho para erro, azul para informativo.

## Por que não é o aviso "voltando pro topo"

O que sumia atrás da status bar do iPhone em #51/#53 era um card curto ancorado a `top-6`, inteiramente dentro daquela zona. A barra nova pinta de `top: 0` até abaixo da status bar (`pt-[env(safe-area-inset-top)]`) e põe o conteúdo na faixa sob o relógio — a cor cobre a área do sistema justamente para o texto não cair nela.

## Desenho

Três peças:

- **`src/utils/notifyStore.js`** — store de módulo, sem React. `notify.success/error/info/dismiss`, fila de um, `id` incremental como chave de remount, timer do auto-dismiss. Ser módulo é requisito, não estilo: `workoutService` e `HomeDashboard` emitem erro de fora da árvore React e faziam `await import('sonner')` só para isso.
- **`src/components/design-system/TopBanner.jsx`** — lê o store com `useSyncExternalStore`, anima com framer-motion. `pointer-events-none` no wrapper, o que permite `z-[10000]` acima dos modais de 9999 sem roubar toque.
- **Montagem na raiz autenticada** (`AppAuthed.jsx`), no lugar do `SonnerToaster` — é o que faz o aviso sobreviver à navegação, necessário porque salvar uma ficha volta pra lista no mesmo tique.

Descartado manter o `sonner` como motor e trocar só a pele: chegar a full-bleed exige vencer o CSS do pacote, e #53 já registrou que sobrescrita briga com a animação de `transform` dele — aqui a descida é o pedido central.

## Também entra

- **Aviso ao salvar ficha.** O caminho normal voltava pra lista em silêncio; só a fila de importação por PDF avisava.
- **40 chamadas migradas** em 11 arquivos, sem mudar nenhum texto. O `sonner` sai do `package.json` (lockfile perdeu só as 11 linhas dele).

## Duas decisões tomadas durante a execução

**`description` e `duration` no store.** A contagem inicial usou `grep "toast\."` e perdeu uma chamada sem método: a sugestão de agrupar bi-set, com segunda linha, botão e `duration: 8000`. Em vez de perder a explicação, a barra ganhou linha secundária e duração opcional.

**O timer do aviso do perfil voltou.** A regra "com ação, espera toque" foi desenhada olhando o aviso isolado. Como a barra vive na raiz autenticada e não tem X nem swipe, o erro de carregar perfil ficava permanente e acompanhava o usuário por todas as telas. Devolvido o `duration: 5000` que ele tinha com o `sonner`.

## Verificação

`npm run lint` limpo · 400 testes · 12 das Functions · build ok · nenhum chunk `vendor-sonner-*` no `dist/`. O boot do bundle de produção foi conferido rodando o build com as flags ligadas — sem `Cannot access ... before initialization`.

Geometria medida no Chrome real a 375px, nos quatro casos: `top: 0`, `left: 0`, largura cheia, `transform: none` após a descida. Auto-dismiss conferido com relógio real — sucesso some entre 0,8s e 4,0s; com ação segue de pé a 4,5s.

## O que fica pendente

**`env(safe-area-inset-top)` é 0 no desktop.** A faixa de cor sob o relógio e a altura real da barra no iPhone não foram validadas por ninguém e dependem de conferência no aparelho.

Duas dívidas registradas, nenhuma bloqueante:

- O `mode="wait"` que impede duas barras de se cruzarem está correto, mas o teste não trava a regressão — reverter a prop mantém a suíte verde.
- A região `aria-live` nasce junto com o conteúdo, então leitor de tela pode não anunciar confirmações "polite" (erros, `role="alert"`, anunciam). Fechar exige wrapper permanente.

Spec em `docs/superpowers/specs/2026-08-12-banner-aviso-topo-design.md`, plano com as duas emendas em `docs/superpowers/plans/2026-08-12-banner-aviso-topo.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)