### PR TITLE
docs: registra que a barra não pinta mais sob o relógio

### DIFF
--- a/docs/superpowers/plans/2026-08-12-banner-aviso-topo.md
+++ b/docs/superpowers/plans/2026-08-12-banner-aviso-topo.md
@@ -69,6 +69,34 @@ incômodo de repetição aqui é o `duration`, não a dedup. Os comentários de
 Isso reabre `notifyStore` e `TopBanner` (Tarefas 1 e 2) numa tarefa 5a, executada
 antes de fechar a Tarefa 5.
 
+## Emenda 3 — a barra não pinta mais sob o relógio (15/08/2026)
+
+Tudo neste plano que descreve a barra alcançando o pixel 0 e a cor cobrindo a
+área do relógio **deixou de valer**. Vale para o objetivo no topo do documento, o
+comentário da Tarefa 2 sobre "a cor precisa alcançar o pixel 0", o comentário da
+Tarefa 3 e a seção de verificação.
+
+O app trocou `apple-mobile-web-app-status-bar-style` de `black-translucent` para
+`black` (#70). O conteúdo deixa de passar por baixo da status bar,
+`env(safe-area-inset-top)` passa a **0** em tela cheia, e a barra começa abaixo
+da faixa que o iOS pinta. O `pt-[env(safe-area-inset-top)]` continua no código e
+vira no-op nesse modo, de propósito — volta a valer se a tag mudar.
+
+**Motivo:** com `black-translucent`, o iOS esfumaça o conteúdo que entra na faixa
+da status bar. Isso borrava os botões da `ExecutionTopBar`, que é `fixed` no topo
+e mora dentro da faixa. Antes de chegar aí, cinco hipóteses do lado do app foram
+testadas no aparelho com painel de A/B e todas caíram: `backdrop-filter`
+aninhado, pixel fracionário, camada de composição, suavização de fonte e o véu
+ciano do "ambient glow" — este último era real e foi corrigido em #69, mas era
+outro problema. O efeito é do sistema; nenhum CSS o remove.
+
+Quem localizou foi o usuário, rolando a Home e vendo a saudação borrar ao entrar
+na faixa enquanto a linha logo abaixo ficava nítida — observação que tirou a
+investigação da tela de execução, onde ela estava presa.
+
+**Decisão do usuário**, tomada comparando os dois estados no aparelho: texto
+nítido vale mais que cor de ponta a ponta.
+
 ## Estrutura de arquivos
 
 **Criar:**

--- a/docs/superpowers/specs/2026-08-12-banner-aviso-topo-design.md
+++ b/docs/superpowers/specs/2026-08-12-banner-aviso-topo-design.md
@@ -16,6 +16,32 @@ Substituir o `sonner` por um componente próprio de barra superior, usado por **
 
 Não é o aviso voltando pro topo. A barra pinta de `top: 0` até abaixo da status bar — a cor ocupa a área do relógio e da bateria, e o **conteúdo** (ícone e texto) fica na faixa logo abaixo deles. O que escondia o aviso antigo era ele ser um card curto ancorado a `top-6`, inteiramente dentro da zona da status bar. Referência visual fornecida pelo usuário: banner amarelo full-bleed com o relógio do iOS por cima da cor.
 
+> **Emenda de 15/08/2026 — a cor não alcança mais o relógio.**
+>
+> O app trocou `apple-mobile-web-app-status-bar-style` de `black-translucent`
+> para `black` (#70). Com isso o conteúdo deixa de passar por baixo da status
+> bar, `env(safe-area-inset-top)` passa a **0** em tela cheia, e a barra verde
+> **não pinta mais sob o relógio** — ela começa abaixo da faixa que o iOS pinta.
+>
+> O `pt-[env(safe-area-inset-top)]` continua no componente e vira no-op nesse
+> modo. É de propósito: ele volta a valer sozinho se a tag mudar, e cobre
+> plataformas onde o inset não é zero.
+>
+> **Por que a troca:** com `black-translucent`, o iOS aplica um esfumaçado
+> próprio no conteúdo que entra na faixa da status bar. Isso borrava os botões
+> da barra de execução, que é `fixed` no topo e mora dentro da faixa. O usuário
+> localizou o efeito rolando a Home e vendo a saudação borrar ao entrar ali,
+> enquanto a linha logo abaixo ficava nítida. Cinco hipóteses do lado do app
+> foram testadas no aparelho antes disso e todas caíram — o efeito é do sistema,
+> e nenhum CSS o remove.
+>
+> **O que se perdeu:** o full-bleed sob o relógio, que era a premissa central
+> deste spec. A decisão foi do usuário, tomada comparando os dois estados no
+> aparelho: texto nítido valeu mais que cor de ponta a ponta.
+>
+> O resto do spec — fila de um, `id` como chave de remount, `pointer-events-none`,
+> auto-dismiss, aviso com ação — segue valendo sem alteração.
+
 ## Decisão de arquitetura
 
 Duas abordagens foram avaliadas:

--- a/src/AppAuthed.jsx
+++ b/src/AppAuthed.jsx
@@ -427,10 +427,11 @@ function AppAuthedContent() {
             </div>
 
             {/*
-              * A barra pinta de `top: 0` até abaixo da status bar e põe o texto
-              * na faixa sob o relógio. Não é o aviso "voltando pro topo": o que
-              * sumia atrás da status bar em #51/#53 era um card curto ancorado
-              * a `top-6`, inteiramente dentro daquela zona.
+              * Barra de largura inteira a partir do topo do conteúdo. Não é o
+              * aviso "voltando pro topo": o que sumia atrás da status bar em
+              * #51/#53 era um card curto ancorado a `top-6`, dentro daquela
+              * zona. Desde 15/08/2026 o app usa status bar opaca e o conteúdo
+              * não corre mais sob o relógio — ver o comentário no `TopBanner`.
               *
               * Fica na raiz autenticada de propósito — salvar uma ficha volta
               * pra lista no mesmo tique, e o aviso precisa sobreviver à

--- a/src/components/design-system/TopBanner.jsx
+++ b/src/components/design-system/TopBanner.jsx
@@ -2,10 +2,21 @@
  * TopBanner.jsx
  * Barra de aviso que desce do topo — o único formato de aviso do app.
  *
- * Ela pinta de `top: 0` até abaixo da status bar (`pt-[env(safe-area-inset-top)]`)
- * e põe o conteúdo na faixa sob o relógio. Isso é o oposto do defeito que #51/#53
- * corrigiram: o aviso antigo era um card curto ancorado a `top-6`, inteiramente
- * dentro da zona da status bar, e sumia sem ser lido.
+ * Ela ocupa a largura inteira a partir do topo do conteúdo do app. O desenho
+ * original ia além: pintava até o pixel 0, com a cor cobrindo a área do relógio
+ * e o texto na faixa abaixo dele — o oposto do defeito que #51/#53 corrigiram,
+ * em que um card curto ancorado a `top-6` sumia dentro da zona da status bar.
+ *
+ * Desde 15/08/2026 isso não acontece mais: o app passou a declarar
+ * `apple-mobile-web-app-status-bar-style: black` (index.html), o conteúdo deixou
+ * de correr por baixo da status bar e `env(safe-area-inset-top)` virou 0 em tela
+ * cheia. Com `black-translucent` o iOS esfumaçava o que entrava naquela faixa, e
+ * isso borrava os botões da barra de execução.
+ *
+ * O `pt-[env(safe-area-inset-top)]` fica: vira no-op nesse modo e volta a valer
+ * sozinho se a tag mudar ou em plataforma onde o inset não seja zero. A lição de
+ * #51/#53 continua de pé — o que não pode voltar é ancorar o aviso num card
+ * curto no topo.
  *
  * `pointer-events-none` no wrapper: sem botão, a barra não recebe toque nenhum,
  * e por isso pode ficar em z-10000 — acima dos modais de z-9999 (NumericKeypad,


### PR DESCRIPTION
Só documentação e comentários. Nenhuma mudança de comportamento.

## O que caducou

O spec e o plano do #62 descreviam a barra de aviso alcançando o pixel 0, com a cor cobrindo a área do relógio e o texto na faixa abaixo dele. Era a premissa central daquele trabalho.

A troca de `apple-mobile-web-app-status-bar-style` para `black` (#70) tirou isso: o conteúdo não corre mais sob a status bar, `env(safe-area-inset-top)` é 0 em tela cheia, e a barra começa abaixo da faixa que o iOS pinta.

## O que muda aqui

- **Spec** — emenda datada na seção que fazia a afirmação, explicando o que se perdeu, por quê, e que o resto do desenho segue valendo.
- **Plano** — "Emenda 3", listando os pontos do documento que deixaram de valer (objetivo, comentários das Tarefas 2 e 3, verificação).
- **`TopBanner.jsx` e `AppAuthed.jsx`** — os comentários afirmavam a mesma coisa e foram corrigidos.

A lição de #51/#53 fica preservada em todos eles: o que não pode voltar é ancorar o aviso num card curto no topo, que foi o defeito original.

O `pt-[env(safe-area-inset-top)]` **continua no código** de propósito — vira no-op neste modo e volta a valer sozinho se a tag mudar ou em plataforma onde o inset não seja zero.

## Por que ficou registrado o motivo da troca

Para o histórico não sugerir que foi preferência estética. Com `black-translucent`, o iOS aplica um esfumaçado próprio no conteúdo que entra na faixa da status bar, e a `ExecutionTopBar` é `fixed` no topo — mora dentro dela. Cinco hipóteses do lado do app foram testadas no aparelho com painel de A/B antes de chegar aí, e todas caíram: `backdrop-filter` aninhado, pixel fracionário, camada de composição, suavização de fonte e o véu ciano do "ambient glow" (real, corrigido em #69, mas outro problema).

Quem localizou a causa foi o usuário, rolando a Home e vendo a saudação borrar ao entrar na faixa enquanto a linha logo abaixo ficava nítida.

## Verificação

`npm run lint` limpo · 407 testes · build ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)