### PR TITLE
diag: teste A/B da camada da barra, ao vivo no aparelho

### DIFF
--- a/src/components/execution/LayoutMetricsPanel.jsx
+++ b/src/components/execution/LayoutMetricsPanel.jsx
@@ -61,9 +61,77 @@ const Linha = ({ nome, valor, alerta }) => (
     </div>
 );
 
+/**
+ * Candidatos a causa do borrão, aplicados ao vivo na barra.
+ *
+ * A medição derrubou a hipótese do pixel fracionário — tudo inteiro nos dois
+ * modos. O que sobrou de confirmado: em tela cheia, o texto da barra rasteriza
+ * pior que o texto em fluxo normal logo abaixo, no mesmo print e na mesma
+ * ampliação. Ou seja, o problema é a camada de composição, não o conteúdo.
+ *
+ * Cada botão mexe em um suspeito de forçar ou piorar essa camada. Testar no
+ * aparelho é o único caminho: nenhum navegador de desktop reproduz.
+ */
+const CANDIDATOS = [
+    {
+        id: 'estatico',
+        rotulo: 'sem fixed',
+        dica: 'tira a camada de composição — a barra passa a rolar com a página',
+        aplicar: (el) => { el.style.position = 'static'; }
+    },
+    {
+        id: 'semRaio',
+        rotulo: 'sem raio',
+        dica: 'canto arredondado obriga máscara na camada',
+        aplicar: (el) => { el.style.borderRadius = '0'; }
+    },
+    {
+        id: 'semSombra',
+        rotulo: 'sem sombra',
+        dica: 'shadow-2xl aumenta a área que a camada precisa pintar',
+        aplicar: (el) => { el.style.boxShadow = 'none'; }
+    },
+    {
+        id: 'semGradiente',
+        rotulo: 'sem gradiente',
+        dica: 'o overlay ciano é mais uma camada por cima',
+        aplicar: (el) => {
+            const g = el.querySelector('[class*="from-cyan-500"]');
+            if (g) g.style.display = 'none';
+        }
+    },
+    {
+        id: 'camadaPropria',
+        rotulo: 'forçar camada',
+        dica: 'translateZ(0) força rasterização própria, às vezes na escala certa',
+        aplicar: (el) => { el.style.transform = 'translateZ(0)'; }
+    }
+];
+
 export function LayoutMetricsPanel() {
     const [m, setM] = useState(null);
+    const [aplicado, setAplicado] = useState(null);
     const remedir = useCallback(() => setM(medir()), []);
+
+    const limpar = useCallback(() => {
+        const el = document.querySelector('[data-execution-topbar]');
+        if (!el) return;
+        el.style.position = '';
+        el.style.borderRadius = '';
+        el.style.boxShadow = '';
+        el.style.transform = '';
+        const g = el.querySelector('[class*="from-cyan-500"]');
+        if (g) g.style.display = '';
+        setAplicado(null);
+    }, []);
+
+    const aplicar = useCallback((candidato) => {
+        const el = document.querySelector('[data-execution-topbar]');
+        if (!el) return;
+        limpar();
+        candidato.aplicar(el);
+        setAplicado(candidato.id);
+    }, [limpar]);
 
     // Medição sob toque, e não em efeito: o lint do projeto barra `setState`
     // síncrono dentro de effect, e medir depois que a tela assentou é mais fiel
@@ -121,6 +189,50 @@ export function LayoutMetricsPanel() {
             >
                 {m ? 'MEDIR DE NOVO' : 'MEDIR'}
             </button>
+
+            <div style={{ marginTop: 14, borderTop: '1px solid #334155', paddingTop: 10 }}>
+                <div style={{ color: '#67e8f9', fontWeight: 800, marginBottom: 2 }}>TESTE A/B DA CAMADA</div>
+                <div style={{ color: '#94a3b8', marginBottom: 8 }}>
+                    Toque num botão e olhe CALC / TIMER / FOCO acima. Qual deixa o texto cravado?
+                </div>
+
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                    {CANDIDATOS.map((c) => (
+                        <button
+                            key={c.id}
+                            type="button"
+                            onClick={() => aplicar(c)}
+                            title={c.dica}
+                            style={{
+                                flex: '1 1 46%', padding: '10px 4px', borderRadius: 8,
+                                border: `1px solid ${aplicado === c.id ? '#22d3ee' : '#334155'}`,
+                                background: aplicado === c.id ? '#083344' : '#1e293b',
+                                color: aplicado === c.id ? '#67e8f9' : '#cbd5e1',
+                                font: 'inherit', fontWeight: 800
+                            }}
+                        >
+                            {c.rotulo}
+                        </button>
+                    ))}
+                    <button
+                        type="button"
+                        onClick={limpar}
+                        style={{
+                            flex: '1 1 46%', padding: '10px 4px', borderRadius: 8,
+                            border: '1px solid #475569', background: '#0f172a',
+                            color: '#94a3b8', font: 'inherit', fontWeight: 800
+                        }}
+                    >
+                        original
+                    </button>
+                </div>
+
+                <div style={{ marginTop: 8, color: '#94a3b8' }}>
+                    {aplicado
+                        ? `aplicado: ${CANDIDATOS.find(c => c.id === aplicado)?.rotulo}`
+                        : 'nada aplicado — barra como está no código'}
+                </div>
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
> ⚠️ **Temporário.** Estende o painel do #66. Sai junto com ele assim que o culpado aparecer.

## O que a medição do #66 resolveu

**Derrubou a hipótese do pixel fracionário.** Em tela cheia: área segura 62px css / 186 no aparelho, barra 127px css / 381 no aparelho, escala do viewport 1.0000. Todos inteiros. Na aba do Safari: 0 e 65/195, também inteiros. A geometria não tem nada de anômalo, e os dois modos batem entre si (127 − 70 = 57 = 65 − 8).

**E confirmou o alvo.** Num recorte ampliado do próprio usuário, no mesmo print e na mesma ampliação, o texto monoespaçado do painel — que está em fluxo normal — sai cravado, enquanto "CALC / TIMER / FOCO" logo acima sai mole. A ampliação amolece os dois por igual, então a diferença é real: a camada de composição da barra rasteriza pior que o conteúdo em fluxo.

## Por que A/B em vez de mais um palpite

Nenhum navegador de desktop reproduz o efeito — já foram dois PRs (#63, #64) mirando o conteúdo da camada sem resolver. Testar um candidato por vez custaria uma volta de deploy para cada. Os cinco viram botões:

| botão | hipótese |
|---|---|
| **sem fixed** | tira a camada de composição de vez; a barra passa a rolar com a página |
| **sem raio** | canto arredondado obriga máscara na camada |
| **sem sombra** | `shadow-2xl` amplia a área que a camada pinta |
| **sem gradiente** | o overlay ciano é mais uma camada por cima |
| **forçar camada** | `translateZ(0)`, que às vezes força rasterização na escala certa |

Mais um **original**, que restaura tudo. Um por vez — aplicar um limpa o anterior.

## Verificação

`npm run lint` limpo · 407 testes · build ok. Conferido no DOM que cada botão altera só a sua propriedade e que "original" devolve `fixed`, raio 24px, sombra, gradiente visível e `transform: none`.

## Como usar

Em tela cheia, num treino: toque num botão e olhe CALC / TIMER / FOCO. Me diga qual deixa o texto cravado — ou se nenhum deixa, o que também é resposta e manda a investigação para outro lugar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)