### PR TITLE
fix: tampa opaca sobre a status bar, no lugar da tag opaca

### DIFF
--- a/docs/superpowers/plans/2026-08-12-banner-aviso-topo.md
+++ b/docs/superpowers/plans/2026-08-12-banner-aviso-topo.md
@@ -69,7 +69,31 @@ incômodo de repetição aqui é o `duration`, não a dedup. Os comentários de
 Isso reabre `notifyStore` e `TopBanner` (Tarefas 1 e 2) numa tarefa 5a, executada
 antes de fechar a Tarefa 5.
 
-## Emenda 3 — a barra não pinta mais sob o relógio (15/08/2026)
+## Emenda 3 — revertida no mesmo dia; o full-bleed continua valendo
+
+**Leia isto antes da emenda abaixo.** A troca que ela descreve durou algumas
+horas e foi desfeita. O texto original ficou porque o raciocínio explica o
+`StatusBarCap`, que ficou no lugar.
+
+Motivo de desfazer: a tag é lida quando o iOS monta a janela, não a cada
+carregamento — um "Atualizar Agora" faz `skipWaiting` + reload dentro da janela
+já montada, então ela não chegava sem matar o app ou reinstalar o atalho.
+Depender de configuração de instalação é a única categoria de mudança que não
+alcança o usuário sozinha. E `black` custava o full-bleed, que é a premissa do
+plano.
+
+No lugar entrou `src/components/common/StatusBarCap.jsx`: tampa opaca em z-45
+cobrindo a área segura, acima do conteúdo e dos headers grudentos, abaixo da
+`ExecutionTopBar` (z-50) e do `TopBanner` (z-10000). Esconde o conteúdo antes que
+ele entre na faixa esfumaçada, sem tirar o full-bleed da barra de aviso. Como é
+código, chega por atualização normal.
+
+**Portanto: tudo neste plano que descreve a barra alcançando o pixel 0 volta a
+valer.**
+
+---
+
+### Emenda 3 original (revertida) — a barra não pinta mais sob o relógio
 
 Tudo neste plano que descreve a barra alcançando o pixel 0 e a cor cobrindo a
 área do relógio **deixou de valer**. Vale para o objetivo no topo do documento, o

--- a/docs/superpowers/specs/2026-08-12-banner-aviso-topo-design.md
+++ b/docs/superpowers/specs/2026-08-12-banner-aviso-topo-design.md
@@ -16,7 +16,27 @@ Substituir o `sonner` por um componente próprio de barra superior, usado por **
 
 Não é o aviso voltando pro topo. A barra pinta de `top: 0` até abaixo da status bar — a cor ocupa a área do relógio e da bateria, e o **conteúdo** (ícone e texto) fica na faixa logo abaixo deles. O que escondia o aviso antigo era ele ser um card curto ancorado a `top-6`, inteiramente dentro da zona da status bar. Referência visual fornecida pelo usuário: banner amarelo full-bleed com o relógio do iOS por cima da cor.
 
-> **Emenda de 15/08/2026 — a cor não alcança mais o relógio.**
+> **Emenda de 15/08/2026 — revertida no mesmo dia. O full-bleed continua valendo.**
+>
+> A emenda abaixo descreve uma troca que durou algumas horas e foi desfeita. Está
+> mantida porque o raciocínio dela explica o `StatusBarCap`, que ficou no lugar.
+>
+> **O que motivou desfazer:** a tag é lida quando o iOS monta a janela do app,
+> não a cada carregamento. Um "Atualizar Agora" faz `skipWaiting` + reload dentro
+> da janela já montada, então a troca não chegava sem matar o app ou reinstalar o
+> atalho — e depender de configuração de instalação é a única categoria de
+> mudança que não alcança o usuário sozinha. Somado a isso, `black` custava
+> justamente o full-bleed que é a premissa deste spec.
+>
+> **O que ficou no lugar:** `src/components/common/StatusBarCap.jsx`, uma tampa
+> opaca em z-45 que cobre a área segura e esconde o conteúdo antes que ele entre
+> na faixa esfumaçada. Fica abaixo do `TopBanner` (z-10000), então a barra de
+> aviso continua pintando sob o relógio. Como é código, chega por atualização
+> normal.
+>
+> ---
+>
+> **Emenda original (revertida) — a cor não alcança mais o relógio.**
 >
 > O app trocou `apple-mobile-web-app-status-bar-style` de `black-translucent`
 > para `black` (#70). Com isso o conteúdo deixa de passar por baixo da status

--- a/index.html
+++ b/index.html
@@ -10,24 +10,33 @@
   <link rel="icon" type="image/png" href="/apple-touch-icon.png" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <!--
-    EM TESTE (15/08/2026) — era `black-translucent`.
+    `black-translucent` é a escolha, e ela voltou depois de um dia em `black`.
+    Não troque sem ler isto.
 
     Com `black-translucent` + `viewport-fit=cover`, o conteúdo passa por baixo da
-    status bar em tela cheia (é o que dá os 62px de `env(safe-area-inset-top)`
-    medidos no iPhone 15 Pro), e o iOS aplica um esfumaçado próprio em quem entra
-    nessa faixa. Como a barra da execução é `fixed` no topo, ela mora dentro da
-    faixa e sai borrada; o card, abaixo, sai nítido. Numa aba do Safari nada
-    disso acontece porque esta tag só vale para app instalado na tela inicial.
+    status bar em tela cheia — é o que dá os 62px de `env(safe-area-inset-top)`
+    medidos no iPhone 15 Pro, e o que permite a barra de aviso (`TopBanner`) e a
+    `ExecutionTopBar` pintarem a cor delas sob o relógio.
 
-    Com `black`, o iOS pinta a faixa do relógio e o conteúdo começa abaixo dela:
-    acaba o esfumaçado, e `env(safe-area-inset-top)` passa a 0 — os layouts se
-    ajustam sozinhos, porque todos usam `env()`.
+    O preço: o iOS aplica um esfumaçado próprio no conteúdo que entra nessa
+    faixa. Em 15/08/2026 trocamos para `black` para matar o esfumaçado, e
+    voltamos atrás por dois motivos.
 
-    O custo é o sangramento até o topo: a barra verde de aviso e a barra da
-    execução deixam de pintar sob o relógio. Reverter é trocar esta linha de
-    volta.
+    Primeiro, a tag é lida quando o iOS **monta a janela do app**, não a cada
+    carregamento. O `index.html` chega pelo service worker como todo o resto, mas
+    um "Atualizar Agora" faz `skipWaiting` + reload dentro da janela já montada —
+    então a troca não pegava sem matar o app, ou reinstalar o atalho. Depender de
+    configuração lida na instalação é ruim: é a única categoria de mudança que
+    não chega sozinha ao usuário.
+
+    Segundo, `black` custava o sangramento até o topo, que é a premissa do #62.
+
+    O esfumaçado passou a ser resolvido em código, por `StatusBarCap` — uma
+    tampa opaca que cobre a área segura e esconde o conteúdo antes que ele entre
+    na faixa. Ela fica em z-45, abaixo dos dois elementos que legitimamente
+    pintam ali. Ver `src/components/common/StatusBarCap.jsx`.
   -->
-  <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <title>Vitalità</title>
   <meta name="theme-color" content="#0f172a" />
 </head>

--- a/src/AppAuthed.jsx
+++ b/src/AppAuthed.jsx
@@ -427,11 +427,10 @@ function AppAuthedContent() {
             </div>
 
             {/*
-              * Barra de largura inteira a partir do topo do conteúdo. Não é o
-              * aviso "voltando pro topo": o que sumia atrás da status bar em
-              * #51/#53 era um card curto ancorado a `top-6`, dentro daquela
-              * zona. Desde 15/08/2026 o app usa status bar opaca e o conteúdo
-              * não corre mais sob o relógio — ver o comentário no `TopBanner`.
+              * A barra pinta de `top: 0` até abaixo da status bar e põe o texto
+              * na faixa sob o relógio. Não é o aviso "voltando pro topo": o que
+              * sumia atrás da status bar em #51/#53 era um card curto ancorado
+              * a `top-6`, inteiramente dentro daquela zona.
               *
               * Fica na raiz autenticada de propósito — salvar uma ficha volta
               * pra lista no mesmo tique, e o aviso precisa sobreviver à

--- a/src/components/common/StatusBarCap.jsx
+++ b/src/components/common/StatusBarCap.jsx
@@ -1,0 +1,37 @@
+/**
+ * StatusBarCap.jsx
+ * Tampa opaca sobre a área da status bar.
+ *
+ * O app usa `apple-mobile-web-app-status-bar-style: black-translucent`, então em
+ * tela cheia o conteúdo corre por baixo do relógio — é o que permite a barra de
+ * aviso pintar a cor dela até o pixel 0. O preço é que o iOS **esfumaça** o que
+ * entra nessa faixa: rolar a Home fazia a saudação borrar ao subir, enquanto a
+ * linha logo abaixo ficava nítida.
+ *
+ * Esta tampa esconde o conteúdo antes que ele fique visível ali. Como é código,
+ * chega pela atualização normal do service worker — diferente da meta tag, que o
+ * iOS lê ao montar a janela e exigia matar o app ou reinstalar o atalho.
+ *
+ * **O `z-index` 45 é o ponto todo do componente.** Ele precisa ficar:
+ *   - acima do conteúdo de página e dos headers grudentos (30 no TrainerDashboard,
+ *     40 no HistoryPage e no FocusModeNav), que é o que esconde o borrão;
+ *   - abaixo de `ExecutionTopBar` (z-50) e `TopBanner` (z-10000), os dois que
+ *     legitimamente pintam aquela faixa.
+ * Subir esse número apaga a barra verde full-bleed; baixar devolve o esfumaçado.
+ *
+ * Com `env(safe-area-inset-top)` valendo 0 — desktop, aba do Safari — a altura é
+ * zero e o componente não afeta nada.
+ */
+export function StatusBarCap() {
+    return (
+        // Tudo em classe, e não em `style` inline: o jsdom descarta `env()` do
+        // CSSOM, então inline não seria testável. `bg-slate-950` é o `#020617`
+        // do `body` em index.css — a tampa não deve se anunciar como faixa
+        // própria quando não há nada rolando por baixo.
+        <div
+            aria-hidden="true"
+            data-status-bar-cap=""
+            className="fixed inset-x-0 top-0 z-[45] h-[env(safe-area-inset-top)] bg-slate-950 pointer-events-none"
+        />
+    );
+}

--- a/src/components/common/StatusBarCap.test.jsx
+++ b/src/components/common/StatusBarCap.test.jsx
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { StatusBarCap } from './StatusBarCap';
+
+const renderCap = () => {
+    const { container } = render(<StatusBarCap />);
+    return container.querySelector('[data-status-bar-cap]');
+};
+
+describe('StatusBarCap', () => {
+    it('cobre a largura toda a partir do topo, sem receber toque', () => {
+        const cap = renderCap();
+
+        expect(cap.className).toContain('fixed');
+        expect(cap.className).toContain('inset-x-0');
+        expect(cap.className).toContain('top-0');
+        expect(cap.className).toContain('pointer-events-none');
+    });
+
+    // A altura é a própria área segura: com `env()` valendo 0 (desktop, aba do
+    // Safari) a tampa some sozinha, em vez de virar uma faixa preta à toa.
+    it('tem a altura da área segura', () => {
+        expect(renderCap().className).toContain('h-[env(safe-area-inset-top)]');
+    });
+
+    // Esta é a trava que dá sentido ao componente. De 50 para cima a tampa passa
+    // por cima da ExecutionTopBar (z-50) e do TopBanner (z-10000), apagando a
+    // barra verde full-bleed; em 40 ou menos ela deixa de cobrir os headers
+    // grudentos e o esfumaçado do iOS volta a aparecer.
+    it('fica entre os headers grudentos e as barras que pintam o topo', () => {
+        const z = Number(renderCap().className.match(/z-\[(\d+)\]/)?.[1]);
+
+        expect(z).toBeGreaterThan(40);
+        expect(z).toBeLessThan(50);
+    });
+
+    it('é invisível para leitores de tela', () => {
+        expect(renderCap()).toHaveAttribute('aria-hidden', 'true');
+    });
+});

--- a/src/components/design-system/TopBanner.jsx
+++ b/src/components/design-system/TopBanner.jsx
@@ -2,21 +2,17 @@
  * TopBanner.jsx
  * Barra de aviso que desce do topo — o único formato de aviso do app.
  *
- * Ela ocupa a largura inteira a partir do topo do conteúdo do app. O desenho
- * original ia além: pintava até o pixel 0, com a cor cobrindo a área do relógio
- * e o texto na faixa abaixo dele — o oposto do defeito que #51/#53 corrigiram,
- * em que um card curto ancorado a `top-6` sumia dentro da zona da status bar.
+ * Ela pinta de `top: 0` até abaixo da status bar (`pt-[env(safe-area-inset-top)]`)
+ * e põe o conteúdo na faixa sob o relógio. Isso é o oposto do defeito que #51/#53
+ * corrigiram: o aviso antigo era um card curto ancorado a `top-6`, inteiramente
+ * dentro da zona da status bar, e sumia sem ser lido.
  *
- * Desde 15/08/2026 isso não acontece mais: o app passou a declarar
- * `apple-mobile-web-app-status-bar-style: black` (index.html), o conteúdo deixou
- * de correr por baixo da status bar e `env(safe-area-inset-top)` virou 0 em tela
- * cheia. Com `black-translucent` o iOS esfumaçava o que entrava naquela faixa, e
- * isso borrava os botões da barra de execução.
- *
- * O `pt-[env(safe-area-inset-top)]` fica: vira no-op nesse modo e volta a valer
- * sozinho se a tag mudar ou em plataforma onde o inset não seja zero. A lição de
- * #51/#53 continua de pé — o que não pode voltar é ancorar o aviso num card
- * curto no topo.
+ * Esse full-bleed depende de `apple-mobile-web-app-status-bar-style:
+ * black-translucent` (index.html). Em 15/08/2026 a tag foi trocada por `black`
+ * durante algumas horas e o full-bleed sumiu junto; foi revertida. O
+ * esfumaçado que o iOS aplica nessa faixa é resolvido por `StatusBarCap`, que
+ * fica em z-45 — **abaixo** do z-10000 daqui, e é isso que deixa a barra passar
+ * por cima da tampa.
  *
  * `pointer-events-none` no wrapper: sem botão, a barra não recebe toque nenhum,
  * e por isso pode ficar em z-10000 — acima dos modais de z-9999 (NumericKeypad,

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -16,6 +16,7 @@ import { SpeedInsightsLoader } from './components/SpeedInsightsLoader';
 import { ObservabilityTracker } from './components/ObservabilityTracker';
 import { PushDebugPanel } from './components/PushDebugPanel';
 import { AppCheckDebugPanel } from './components/AppCheckDebugPanel';
+import { StatusBarCap } from './components/common/StatusBarCap';
 import {
     initializeAppCheckMonitoring,
     isAppCheckMonitoringEnabled
@@ -31,6 +32,9 @@ function renderApplication() {
                 <BrowserRouter>
                     <ObservabilityTracker />
                     <App />
+                    {/* Global, e não no AppAuthed: a tela de login também rola
+                        por baixo do relógio. */}
+                    <StatusBarCap />
                     <PushDebugPanel />
                     <AppCheckDebugPanel />
                     <SpeedInsightsLoader />


### PR DESCRIPTION
Reverte `apple-mobile-web-app-status-bar-style` para `black-translucent` e passa a resolver o esfumaçado do iOS **em código**.

## Por que desfazer a tag opaca

Ela funcionava, mas dependia de algo ruim: **o iOS lê essa tag quando monta a janela do app**, não a cada carregamento. Um "Atualizar Agora" faz `skipWaiting` + reload dentro da janela já montada, então a troca não chegava sem matar o app ou reinstalar o atalho.

Isso levantou uma preocupação legítima do usuário — "toda atualização vai exigir desinstalar?". **Não**: código, CSS, `index.html`, manifesto e assets estão no precache do `dist/sw.js` e chegam normalmente. Só ícone e nome do atalho ficam congelados na instalação. Mas a tag da status bar é exatamente a categoria que *não* chega sozinha, e depender dela é ruim por princípio.

Somado a isso, `black` custava o full-bleed que é a premissa do #62 — e o usuário tinha acabado de ver a barra verde funcionando pela primeira vez, cor sobre o relógio.

## A tampa

[`src/components/common/StatusBarCap.jsx`](src/components/common/StatusBarCap.jsx): retângulo opaco, largura cheia, altura `env(safe-area-inset-top)`, `pointer-events-none`. Esconde o conteúdo antes que ele fique visível na faixa que o iOS esfumaça.

**O `z-index` 45 é o componente inteiro**, e vem do mapa de empilhamento real do app:

| | z | |
|---|---|---|
| conteúdo de página, headers grudentos | 10–40 | **abaixo** da tampa — é o que fica escondido |
| **StatusBarCap** | **45** | |
| `ExecutionTopBar` | 50 | **acima** — continua pintando a faixa |
| `TopBanner` | 10000 | **acima** — o full-bleed verde é preservado |

Com `env(safe-area-inset-top)` valendo 0 — desktop, aba do Safari — a altura é zero e o componente não afeta nada.

Montado em `src/main.jsx`, junto dos outros overlays globais: no `AppAuthed` a tela de login ficaria descoberta.

## Detalhes que valem registro

**Classe do Tailwind, não `style` inline.** O jsdom descarta `env()` do CSSOM, então `style.height` voltava vazio e o teste não conseguia afirmar nada. Em classe (`h-[env(safe-area-inset-top)]`) fica testável — e é o idioma que o `TopBanner` já usa.

**O teste trava o z-index entre 41 e 49**, com o porquê no comentário: acima de 49 a tampa apaga a barra verde, abaixo de 41 devolve o esfumaçado. Validado nos dois sentidos — com `z-55` o caso falha.

## Verificação

`npm run lint` limpo · **411 testes** (4 novos) · 12 das Functions · build ok, com `.h-\[env\(safe-area-inset-top\)\]{height:env(safe-area-inset-top)}` confirmado no CSS gerado.

Ordem de empilhamento medida no Chrome real com a área segura simulada em 62px: `tampa top 0 / altura 62 / z-45`, `banner top 0 / altura 106 / z-10000`. E conferida em imagem — sem aviso a tampa cobre o conteúdo, com aviso o verde cobre a tampa e pinta até o pixel 0.

## O que só o iPhone confirma

1. Rolar a Home: a saudação deve **sumir atrás da faixa**, em vez de entrar borrada nela.
2. Salvar uma ficha: a barra verde deve continuar full-bleed.
3. Os headers grudentos de Histórico e do painel do Personal passam a ser cobertos na faixa — desejado, mas precisa ser olhado.
4. **Sem reinstalar nada.** Se a tampa exigir reinstalação, falhou no propósito.

## Limite conhecido

A tampa resolve o sintoma confirmado — conteúdo entrando visivelmente na faixa esfumaçada. Ela **não** promete resolver a moleza residual dos botões da `ExecutionTopBar`, que ficam abaixo da área segura e mesmo assim pareciam moles. Isso nunca teve explicação fechada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)