### PR TITLE
fix: dá corpo aos botões da barra de execução e marca o ativo em ciano

### DIFF
--- a/src/components/execution/TopBarButton.jsx
+++ b/src/components/execution/TopBarButton.jsx
@@ -18,9 +18,18 @@ export const TopBarButton = ({ icon, label, variant = 'default', onClick, active
     const variants = {
         primary: "bg-cyan-500/10 text-cyan-400 border-cyan-500/50 hover:bg-cyan-500/20",
         danger: "bg-red-500/10 text-red-400 border-red-500/20 hover:bg-red-500/20",
+        // O inativo era `bg-slate-900/60 text-slate-300 border-white/10`: cinza
+        // sobre quase-preto, com borda a 10% de branco. Ao lado do card de
+        // execução, cheio de ciano e branco, lia como desabilitado.
+        //
+        // Clarear o inativo aproxima ele do ativo, que era `bg-slate-800`
+        // sólido — os dois estados quase se encostavam e o toggle deixava de
+        // se anunciar. Por isso o ativo passa a ser ciano, que é a cor que o
+        // app já usa para "ligado" (ver o `primary` logo acima), em vez de
+        // continuar disputando o mesmo cinza com o inativo.
         default: active
-            ? "bg-slate-800 text-white border-slate-600 shadow-lg"
-            : "bg-slate-900/60 text-slate-300 border-white/10 hover:bg-slate-800/80 hover:text-white"
+            ? "bg-cyan-500/20 text-cyan-300 border-cyan-400/60 shadow-lg shadow-cyan-500/20"
+            : "bg-slate-800/70 text-slate-100 border-white/25 hover:bg-slate-700/80 hover:text-white"
     };
 
     return (


### PR DESCRIPTION
Na tela de execução, os botões CALC, TIMER e FOCO liam como desabilitados. Eles usam a variante `default` inativa do `TopBarButton`: `slate-300` sobre `slate-900/60`, com borda a 10% de branco — cinza sobre quase-preto, logo acima de um card cheio de ciano e branco.

## O que foi investigado antes de mexer

A primeira hipótese era o painel da barra: `bg-slate-950/80` + `backdrop-blur-xl` + `shadow-2xl` + um glow ciano. **Estava errada.** `slate-950` é `#020617`, exatamente a cor de fundo da página — o painel a 80% sobre a mesma cor é invisível, o blur não tem o que desfocar num fundo chapado, e sombra preta sobre quase-preto também não aparece. Renderizei painel sólido contra painel translúcido lado a lado e as duas versões são indistinguíveis.

O contraste dos botões é o único lever real. O painel fica como está.

## A mudança

Um arquivo, a variante `default` de [`TopBarButton.jsx`](src/components/execution/TopBarButton.jsx):

| | antes | depois |
|---|---|---|
| inativo | `bg-slate-900/60 text-slate-300 border-white/10` | `bg-slate-800/70 text-slate-100 border-white/25` |
| ativo | `bg-slate-800 text-white border-slate-600 shadow-lg` | `bg-cyan-500/20 text-cyan-300 border-cyan-400/60 shadow-cyan-500/20` |

O ativo mudou por consequência, não por gosto: clarear o inativo o aproximava do `bg-slate-800` sólido do ativo, e os dois estados quase se encostavam — o toggle deixava de se anunciar. O ciano é a cor que o próprio componente já usa para destaque na variante `primary`.

Isso vale também para o **Modo Foco**, que usa o mesmo `TopBarButton`.

## Verificação

Conferido nos quatro estados — antes/depois × ligado/desligado — renderizando o componente real num entry point temporário, com a safe area do iPhone simulada em 56px e captura no Chrome real. Os arquivos temporários foram removidos; nada disso entra no commit.

`npm run lint` limpo · 400 testes · build ok.

**Falta o teste no aparelho.** A simulação é desktop; no OLED do iPhone, com brilho automático, o contraste percebido pode ser diferente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)