### PR TITLE
docs: a barra volta a pintar sob o relógio, e agora de verdade

### DIFF
--- a/docs/superpowers/plans/2026-08-12-banner-aviso-topo.md
+++ b/docs/superpowers/plans/2026-08-12-banner-aviso-topo.md
@@ -69,36 +69,40 @@ incômodo de repetição aqui é o `duration`, não a dedup. Os comentários de
 Isso reabre `notifyStore` e `TopBanner` (Tarefas 1 e 2) numa tarefa 5a, executada
 antes de fechar a Tarefa 5.
 
-## Emenda 3 — o full-bleed sob o relógio saiu, em definitivo (15/08/2026)
+## Emenda 3 — o full-bleed vale, e agora aparece de verdade (16/08/2026)
 
-**Tudo neste plano que descreve a barra alcançando o pixel 0 e a cor cobrindo a
-área do relógio deixou de valer.** Vale para o objetivo no topo, o comentário da
-Tarefa 2 sobre "a cor precisa alcançar o pixel 0", o da Tarefa 3 e a seção de
-verificação.
+**Tudo neste plano que descreve a barra alcançando o pixel 0 continua valendo.**
+Confirmado no iPhone: a cor vai até o topo, com o relógio por cima dela.
 
-Com `apple-mobile-web-app-status-bar-style: black-translucent`, o iOS aplica dois
-efeitos próprios em quem entra na faixa da status bar: um esfumaçado e um
-escurecimento, este para o relógio branco continuar legível sobre qualquer cor.
-Ou seja: **a barra verde nunca chegou a aparecer com a cor real ali** — saía com
-o topo escurecido. O full-bleed era uma promessa que o sistema não entrega.
+Houve uma emenda intermediária em 15/08 declarando o contrário. **Ela estava
+errada** e foi substituída por esta. O que ela acertou e o que ela errou:
 
-Duas tentativas de conviver falharam, ambas verificadas no aparelho:
+**Acertou o diagnóstico.** Com `apple-mobile-web-app-status-bar-style:
+black-translucent`, o iOS aplica dois efeitos em quem entra na faixa da status
+bar — esfumaçado e escurecimento, este para o relógio branco continuar legível
+sobre qualquer cor. A barra verde saía com o topo lavado, e o texto da tela
+borrava ao rolar para cima.
+
+**Errou o veredito.** Concluiu que trocar para `black` custaria o full-bleed. Não
+custa: o `viewport-fit=cover` mantém o conteúdo ocupando a tela toda nos dois
+modos, e `env(safe-area-inset-top)` segue valendo 62px. O que muda é que, com
+`black`, o iOS assume fundo escuro e **não aplica efeito nenhum** — cor cheia até
+o topo, sem esfumaçado e sem escurecimento.
+
+Antes de chegar aí, duas abordagens falharam, ambas verificadas no aparelho:
 
 1. Cinco hipóteses do lado do app, testadas com painel de A/B — backdrop-filter
    aninhado, pixel fracionário, camada de composição, suavização de fonte e o
    gradiente "ambient glow". Todas caíram.
 2. `StatusBarCap` (#72), tampa opaca sobre a área segura. Falhou porque a região
    afetada não coincide com `env(safe-area-inset-top)`, e porque a barra de aviso
-   vive em z-10000 — acima de qualquer tampa. Removida.
+   vive em z-10000 — acima de qualquer tampa. Removida em #73.
 
-A tag passou a `black`: o iOS pinta a faixa, o conteúdo começa abaixo,
-`env(safe-area-inset-top)` vira 0 e os layouts se ajustam sozinhos. O
-`pt-[env(...)]` fica nos componentes e vira no-op.
-
-**Ao entregar:** o iOS lê essa tag ao montar a janela do app. Um "Atualizar
-Agora" faz skipWaiting + reload dentro da janela já montada e não a aplica — é
-preciso matar o app no seletor e reabrir. Custo de uma vez só; código, CSS,
-manifesto e assets continuam chegando pelo service worker normalmente.
+**Ao mexer nessa tag:** o iOS a lê ao montar a janela do app. Nem "Atualizar
+Agora" nem matar o app no seletor bastaram — só pegou removendo o ícone da tela
+inicial e adicionando de novo pelo Safari. Custo de uma vez só, restrito às três
+configurações de janela (status bar, ícone, nome). Código, CSS, manifesto e
+assets continuam chegando pelo service worker normalmente.
 
 ## Estrutura de arquivos
 

--- a/docs/superpowers/specs/2026-08-12-banner-aviso-topo-design.md
+++ b/docs/superpowers/specs/2026-08-12-banner-aviso-topo-design.md
@@ -16,37 +16,41 @@ Substituir o `sonner` por um componente próprio de barra superior, usado por **
 
 Não é o aviso voltando pro topo. A barra pinta de `top: 0` até abaixo da status bar — a cor ocupa a área do relógio e da bateria, e o **conteúdo** (ícone e texto) fica na faixa logo abaixo deles. O que escondia o aviso antigo era ele ser um card curto ancorado a `top-6`, inteiramente dentro da zona da status bar. Referência visual fornecida pelo usuário: banner amarelo full-bleed com o relógio do iOS por cima da cor.
 
-> **Emenda de 15/08/2026 — o full-bleed sob o relógio saiu, em definitivo.**
+> **Emenda de 16/08/2026 — o full-bleed vale, e agora aparece de verdade.**
 >
-> Esta seção **não descreve mais o comportamento**. A barra ocupa a largura
-> inteira a partir do topo do conteúdo, mas não pinta sob o relógio.
+> Esta seção continua descrevendo o comportamento. A barra pinta até o pixel 0,
+> com o relógio por cima da cor. Confirmado no iPhone.
 >
-> **Por quê.** Com `black-translucent`, o iOS aplica dois efeitos próprios em
-> quem entra na faixa da status bar: um esfumaçado e um escurecimento — este
-> para o relógio branco continuar legível sobre qualquer cor. Resultado: a barra
-> verde **nunca chegou a aparecer com a cor real ali**, saía com o topo
-> escurecido. O full-bleed era uma promessa que o sistema não entregava.
+> O caminho até aqui passou por uma emenda intermediária, escrita em 15/08 e
+> **errada**, que declarava o full-bleed morto. Ela ficou registrada abaixo
+> porque o raciocínio dela — não o veredito — explica a configuração atual.
 >
-> **Duas tentativas de conviver falharam, ambas verificadas no aparelho:** cinco
-> hipóteses do lado do app testadas com painel de A/B, todas derrubadas; e uma
-> tampa opaca sobre a área segura (`StatusBarCap`, #72), que falhou porque a
-> região afetada não coincide com `env(safe-area-inset-top)` e porque a própria
-> barra de aviso, em z-10000, fica acima de qualquer tampa.
+> **O que estava certo nela:** com `apple-mobile-web-app-status-bar-style:
+> black-translucent`, o iOS aplica dois efeitos em quem entra na faixa da status
+> bar — esfumaçado e escurecimento, este para o relógio branco continuar legível
+> sobre qualquer cor. A barra verde saía com o topo lavado, e o texto da tela
+> borrava ao rolar para cima.
 >
-> A tag passou a `black`: o iOS pinta a faixa e o conteúdo começa abaixo dela.
-> `env(safe-area-inset-top)` vira 0 e o `pt-[env(...)]` do componente vira no-op.
+> **O que estava errado:** concluir que `black` custaria o full-bleed. Não custa.
+> O `viewport-fit=cover` mantém o conteúdo ocupando a tela toda nos dois modos; o
+> que muda é que, com `black`, o iOS assume fundo escuro e **não aplica efeito
+> nenhum**. Resultado: cor cheia até o topo, sem esfumaçado e sem escurecimento.
 >
-> **O que se perdeu é menos do que parece** — um full-bleed que já vinha
-> degradado. Tudo o mais neste spec segue valendo.
+> **Duas tentativas de conviver com `black-translucent` falharam antes**, ambas
+> verificadas no aparelho: cinco hipóteses de CSS testadas com painel de A/B, e
+> uma tampa opaca sobre a área segura (`StatusBarCap`, #72) — que falhou porque a
+> região afetada não coincide com `env(safe-area-inset-top)` e porque a barra de
+> aviso, em z-10000, fica acima de qualquer tampa.
 >
-> **Ao entregar:** o iOS lê essa tag ao montar a janela do app, não a cada
-> carregamento — um "Atualizar Agora" não a aplica. É preciso matar o app no
-> seletor e reabrir. Custo de uma vez só; todo o resto continua chegando pelo
+> **Ao mexer nessa tag:** o iOS a lê ao montar a janela do app. Nem "Atualizar
+> Agora" nem matar o app no seletor bastaram — só pegou removendo o ícone da tela
+> inicial e adicionando de novo pelo Safari. Custo de uma vez só, e restrito às
+> três configurações de janela (status bar, ícone, nome). Todo o resto chega pelo
 > service worker.
 >
 > ---
 >
-> **Emenda anterior (histórica) — a cor não alcança mais o relógio.**
+> **Emenda intermediária (15/08, veredito errado) — a cor não alcança mais o relógio.**
 >
 > O app trocou `apple-mobile-web-app-status-bar-style` de `black-translucent`
 > para `black` (#70). Com isso o conteúdo deixa de passar por baixo da status

--- a/index.html
+++ b/index.html
@@ -30,16 +30,23 @@
        o topo escurecido, ou seja, o full-bleed que a tampa existia para preservar
        já vinha degradado.
 
-    Com `black`, o iOS pinta a faixa e o conteúdo começa abaixo dela.
-    `env(safe-area-inset-top)` vira 0 e os layouts se ajustam sozinhos, porque
-    todos usam `env()`.
+    Com `black` o iOS assume fundo escuro e **não aplica efeito nenhum**. O
+    `viewport-fit=cover` mantém o conteúdo ocupando a tela toda nos dois modos e
+    `env(safe-area-inset-top)` continua valendo 62px — ou seja, não se perde o
+    sangramento até o topo. Pelo contrário: é com `black` que a barra de aviso
+    finalmente aparece com a cor cheia sob o relógio, sem o topo lavado. Isso
+    contraria o que estava escrito aqui em 15/08, e foi confirmado no aparelho.
 
     ATENÇÃO ao entregar: o iOS lê esta tag ao **montar a janela do app**, não a
-    cada carregamento. Um "Atualizar Agora" faz skipWaiting + reload dentro da
-    janela já montada e NÃO aplica a troca. É preciso matar o app no seletor e
-    reabrir — ou, se nem isso bastar, remover o ícone e adicionar de novo. Custo
-    de uma vez só: é a única categoria de mudança que não chega sozinha, e todo o
-    resto (código, CSS, manifesto, assets) continua chegando pelo service worker.
+    cada carregamento. Nem "Atualizar Agora" (skipWaiting + reload dentro da
+    janela já montada) nem matar o app no seletor bastaram — na prática, em
+    16/08/2026, só pegou removendo o ícone da tela inicial e adicionando de novo
+    pelo Safari. Avise isso de cara para quem for testar.
+
+    São só três coisas assim, todas configuração de janela lida na instalação:
+    esta tag, o ícone e o nome do atalho. Todo o resto — código, CSS, manifesto,
+    assets, fontes — está no precache do service worker e chega pelo fluxo
+    normal, sem reinstalar nada.
   -->
   <meta name="apple-mobile-web-app-status-bar-style" content="black" />
   <title>Vitalità</title>

--- a/src/AppAuthed.jsx
+++ b/src/AppAuthed.jsx
@@ -427,11 +427,10 @@ function AppAuthedContent() {
             </div>
 
             {/*
-              * Barra de largura inteira a partir do topo do conteúdo. Não é
-              * o aviso "voltando pro topo": o que sumia atrás da status bar em
-              * #51/#53 era um card curto ancorado a `top-6`, dentro daquela
-              * zona. Desde 15/08/2026 o app usa status bar opaca e nada corre
-              * mais sob o relógio — ver o comentário no `TopBanner`.
+              * A barra pinta de `top: 0` até abaixo da status bar e põe o
+              * texto na faixa sob o relógio. Não é o aviso "voltando pro topo":
+              * o que sumia atrás da status bar em #51/#53 era um card curto
+              * ancorado a `top-6`, inteiramente dentro daquela zona.
               *
               * Fica na raiz autenticada de propósito — salvar uma ficha volta
               * pra lista no mesmo tique, e o aviso precisa sobreviver à

--- a/src/components/design-system/TopBanner.jsx
+++ b/src/components/design-system/TopBanner.jsx
@@ -2,20 +2,20 @@
  * TopBanner.jsx
  * Barra de aviso que desce do topo — o único formato de aviso do app.
  *
- * Ela ocupa a largura inteira a partir do topo do conteúdo do app, com o texto
- * na primeira linha. Não é o aviso "voltando pro topo": o que sumia atrás da
- * status bar em #51/#53 era um card curto ancorado a `top-6`, inteiramente
- * dentro daquela zona. Essa lição continua valendo.
+ * Ela pinta de `top: 0` até abaixo da status bar (`pt-[env(safe-area-inset-top)]`)
+ * e põe o conteúdo na faixa sob o relógio. Isso é o oposto do defeito que #51/#53
+ * corrigiram: o aviso antigo era um card curto ancorado a `top-6`, inteiramente
+ * dentro da zona da status bar, e sumia sem ser lido.
  *
- * O desenho original ia além e pintava até o pixel 0, sob o relógio. Isso saiu
- * em 15/08/2026, junto com a troca da status bar para `black` (index.html): o
- * iOS escurecia o topo da barra para manter o relógio legível, então o
- * full-bleed nunca chegou a aparecer com a cor real. Melhor não prometer o que
- * o sistema não entrega.
+ * Esse full-bleed depende de `apple-mobile-web-app-status-bar-style: black`
+ * (index.html), e a razão é contraintuitiva. Com `black-translucent` o iOS não
+ * sabe o que há atrás do relógio e aplica dois efeitos por precaução —
+ * esfumaçado e escurecimento — que lavavam o topo da barra. Com `black` ele
+ * assume fundo escuro e não aplica nada, então a cor chega inteira ao topo.
+ * `viewport-fit=cover` mantém o conteúdo ocupando a tela nos dois modos.
  *
- * O `pt-[env(safe-area-inset-top)]` fica: vira no-op com a status bar opaca e
- * volta a valer sozinho se a tag mudar ou em plataforma onde o inset não seja
- * zero.
+ * Ou seja: a status bar opaca é o que faz o full-bleed aparecer de verdade, não
+ * o que o impede. Não troque a tag achando que recupera alguma coisa.
  *
  * `pointer-events-none` no wrapper: sem botão, a barra não recebe toque nenhum,
  * e por isso pode ficar em z-10000 — acima dos modais de z-9999 (NumericKeypad,


### PR DESCRIPTION
Só documentação e comentários. Nenhuma mudança de comportamento.

## O que estava errado

A emenda de 15/08 declarou o full-bleed morto — que a barra de aviso não pintaria mais sob o relógio com a status bar opaca. **Errado**, e o usuário confirmou no aparelho: a cor vai até o topo, com o relógio por cima dela, e sem o escurecimento que aparecia antes.

## O que continua certo, e o que caiu

**Certo — o diagnóstico.** Com `black-translucent`, o iOS aplica dois efeitos em quem entra na faixa da status bar: esfumaçado e escurecimento, este para o relógio branco continuar legível sobre qualquer cor. Era o que lavava o topo da barra verde e borrava o texto ao rolar.

**Caiu — o veredito.** `black` não custa o sangramento. O `viewport-fit=cover` mantém o conteúdo ocupando a tela toda nos dois modos, e `env(safe-area-inset-top)` segue valendo 62px. O que muda é que, com o fundo declarado escuro, **o iOS não aplica efeito nenhum**.

A conclusão é contraintuitiva o bastante para merecer estar no código: **a status bar opaca é o que faz o full-bleed aparecer de verdade, não o que o impede.** Está escrito no `TopBanner`, para ninguém trocar a tag achando que recupera alguma coisa.

## O que muda

- Spec e plano: emenda nova com o veredito correto. A errada fica registrada e marcada como tal — o diagnóstico dela continua útil.
- `index.html`: o comentário afirmava que `black` custava o sangramento.
- `TopBanner.jsx` e `AppAuthed.jsx`: idem.

## Instrução de entrega, corrigida pela prática

O comentário dizia "mate o app no seletor e reabra". Não bastou. Na prática só pegou **removendo o ícone da tela inicial e adicionando de novo pelo Safari** — agora está escrito assim, para quem for testar não perder tempo.

E ficou explícito que são **só três coisas** nessa categoria: esta tag, o ícone e o nome do atalho. Todo o resto chega pelo service worker sem reinstalar nada.

## Verificação

`npm run lint` limpo · 407 testes · build ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)