### PR TITLE
diag: testa a suavização de fonte no A/B da barra

### DIFF
--- a/src/components/execution/LayoutMetricsPanel.jsx
+++ b/src/components/execution/LayoutMetricsPanel.jsx
@@ -105,6 +105,22 @@ const CANDIDATOS = [
         rotulo: 'forçar camada',
         dica: 'translateZ(0) força rasterização própria, às vezes na escala certa',
         aplicar: (el) => { el.style.transform = 'translateZ(0)'; }
+    },
+    {
+        // Último candidato, e o único que não é sobre camada: index.css põe
+        // `-webkit-font-smoothing: antialiased` no body, o que troca subpixel
+        // por escala de cinza e AFINA texto claro sobre fundo escuro. O estrago
+        // se concentra em texto pequeno, negrito e caixa alta — exatamente
+        // CALC/TIMER/FOCO em 11px. Título grande em peso 700 aguenta.
+        id: 'fonteNormal',
+        rotulo: 'fonte normal',
+        dica: 'devolve a suavização subpixel só na barra',
+        aplicar: (el) => {
+            el.style.webkitFontSmoothing = 'auto';
+            el.querySelectorAll('*').forEach((filho) => {
+                filho.style.webkitFontSmoothing = 'auto';
+            });
+        }
     }
 ];
 
@@ -120,6 +136,10 @@ export function LayoutMetricsPanel() {
         el.style.borderRadius = '';
         el.style.boxShadow = '';
         el.style.transform = '';
+        el.style.webkitFontSmoothing = '';
+        el.querySelectorAll('*').forEach((filho) => {
+            filho.style.webkitFontSmoothing = '';
+        });
         const g = el.querySelector('[class*="from-cyan-500"]');
         if (g) g.style.display = '';
         setAplicado(null);


### PR DESCRIPTION
> ⚠️ **Temporário.** Último candidato. Sai com o resto do painel no PR de limpeza.

## O que já caiu, testado no aparelho

| hipótese | como caiu |
|---|---|
| pixel fracionário reamostrando a camada | medição do #66: área segura 62px/186, barra 127px/381, viewport 1.0000 — tudo inteiro |
| gradiente ciano | melhorou o **contraste**, não a nitidez — o usuário confirmou que o texto seguiu mole |
| camada de composição | **nem tirando o `position: fixed`** o texto endurece |

Três PRs de correção (#63, #64, #65) e dois de diagnóstico depois, nenhuma explicação estrutural sobreviveu ao teste.

## O candidato que sobra

[`index.css:253`](src/index.css:253) aplica `-webkit-font-smoothing: antialiased` no `body`. Isso troca a suavização subpixel por escala de cinza e **afina** texto claro sobre fundo escuro.

O estrago se concentra onde o efeito aparece: **texto pequeno, negrito e em caixa alta**. CALC, TIMER e FOCO são `text-[11px] font-bold uppercase tracking-wide`. Título em peso 700, como "PUXADA PELA FRENTE PRONADA", aguenta a mesma regra — que é exatamente por que o card sai nítido na mesma tela, e por que o painel monoespaçado, de traço mais grosso, parece mais definido.

É a primeira hipótese desta investigação que não é sobre camada, e sim sobre como o glifo é desenhado.

## O botão

**fonte normal** devolve `-webkit-font-smoothing: auto` na barra e em todos os descendentes, sem tocar no resto do app. Um toque responde.

## Verificação

`npm run lint` limpo · 407 testes · build ok. Conferido no DOM que o valor computado no botão CALC vai de `antialiased` para `auto` e volta ao original — e que o `antialiased` do `body` de fato chega aos botões por herança.

## Se este cair também

Eu paro. Não terei mais hipótese, e vou dizer isso em vez de inventar a quarta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)