### PR TITLE
chore(deps): sobe o @anthropic-ai/sdk de 0.68 para 0.122

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "treino",
       "version": "0.0.0",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.68.0",
+        "@anthropic-ai/sdk": "^0.122.0",
         "@sentry/react": "^10.65.0",
         "@tailwindcss/postcss": "^4.1.18",
         "@vercel/speed-insights": "^1.3.1",
@@ -80,12 +80,13 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.68.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.68.0.tgz",
-      "integrity": "sha512-SMYAmbbiprG8k1EjEPMTwaTqssDT7Ae+jxcR5kWXiqTlbwMR2AthXtscEVWOHkRfyAV5+y3PFYTJRNa3OJWIEw==",
+      "version": "0.122.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.122.0.tgz",
+      "integrity": "sha512-GGPNftt0caaz9MDlmNQGHX8855Ojaduyy5pm9Sm1h7HalCn0cWNb5/bweadJF+4yzbal+QL6ztBa09WAAOzLmQ==",
       "license": "MIT",
       "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
       },
       "bin": {
         "anthropic-ai-sdk": "bin/cli"
@@ -5751,6 +5752,12 @@
         "text-hex": "1.0.x"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -10672,6 +10679,12 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fast-uri": {
       "version": "3.1.6",
@@ -18128,6 +18141,16 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.1.1.tgz",
+      "integrity": "sha512-bCbX9ZEyFkWPsRz7Bl3NuQUJohmwGSev/yhr7vhaGPlc4AfIrspIRa6cPTBuI1ItmrTDJ4d/S2hCsfe4+vQGnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
     },
     "node_modules/statuses": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:ui": "vitest --ui"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.68.0",
+    "@anthropic-ai/sdk": "^0.122.0",
     "@sentry/react": "^10.65.0",
     "@tailwindcss/postcss": "^4.1.18",
     "@vercel/speed-insights": "^1.3.1",


### PR DESCRIPTION
> **PR empilhado sobre o #77**, que por sua vez está sobre o #76 — os três mexem no lockfile. Ordem: **#76 → #77 → este**. O GitHub reaponta a base sozinho conforme os anteriores forem mesclados. Como o `ci.yml` só escuta PRs com base na `main`, **não há run de CI aqui** até este PR passar a apontar para a `main`.

## O que foi alterado

O único bump que ficou de fora do #77, por estar na importação por PDF — a única funcionalidade paga do app. Vai sozinho justamente para poder ser revertido sozinho.

`@anthropic-ai/sdk` **0.68.0 → 0.122.0**. Nenhuma linha de código mudou: só `package.json` e o lockfile.

## Por que não bastava confiar na versão

É uma faixa `0.x`, onde minor pode quebrar por semver. Então fui atrás em vez de assumir:

- os **1058 commits de changelog** entre 0.68.0 e 0.122.0 **não declaram nenhuma seção de breaking change**;
- as remoções que aparecem são de **tipos** e de **modelos aposentados** — irrelevantes aqui, porque `api/parse-workout-pdf.js` é JavaScript puro, sem etapa de tipos;
- nem `engines` nem o formato do pacote mudaram: segue CommonJS, mesmo entrypoint, sem piso novo de Node.

### Os testes existentes não provam o que este PR precisa provar

`api/parse-workout-pdf.test.js` **mocka o SDK inteiro** (`vi.mock('@anthropic-ai/sdk')`). Os 19 casos validam `sanitizeResult`, a decomposição de bi-sets e o mapeamento de erros — tudo em volta da chamada, nada dentro dela. A suíte é **estruturalmente incapaz de detectar regressão de SDK**; passar ali não era evidência.

Então fiz a verificação que faltava, **contra o pacote 0.122 real e sem gastar requisição paga**: subi um servidor HTTP local e apontei o cliente para ele via `baseURL`, com exatamente os mesmos parâmetros de produção. Treze conferências, todas passando:

| Conferido | |
|---|---|
| `POST /v1/messages`, `x-api-key`, `anthropic-version` | ✅ |
| `model` e `max_tokens` preservados no corpo | ✅ |
| `tools` serializado com `input_schema` | ✅ |
| `tool_choice` forçado na ferramenta | ✅ |
| bloco `document` base64 intacto, **antes** do bloco de texto | ✅ |
| resposta ainda lida por `content.find(type === 'tool_use')` | ✅ |
| um 402 continua expondo `.status` e `.error.type` — os campos que `isBillingError` e o log de saldo leem | ✅ |

## Como foi testado

| Comando | Resultado |
|---|---|
| `npm run lint` | limpo |
| `npm test -- --run` | 449 testes, 51 arquivos |
| `npm --prefix functions test` | 12 testes |
| `npm run test:rules` | 12 cenários no emulador |
| `VITE_ENABLE_PDF_IMPORT=true npm run build` | OK |
| verificação do SDK real contra servidor local | 13/13 |

**Sem efeito no cliente, provado por dois caminhos:** "anthropic" não aparece em `dist/assets`, e o build saiu com **hashes idênticos** aos da branch anterior — `vendor-recharts-o5oUwEG5.js`, `vendor-firebase-firestore-YLt53fqm.js`, precache 2211.67 KiB. É o mesmo artefato. Por isso **não** repeti o preview de produção do skill `verificacao-build-producao`: o bundle é literalmente o já verificado no navegador, e o SDK é dependência de servidor que só roda na função serverless.

**O que não foi testado:** nenhum PDF real foi importado. Isso exigiria uma chamada paga (~US$ 0,04) contra a API da Anthropic, que eu não disparo sem você pedir. A verificação acima cobre o contrato SDK↔código; o que ela não cobre é a resposta do modelo, que este PR não altera.

## Impacto em segurança

Nenhum. A `ANTHROPIC_API_KEY` continua sendo variável de servidor, nunca `VITE_*`, e a fronteira de responsabilidade não muda: a função só parseia, e quem grava em `workout_templates` segue sendo o cliente autenticado via `workoutService.createTemplate`, sob as `firestore.rules`.

## Impacto em Firestore/rules/indexes

Nenhum. Regras intocadas; suíte rodada mesmo assim, 12 cenários passando.

## Impacto visual

Nenhum. Build com hashes idênticos.

## Duas observações para depois, deliberadamente fora deste PR

1. **O `claude-opus-5` custa o mesmo que o `claude-opus-4-8`** — US$ 5 / US$ 25 por MTok nos dois. Trocar o modelo poderia melhorar a leitura de ficha sem mudar o custo por PDF. Mas troca de modelo é decisão separada, com teste próprio e PDFs reais, e não tem por que viajar junto de um bump de biblioteca.
2. **A verificação do SDK poderia virar teste permanente.** Hoje ela é um script de uso único; como teste, fecharia o buraco de a suíte mockar o SDK e nunca notar uma regressão dele. Não incluí para não ampliar o escopo — mas se quiser, é rápido.

## Checklist

- [x] Rodei `npm run lint`
- [x] Rodei `npm test -- --run`
- [x] Rodei `npm run test:rules` — 12 cenários no emulador
- [x] Rodei `npm run build` — hashes idênticos aos da base, sem efeito no cliente
- [ ] Revisei regras do Firestore — não aplicável, nada tocado
- [ ] Atualizei documentação — não aplicável, nenhum comportamento documentado muda

🤖 Generated with [Claude Code](https://claude.com/claude-code)
