### PR TITLE
diag: painel temporário para medir a barra da execução no aparelho

### DIFF
--- a/src/components/execution/ExecutionTopBar.jsx
+++ b/src/components/execution/ExecutionTopBar.jsx
@@ -39,6 +39,7 @@ export function ExecutionTopBar({
      */
     return (
         <div
+            data-execution-topbar=""
             className="
                 fixed top-0 left-0 right-0 z-50 pointer-events-none
                 bg-slate-950

--- a/src/components/execution/LayoutMetricsPanel.jsx
+++ b/src/components/execution/LayoutMetricsPanel.jsx
@@ -1,0 +1,126 @@
+/**
+ * LayoutMetricsPanel.jsx
+ * TEMPORÁRIO — painel de medição para investigar por que o texto da
+ * `ExecutionTopBar` sai borrado no PWA em tela cheia e nítido na aba do Safari.
+ *
+ * Hipótese sob teste: a barra é `position: fixed`, logo vira camada própria de
+ * composição; em tela cheia o `env(safe-area-inset-top)` é fracionário, a camada
+ * cai fora da grade de pixels do aparelho e o WebKit a reamostra, amolecendo
+ * tudo que está dentro. Na aba do Safari o inset é ~0 e o problema some.
+ *
+ * O que confirma ou derruba: `alturaEmPixelsDoAparelho` e `topoEmPixelsDoAparelho`
+ * serem inteiros ou não. Fracionário = reamostragem.
+ *
+ * Sem flag de propósito: `useDebugPanelFlag` guarda o estado em `localStorage`, e
+ * o iOS pode separar o storage do Safari do storage do app da tela inicial — a
+ * flag ligada na aba não chegaria onde a medição precisa acontecer.
+ *
+ * REMOVER assim que a medição for feita.
+ */
+import React, { useCallback, useState } from 'react';
+
+const inteiro = (n) => Math.abs(n - Math.round(n)) < 0.001;
+
+function medir() {
+    if (typeof window === 'undefined') return null;
+
+    // Sonda para ler o valor resolvido de env(safe-area-inset-top): não dá para
+    // pedir o valor direto, só aplicar e medir.
+    const sonda = document.createElement('div');
+    sonda.style.cssText = 'position:fixed;top:0;left:0;width:0;height:env(safe-area-inset-top);pointer-events:none;visibility:hidden';
+    document.body.appendChild(sonda);
+    const safeTop = sonda.getBoundingClientRect().height;
+    sonda.remove();
+
+    const barra = document.querySelector('[data-execution-topbar]');
+    const r = barra ? barra.getBoundingClientRect() : null;
+    const dpr = window.devicePixelRatio;
+    const vv = window.visualViewport;
+
+    return {
+        telaCheia: window.matchMedia('(display-mode: standalone)').matches || navigator.standalone === true,
+        dpr,
+        safeTop,
+        safeTopEmPixelsDoAparelho: safeTop * dpr,
+        alturaBarra: r?.height,
+        topoBarra: r?.top,
+        alturaEmPixelsDoAparelho: r ? r.height * dpr : null,
+        topoEmPixelsDoAparelho: r ? r.top * dpr : null,
+        paddingTopBarra: barra ? getComputedStyle(barra).paddingTop : null,
+        escalaViewport: vv?.scale,
+        offsetTopViewport: vv?.offsetTop,
+        innerHeight: window.innerHeight,
+        screenHeight: window.screen?.height
+    };
+}
+
+const Linha = ({ nome, valor, alerta }) => (
+    <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, padding: '2px 0' }}>
+        <span style={{ color: '#94a3b8' }}>{nome}</span>
+        <span style={{ color: alerta ? '#fca5a5' : '#e2e8f0', fontWeight: 700, textAlign: 'right' }}>{valor}</span>
+    </div>
+);
+
+export function LayoutMetricsPanel() {
+    const [m, setM] = useState(null);
+    const remedir = useCallback(() => setM(medir()), []);
+
+    // Medição sob toque, e não em efeito: o lint do projeto barra `setState`
+    // síncrono dentro de effect, e medir depois que a tela assentou é mais fiel
+    // do que medir no primeiro commit.
+    const n = (v, casas = 3) => (typeof v === 'number' ? v.toFixed(casas) : '—');
+    const alturaFracionaria = m && typeof m.alturaEmPixelsDoAparelho === 'number' && !inteiro(m.alturaEmPixelsDoAparelho);
+    const topoFracionario = m && typeof m.topoEmPixelsDoAparelho === 'number' && !inteiro(m.topoEmPixelsDoAparelho);
+    const safeFracionario = m && !inteiro(m.safeTopEmPixelsDoAparelho);
+
+    return (
+        <div style={{
+            margin: '0 16px 12px', padding: 12, borderRadius: 12,
+            border: '1px solid #334155', background: '#0f172a',
+            font: '600 12px/1.35 ui-monospace, SFMono-Regular, Menlo, monospace'
+        }}>
+            <div style={{ color: '#67e8f9', fontWeight: 800, marginBottom: 6 }}>MEDIÇÃO TEMPORÁRIA — BARRA</div>
+
+            {!m && (
+                <div style={{ color: '#94a3b8' }}>
+                    Toque em MEDIR e mande o print desta caixa.
+                </div>
+            )}
+
+            {m && (
+            <>
+            <Linha nome="tela cheia" valor={m.telaCheia ? 'sim' : 'não (aba)'} />
+            <Linha nome="devicePixelRatio" valor={n(m.dpr, 2)} />
+            <Linha nome="safe-area-top (css)" valor={n(m.safeTop)} />
+            <Linha nome="safe-area-top (aparelho)" valor={n(m.safeTopEmPixelsDoAparelho)} alerta={safeFracionario} />
+            <Linha nome="padding-top da barra" valor={m.paddingTopBarra ?? '—'} />
+            <Linha nome="topo da barra (css)" valor={n(m.topoBarra)} />
+            <Linha nome="topo (aparelho)" valor={n(m.topoEmPixelsDoAparelho)} alerta={topoFracionario} />
+            <Linha nome="altura da barra (css)" valor={n(m.alturaBarra)} />
+            <Linha nome="altura (aparelho)" valor={n(m.alturaEmPixelsDoAparelho)} alerta={alturaFracionaria} />
+            <Linha nome="escala do viewport" valor={n(m.escalaViewport, 4)} alerta={typeof m.escalaViewport === 'number' && m.escalaViewport !== 1} />
+            <Linha nome="offset do viewport" valor={n(m.offsetTopViewport, 2)} />
+            <Linha nome="innerHeight / screen" valor={`${m.innerHeight} / ${m.screenHeight ?? '—'}`} />
+
+            <div style={{ marginTop: 8, color: alturaFracionaria || topoFracionario ? '#fca5a5' : '#86efac' }}>
+                {alturaFracionaria || topoFracionario
+                    ? 'Camada em pixel fracionário — hipótese confirmada.'
+                    : 'Camada em pixel inteiro — a hipótese cai, é outra coisa.'}
+            </div>
+            </>
+            )}
+
+            <button
+                type="button"
+                onClick={remedir}
+                style={{
+                    marginTop: 10, width: '100%', padding: '8px 0', borderRadius: 8,
+                    border: '1px solid #0e7490', background: '#083344', color: '#67e8f9',
+                    font: 'inherit', fontWeight: 800
+                }}
+            >
+                {m ? 'MEDIR DE NOVO' : 'MEDIR'}
+            </button>
+        </div>
+    );
+}

--- a/src/pages/WorkoutExecutionPage.jsx
+++ b/src/pages/WorkoutExecutionPage.jsx
@@ -16,6 +16,8 @@ import { SessionConflictDialog } from '../components/execution/SessionConflictDi
 import { Toast } from '../components/design-system/Toast';
 import { SyncStatusBadge } from '../components/design-system/SyncStatusBadge';
 import { ExecutionTopBar } from '../components/execution/ExecutionTopBar';
+// TEMPORÁRIO — remover junto com o painel de medição.
+import { LayoutMetricsPanel } from '../components/execution/LayoutMetricsPanel';
 import { ExecutionProgressCard } from '../components/execution/ExecutionProgressCard';
 import { FocusModeNav } from '../components/execution/FocusModeNav';
 import { ExecutionSkeleton } from '../components/execution/ExecutionSkeleton';
@@ -295,6 +297,10 @@ export function WorkoutExecutionPage({ user }) {
                     `paddingTop` para se afastar da Dynamic Island — os dois
                     números andam juntos, mexeu num, meça o outro. */}
                 <div style={{ height: '66px' }}></div>
+
+                {/* TEMPORÁRIO — medição do borrão da barra no PWA em tela cheia.
+                    Remover junto com LayoutMetricsPanel.jsx. */}
+                <LayoutMetricsPanel />
 
                 {!focusMode && (
                     <div className="px-4 mt-2 mb-2 flex justify-end">


### PR DESCRIPTION
> ⚠️ **Temporário.** Este PR sobe um painel de medição visível na tela de execução. Ele existe só para uma coleta e sai num PR seguinte.

## Por que medir em vez de tentar outra correção

O texto da barra superior sai **borrado no PWA em tela cheia e nítido na aba do Safari**, no mesmo aparelho, com o mesmo CSS. Isso descarta de uma vez classe de botão, cor, sombra e `backdrop-filter` — se fosse CSS, borraria nos dois. E como só a barra borra enquanto o resto da tela fica nítido, o que ela tem de único é ser `position: fixed`, logo camada própria de composição.

Dois PRs já foram gastos mirando o conteúdo da camada (#63, #64) sem resolver. Antes de gastar um terceiro, vale confirmar a causa.

## Hipótese sob teste

Em tela cheia o `env(safe-area-inset-top)` costuma ser **fracionário**. A camada da barra cai fora da grade de pixels do aparelho, o WebKit a reamostra, e tudo dentro dela sai amolecido. Na aba do Safari o inset é ~0, a camada cai em pixel inteiro e o problema some.

O painel mostra os números que decidem isso:

- `área segura`, resolvida de verdade por sonda no DOM
- `devicePixelRatio`
- **topo e altura da barra multiplicados pelo dpr** — se derem fracionário, hipótese confirmada; se derem inteiro, ela cai e a investigação muda de rumo
- escala e offset do `visualViewport`, para descartar zoom

O painel diz a conclusão em uma linha, para não depender de leitura de número.

## Decisões de implementação

**Sem `useDebugPanelFlag`**, apesar de ser o padrão dos outros painéis. A flag persiste em `localStorage`, e o iOS pode separar o storage do Safari do storage do app da tela inicial — ligada na aba, ela não chegaria em tela cheia, que é exatamente onde a medição precisa acontecer.

**Mede sob toque, não em efeito.** O lint do projeto barra `setState` síncrono dentro de effect, e medir com a tela assentada é mais fiel que medir no primeiro commit.

**`data-execution-topbar` na `ExecutionTopBar`** para o painel achá-la sem depender de classe do Tailwind.

## Verificação

`npm run lint` limpo · 407 testes · build ok.

Conferido no navegador ponta a ponta: o painel encontra a barra pelo atributo, o toque preenche os valores, e no desktop (área segura 0) reporta corretamente `130.000` device px e "camada em pixel inteiro".

## Como usar

Entre num treino. O painel aparece logo abaixo da barra. Toque em **MEDIR** e mande o print da caixa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)