### PR TITLE
fix: afasta a barra da execução da Dynamic Island

### DIFF
--- a/src/components/execution/ExecutionTopBar.jsx
+++ b/src/components/execution/ExecutionTopBar.jsx
@@ -47,7 +47,12 @@ export function ExecutionTopBar({
                 rounded-b-3xl
             "
             style={{
-                paddingTop: 'env(safe-area-inset-top)',
+                // +8px sobre a área segura: com `env(safe-area-inset-top)` puro,
+                // sobravam só os 6px do `py-1.5` entre o fim da Dynamic Island e
+                // o topo dos botões, e a barra parecia colada nela. Quem mexer
+                // aqui precisa acertar junto o espaçador de 66px na
+                // WorkoutExecutionPage, que reserva esta altura no fluxo.
+                paddingTop: 'calc(env(safe-area-inset-top) + 8px)',
                 height: 'auto'
             }}
         >

--- a/src/pages/WorkoutExecutionPage.jsx
+++ b/src/pages/WorkoutExecutionPage.jsx
@@ -282,12 +282,19 @@ export function WorkoutExecutionPage({ user }) {
                     onToggleFocus={() => setFocusMode(!focusMode)}
                 />
 
-                {/* Só o "content height" da ExecutionTopBar (~44px) + respiro: o
-                    `env(safe-area-inset-top)` já é aplicado uma vez pelo `body`
-                    em index.css. Somar de novo aqui duplicava o recuo em
-                    iPhones com notch/Dynamic Island e abria um vão enorme
-                    entre a barra e o conteúdo abaixo. */}
-                <div style={{ height: '58px' }}></div>
+                {/* Reserva no fluxo a altura que a ExecutionTopBar ocupa fixa,
+                    descontada a área segura: `env(safe-area-inset-top)` já é
+                    aplicado uma vez pelo `body` em index.css, e somar de novo
+                    aqui duplicava o recuo em iPhones com notch/Dynamic Island,
+                    abrindo um vão enorme entre a barra e o conteúdo.
+
+                    Medido: a barra tem 65px fora da área segura, então 66 deixa
+                    1px de folga. (O valor antigo era 58 para uma barra de 57px;
+                    o comentário anterior dizia "~44px", que estava errado.)
+                    Os 8px a mais acompanham o `+ 8px` que a barra ganhou no
+                    `paddingTop` para se afastar da Dynamic Island — os dois
+                    números andam juntos, mexeu num, meça o outro. */}
+                <div style={{ height: '66px' }}></div>
 
                 {!focusMode && (
                     <div className="px-4 mt-2 mb-2 flex justify-end">


### PR DESCRIPTION
No iPhone, a barra superior da execução encostava na Dynamic Island e parecia puxada pra cima. Com `paddingTop: env(safe-area-inset-top)` puro, sobravam só os 6px do `py-1.5` entre o fim da área segura e o topo dos botões.

Passa a `calc(env(safe-area-inset-top) + 8px)` — respiro de 6px para 14px.

## O espaçador anda junto

A barra é `position: fixed`, então a página reserva a altura dela no fluxo com um espaçador em [`WorkoutExecutionPage.jsx`](src/pages/WorkoutExecutionPage.jsx). Mexer só na barra empurraria o conteúdo para debaixo dela. O espaçador vai de 58 para 66.

Medido no navegador com área segura em 0:

| | antes | depois |
|---|---|---|
| altura da barra | 57px | 65px |
| espaçador | 58px | 66px |
| folga até o conteúdo | 1px | 1px |

Sem sobreposição, e a relação entre os dois números fica preservada.

## Correção de comentário

O comentário do espaçador dizia que ele reservava "o content height da ExecutionTopBar (~44px) + respiro". O valor real sempre foi 57px — a folga nunca foi de 14px, era de 1px. Ficou registrado o número medido, para o próximo não recalcular em cima de premissa falsa.

## Verificação

`npm run lint` limpo · 407 testes · 12 das Functions · build ok.

A medição é do navegador com `env(safe-area-inset-top)` resolvendo para 0, que é o caso do desktop. O efeito que motivou a mudança — o afastamento da Dynamic Island — só aparece no aparelho, e depende de conferência no iPhone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)