### PR TITLE
docs: registra a decisão de não ligar o enforcement do App Check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ Ler antes de "consertar" algo que parece quebrado — vários destes já foram d
 
 **O push de descanso não usa FCM** (é Web Push/VAPID via QStash) **e só é testável em iPhone com a tela bloqueada.** Mexendo nele? **Invoque o skill `push-descanso`**.
 
-**App Check está sem enforcement por decisão.** Ver [docs/app-check.md](docs/app-check.md).
+**App Check está sem enforcement por decisão — reafirmada em 28/08/2026**, já com a métrica em 100% verificadas. Não é TODO esquecido: ligar trocaria um risco teórico (que as `firestore.rules` já cobrem) por um risco observado de trancar o dono fora do app. Ver [docs/app-check.md](docs/app-check.md).
 
 ## Sobre virar app nativo
 

--- a/MANUAL_TECNICO.md
+++ b/MANUAL_TECNICO.md
@@ -202,10 +202,16 @@ público, então pode ser copiado do console sem cuidado especial.
 Com as duas definidas, registre no Firebase Console o token de debug impresso no console do
 navegador. O modo debug só funciona fora de produção.
 
-**Pendente:** o enforcement ainda está desligado — o App Check apenas coleta métricas e não bloqueia
-nada. Só ligue depois de alguns dias com as requisições verificadas perto de 100% no Firebase
-Console → App Check → APIs, e **apenas no Cloud Firestore**. Deixe o Authentication de fora enquanto
-estiver marcado como PRÉ-LANÇAMENTO: travar o login com um recurso em beta tranca você para fora do
+**Decidido, não pendente:** o enforcement está desligado e **assim permanece**. Em 28/08/2026 a
+métrica chegou a 100% de verificadas e 0% sem verificação, ou seja, o critério para *avaliar* foi
+atingido — e a avaliação concluiu que não compensa ligar. O motivo curto: as `firestore.rules` já
+exigem autenticação e propriedade em toda coleção, o projeto está no plano Spark sem faturamento, e
+os 18 dias de 403 do próprio App Check (21/07 a 07/08) mostram na prática o que enforcement ligado
+teria custado — app inutilizável, descoberto na academia. O raciocínio completo e os gatilhos para
+reabrir estão em [docs/app-check.md](docs/app-check.md).
+
+Se um dia for ligar: **apenas no Cloud Firestore**. Deixe o Authentication de fora enquanto estiver
+marcado como PRÉ-LANÇAMENTO — travar o login com um recurso em beta tranca você para fora do
 próprio app.
 
 #### Verificadas em 0% não é falta de uso — é falha

--- a/docs/app-check.md
+++ b/docs/app-check.md
@@ -4,7 +4,8 @@ O Vitalita integra o Firebase App Check como uma camada opcional de validacao do
 
 ## Decisao Arquitetural: Monitoramento Sem Enforcement
 
-**Status:** aceita em 14/07/2026.
+**Status:** aceita em 14/07/2026. Reavaliada em 28/08/2026, ja com o criterio de metricas
+atingido, e **mantida** — ver "Avaliacao de 28/08/2026" no fim deste documento.
 
 O App Check e inicializado com reCAPTCHA Enterprise para classificar o trafego, mas Firestore e demais APIs continuam aceitando requisicoes sem token valido. O objetivo atual e conhecer o comportamento dos clientes legitimos antes de considerar qualquer bloqueio.
 
@@ -143,9 +144,55 @@ Enforcement continua fora do escopo atual. Ele so deve ser avaliado quando:
 - houver procedimento de rollback documentado;
 - o uso do provider permanecer dentro da cota sem custo definida para o projeto.
 
-A avaliacao futura nao significa autorizacao para ativar enforcement. A mudanca exige decisao separada, teste em Preview, plano de rollback e aprovacao explicita.
+A avaliacao futura nao significa autorizacao para ativar enforcement. A mudanca exige decisao separada, plano de rollback e aprovacao explicita.
 
 Ativar enforcement antes disso pode bloquear versoes antigas, navegadores legitimos ou o proprio fluxo de treino.
+
+### O teste em Preview nao e exigivel neste projeto
+
+Uma versao anterior desta secao pedia teste em Preview antes de ativar. Isso e impossivel aqui: previews da Vercel nao autenticam nem leem o Firestore, porque o console do Google nao aceita curinga parcial de subdominio na restricao de referrer da API key (ver `CLAUDE.md`). Nao existe ambiente intermediario onde enforcement possa ser exercitado — qualquer ativacao seria direto em producao, tendo o rollback abaixo como unica rede.
+
+Isso nao e detalhe de processo. E parte do custo de ligar, e pesou na avaliacao a seguir.
+
+## Avaliacao de 28/08/2026: Criterio Atingido, Enforcement Nao Ligado
+
+**Status:** decidido nao ligar. Isto nao e pendencia em aberto; reabrir apenas pelos gatilhos no fim desta secao.
+
+Em 28/08/2026 o Cloud Firestore marcava **100% de solicitacoes verificadas e 0% sem verificacao**. O 0% e o numero que interessa: nao existe trafego legitimo que o enforcement bloquearia hoje. A correcao da chave trocada em 07-08/08/2026 resolveu de fato o 0% travado descrito acima.
+
+Quatro dos cinco criterios estao cumpridos:
+
+| Criterio | Situacao |
+| --- | --- |
+| Versao publicada e estavel | Cumprido — cerca de tres semanas desde a correcao |
+| Trafego legitimo verificado | Cumprido — 100% / 0% |
+| Login, sync offline e conclusao de treino no PWA | Cumprido no essencial, durante a validacao do push de 28/08 (ver [validacao-push-descanso-ios.md](validacao-push-descanso-ios.md)); o estado "SALVO LOCALMENTE" sob Modo Aviao exercitou a sincronizacao offline |
+| Rollback documentado | Cumprido — secao seguinte |
+| Provider dentro da cota sem custo | **Nao conferido** — depende do volume no console do reCAPTCHA Enterprise |
+
+Uma ressalva sobre a metrica: o console mostra percentual, nao volume nem janela. Num app de uso pessoal, 100% se apoia em poucas requisicoes. Mas 0% sem verificacao e 0% independentemente do volume, e e disso que o criterio trata.
+
+**Mesmo assim, a decisao e nao ligar.** Criterio atingido significa que a opcao existe, nao que ela compensa.
+
+### Por que nao compensa
+
+**O que o enforcement acrescentaria e pouco.** As `firestore.rules` exigem `signedIn()` e propriedade (`isSelf`, ou `canReadUserData`, que checa dono ou personal vinculado ativo) em todas as colecoes, sem nenhuma leitura publica. Quem tiver a config publica do bundle nao le dado de ninguem: no maximo cria a propria conta e usa o app como usuario, o que e um cadastro, nao um ataque. O risco residual e queimar cota do Firestore para derrubar o app — e o projeto esta no plano Spark, sem faturamento, entao o pior caso e o app parar ate a cota renovar, nao uma fatura.
+
+**O que ele custaria ja foi observado neste projeto.** De 21/07 a 07/08/2026 o App Check passou 18 dias sem emitir um unico token, pelo 403 da chave trocada. Com enforcement desligado, isso foi um numero esquisito no console. Com enforcement ligado, teriam sido 18 dias de app inutilizavel, descobertos na academia. O mesmo padrao vale para a cota: a secao "Protecao de Custo" registra que estourar os 10.000 assessments/mes faz as verificacoes falharem, e que isso nao bloqueia o acesso *porque o enforcement esta desligado*. Ligar converte um evento inofensivo em tranca.
+
+Somado: trocaria-se um risco teorico — abuso sem motivo aparente, contra dados que as rules ja protegem — por um risco concreto e ja observado de perder acesso ao proprio app por falha de infraestrutura de terceiro, sem ambiente de teste intermediario e com um rollback que exige computador e redeploy.
+
+**O monitoramento sozinho ja entregou o valor que tinha.** Foi a metrica que denunciou a chave trocada. Ela continua funcionando sem o lado ruim.
+
+### Gatilhos para reabrir
+
+- o app ganhar usuarios alem do proprietario;
+- uma conta de faturamento ser vinculada ao projeto — a partir dai queimar cota vira dinheiro, e o calculo inverte;
+- alguma API passar a expor leitura sem autenticacao.
+
+### Se um dia for ligar
+
+Apenas no **Cloud Firestore**. O Authentication seguia marcado PRE-LANCAMENTO no console em 28/08/2026, e travar o login com um recurso em beta tranca o dono para fora do proprio app.
 
 ## Rollback
 


### PR DESCRIPTION
> **Ordem de merge:** de preferência **depois do #76**. Este PR linka `docs/validacao-push-descanso-ios.md`, que nasce lá — se entrar antes, o link fica quebrado até o #76 ser mesclado. Fora isso é independente: não toca em código nem no lockfile, então não conflita com o #76 nem com o #77.

## O que foi alterado

A métrica que faltava chegou. Em **28/08/2026** o Cloud Firestore marcava **100% de solicitações verificadas e 0% sem verificação** — a correção da chave trocada de 07-08/08 (#60/#61) resolveu de fato o 0% travado. Com isso, o critério do `app-check.md` para *avaliar* enforcement foi atingido.

**A avaliação concluiu que não compensa ligar**, e é isso que este PR registra. Nenhuma configuração do Firebase foi alterada; só documentação.

O `MANUAL_TECNICO.md` dizia **"Pendente:** o enforcement ainda está desligado", o que faz uma decisão parecer tarefa esquecida — o tipo de item que alguém "resolve" seis meses depois sem reconstruir o porquê. Agora diz o que é: decidido.

### Por que não ligar

**O que acrescentaria é pouco.** As `firestore.rules` exigem `signedIn()` **e** propriedade (`isSelf`, ou `canReadUserData`, que checa dono ou personal vinculado ativo) em todas as coleções, sem nenhuma leitura pública. Quem tiver a config pública do bundle não lê dado de ninguém — no máximo cria a própria conta e usa o app como usuário, o que é um cadastro. O risco residual é queimar cota do Firestore, e o projeto está no **Spark sem faturamento**: o pior caso é o app parar até a cota renovar, não uma fatura.

**O que custaria já foi observado neste projeto.** De 21/07 a 07/08 o App Check passou **18 dias sem emitir um único token** por causa do 403. Com enforcement desligado, foi um número esquisito no console. Com ele ligado, teriam sido 18 dias de app inutilizável — descobertos na academia. O mesmo padrão vale para a cota do reCAPTCHA Enterprise, que a própria doc registra como inofensiva *"porque o enforcement permanece desligado"*. Ligar converte um evento inofensivo em tranca.

### Uma contradição que sai do caminho

O critério exigia **"teste em Preview"** antes de ativar. Isso é impossível aqui: previews da Vercel não autenticam nem leem o Firestore, porque o console do Google não aceita curinga parcial de subdomínio na restrição de referrer. Não existe ambiente intermediário — qualquer ativação seria direto em produção. Isso não estava escrito em lugar nenhum e só apareceria na pior hora possível; agora está, e pesa explicitamente na avaliação.

### O que fica registrado

- a medição de 28/08 e os 5 critérios avaliados um a um, com o único não conferido nomeado (volume contra a cota do reCAPTCHA Enterprise);
- a ressalva de que o console mostra percentual, não volume nem janela — num app pessoal, 100% se apoia em poucas requisições;
- os **gatilhos para reabrir**: usuários além do dono, conta de faturamento vinculada, ou alguma API expor leitura sem autenticação;
- se um dia for ligar: **só no Cloud Firestore**, porque o Authentication seguia marcado PRÉ-LANÇAMENTO no console.

## Como foi testado

Não se aplica — mudança exclusivamente de documentação, sem código, sem dependências, sem configuração. O CI roda normalmente porque este PR tem base na `main`.

Uma observação de estilo: o `docs/app-check.md` **não usa acentos em nenhuma das suas 156 linhas**. O texto novo segue o padrão do arquivo, para não criar um documento metade acentuado. Vale saber que isso é assim; se for acidente e você quiser corrigir o arquivo inteiro, é outro PR.

## Impacto em segurança

Nenhuma mudança efetiva: o enforcement já estava desligado e continua. O que muda é o registro — e o saldo é positivo, porque some o risco de alguém ligar enforcement no futuro achando que estava executando uma pendência, sem ver o custo.

## Impacto em Firestore/rules/indexes

Nenhum. As `firestore.rules` não foram tocadas — só citadas, como a camada que de fato controla acesso.

## Impacto visual

Nenhum.

## Checklist

- [ ] Rodei `npm run lint` — não aplicável, nenhum arquivo de código
- [ ] Rodei `npm test -- --run` — não aplicável
- [ ] Rodei `npm run test:rules` — não aplicável, regras intocadas
- [ ] Rodei `npm run build` — não aplicável
- [ ] Revisei regras do Firestore — li para fundamentar a decisão, não alterei
- [x] Atualizei documentação — é o PR inteiro: `docs/app-check.md`, `MANUAL_TECNICO.md` e `CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
