### PR TITLE
trial: status bar opaca, para comparar com o esfumaçado do iOS

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,25 @@
   <link rel="preload" href="/fonts/Outfit-700-normal-54.woff2" as="font" type="font/woff2" crossorigin />
   <link rel="icon" type="image/png" href="/apple-touch-icon.png" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <!--
+    EM TESTE (15/08/2026) — era `black-translucent`.
+
+    Com `black-translucent` + `viewport-fit=cover`, o conteúdo passa por baixo da
+    status bar em tela cheia (é o que dá os 62px de `env(safe-area-inset-top)`
+    medidos no iPhone 15 Pro), e o iOS aplica um esfumaçado próprio em quem entra
+    nessa faixa. Como a barra da execução é `fixed` no topo, ela mora dentro da
+    faixa e sai borrada; o card, abaixo, sai nítido. Numa aba do Safari nada
+    disso acontece porque esta tag só vale para app instalado na tela inicial.
+
+    Com `black`, o iOS pinta a faixa do relógio e o conteúdo começa abaixo dela:
+    acaba o esfumaçado, e `env(safe-area-inset-top)` passa a 0 — os layouts se
+    ajustam sozinhos, porque todos usam `env()`.
+
+    O custo é o sangramento até o topo: a barra verde de aviso e a barra da
+    execução deixam de pintar sob o relógio. Reverter é trocar esta linha de
+    volta.
+  -->
+  <meta name="apple-mobile-web-app-status-bar-style" content="black" />
   <title>Vitalità</title>
   <meta name="theme-color" content="#0f172a" />
 </head>


### PR DESCRIPTION
> 🧪 **Teste.** Uma linha. Reverter é trocar de volta.

## A causa, enfim

[`index.html`](index.html) declarava `apple-mobile-web-app-status-bar-style: black-translucent` junto com `viewport-fit=cover`. Essa combinação faz o conteúdo **passar por baixo da status bar** em tela cheia — é daí que vêm os 62px de `env(safe-area-inset-top)` que medimos no aparelho — e o iOS aplica um **esfumaçado próprio** em quem entra nessa faixa.

O usuário achou isso rolando a Home: "Boa noite, Tiago" entrou na faixa e borrou, enquanto "Pronto para o próximo treino?", logo abaixo, ficou intacto.

A barra da execução é `position: fixed` no topo, então **mora permanentemente dentro da faixa**. O card fica abaixo e nunca entra. Bate com tudo que foi observado desde o começo.

## Por que o Safari era nítido

`apple-mobile-web-app-status-bar-style` **só vale para app instalado na tela inicial**. Numa aba, a tag é ignorada, o conteúdo nunca passa por baixo da status bar, e não há o que esfumaçar.

Não era sutileza de rasterização — era a tag não estar valendo. Essa era a pista mais forte da investigação inteira, e ela tinha uma explicação por definição, não por especulação.

## Por que nada do que foi tentado resolveu

Todas as hipóteses anteriores eram do lado do app, e o esfumaçado é do sistema:

| tentado | resultado |
|---|---|
| `backdrop-filter` aninhado (#64) | justificado por si, mas não era isso |
| pixel fracionário | geometria toda inteira no aparelho |
| camada de composição | nem tirando `position: fixed` |
| `-webkit-font-smoothing` | devolver `auto` não muda |
| véu ciano do "ambient glow" (#69) | era real e foi corrigido, mas era outro problema |

## O que muda com `black`

O iOS pinta a faixa do relógio e o conteúdo começa abaixo dela. `env(safe-area-inset-top)` passa a **0**, e os layouts se ajustam sozinhos porque todos usam `env()` — inclusive o `padding` da `ExecutionTopBar` e o espaçador de 66px, que continuam batendo (barra volta a 65px).

**O custo:** acaba o sangramento até o topo. A barra verde de "Treino salvo" deixa de pintar sob o relógio — que era a premissa central do #62 — e a barra da execução perde o mesmo efeito.

## Verificação

`npm run lint` limpo · 407 testes · build ok, com a tag confirmada no `dist/index.html`.

O efeito depende inteiramente do aparelho. A comparação é com os prints que já estão no histórico da conversa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)