### PR TITLE
fix: adota o eslint-plugin-react-hooks 7.1.1 e trata os 14 achados

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -37,7 +37,23 @@ export default defineConfig([
     rules: {
       'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
       'react/react-in-jsx-scope': 'off', // Not needed in React 18+ / Vite
-      'react/prop-types': 'off' // We are forgiving on prop types for now to avoid noise
+      'react/prop-types': 'off', // We are forgiving on prop types for now to avoid noise
+
+      // Aviso, não erro — decidido em 28/08/2026 ao adotar o
+      // eslint-plugin-react-hooks 7.1.1, que passou a reprovar 12 ocorrências
+      // já existentes. As 12 foram lidas uma a uma: são busca de dados no
+      // mount (AppAuthed, TrainerDashboard, WorkoutsPage, HistoryPage) e
+      // reset de estado quando a identidade muda (NumericKeypad, HistoryPage,
+      // RestTimer) — o padrão canônico do React sem uma biblioteca de dados,
+      // sem alternativa mais simples. A única que era de fato estado derivado
+      // virou `useMemo` em `useAchievements.js`; o resto custa um render a
+      // mais, não um defeito.
+      //
+      // Fica em 'warn' de propósito, em vez de 'off' ou de 11 supressões
+      // espalhadas: nada some do relatório de lint, ocorrência nova aparece
+      // junto, e o CI não quebra por dívida herdada. Se um dia o app adotar o
+      // React Compiler, isto vira 'error' e as 11 viram trabalho de verdade.
+      'react-hooks/set-state-in-effect': 'warn'
     },
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "eslint": "^9.39.1",
         "eslint-plugin-cypress": "^5.2.1",
         "eslint-plugin-react": "^7.37.5",
-        "eslint-plugin-react-hooks": "^7.0.1",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "firebase-tools": "^15.22.4",
         "globals": "^16.5.0",
@@ -10126,9 +10126,9 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
-      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10142,7 +10142,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-plugin-react-refresh": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "eslint": "^9.39.1",
     "eslint-plugin-cypress": "^5.2.1",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "firebase-tools": "^15.22.4",
     "globals": "^16.5.0",

--- a/src/hooks/profile/useAchievements.js
+++ b/src/hooks/profile/useAchievements.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { achievementsCatalog } from '../../data/achievementsCatalog';
 import { calculateStats, evaluateAchievements, evaluateHistory } from '../../utils/evaluateAchievements';
 import { calculateWeeklyStats } from '../../utils/workoutStats';
@@ -12,7 +12,6 @@ import { userStatsService } from '../../services/userStatsService';
  * Recebe `profile` para reagir à meta semanal e mesclar overrides manuais.
  */
 export function useAchievements(user, profile) {
-    const [achievementsList, setAchievementsList] = useState([]);
     const [stats, setStats] = useState(null);
     const [loadingAchievements, setLoadingAchievements] = useState(true);
     // Armazenar histórico calculado localmente para combinar com o perfil
@@ -73,16 +72,19 @@ export function useAchievements(user, profile) {
         void loadAchievementsData();
     }, [user, profile?.weeklyGoal]); // Recalcular se meta semanal mudar.
 
-    // Reavaliar quando estatísticas ou perfil mudarem
-    useEffect(() => {
-        if (stats && profile) {
-            // Combinar mapa do perfil com mapa calculado (Calculado tem prioridade para corrigir datas antigas, mas perfil pode ter overrides manuais futuros)
-            // Na verdade, calculo histórico é mais preciso para "quando aconteceu a primeira vez".
-            const mergedUnlockedMap = { ...profile.achievements, ...calculatedHistoryMap };
+    // Derivado, não estado: a lista é função pura de estatísticas + perfil +
+    // histórico calculado. Guardá-la em `useState` alimentado por efeito custava
+    // um render a mais a cada mudança e abria espaço para a lista discordar das
+    // suas próprias entradas por um quadro. `useMemo` elimina os dois.
+    const achievementsList = useMemo(() => {
+        if (!stats || !profile) return [];
 
-            const evaluated = evaluateAchievements(achievementsCatalog, stats, mergedUnlockedMap);
-            setAchievementsList(evaluated);
-        }
+        // Calculado tem prioridade sobre o mapa do perfil: o histórico recalculado
+        // é mais preciso para "quando aconteceu a primeira vez", enquanto o perfil
+        // guarda overrides manuais futuros.
+        const mergedUnlockedMap = { ...profile.achievements, ...calculatedHistoryMap };
+
+        return evaluateAchievements(achievementsCatalog, stats, mergedUnlockedMap);
     }, [stats, profile, calculatedHistoryMap]);
 
     return { achievementsList, stats, loadingAchievements };

--- a/src/hooks/profile/useAchievements.test.js
+++ b/src/hooks/profile/useAchievements.test.js
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+const getUserStats = vi.fn();
+const getRecentSessions = vi.fn();
+const evaluateAchievements = vi.fn();
+
+vi.mock('../../services/userStatsService', () => ({
+    userStatsService: { getUserStats: (...a) => getUserStats(...a) }
+}));
+
+vi.mock('../../services/workoutService', () => ({
+    SESSION_LIMITS: { profileStats: 50 },
+    workoutService: { getRecentSessions: (...a) => getRecentSessions(...a) }
+}));
+
+vi.mock('../../utils/evaluateAchievements', () => ({
+    evaluateAchievements: (...a) => evaluateAchievements(...a),
+    calculateStats: () => ({ totalWorkouts: 0 }),
+    evaluateHistory: () => ({})
+}));
+
+vi.mock('../../utils/workoutStats', () => ({
+    calculateWeeklyStats: () => ({ currentStreak: 0, bestStreak: 0, weeklyGoal: 4 })
+}));
+
+vi.mock('../../data/achievementsCatalog', () => ({ achievementsCatalog: [] }));
+
+import { useAchievements } from './useAchievements';
+
+const USER = { uid: 'u1' };
+
+describe('useAchievements', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        // Devolve o mapa recebido, para as asserções poderem inspecionar o merge.
+        evaluateAchievements.mockImplementation((_catalog, _stats, map) => [{ id: 'lista', map }]);
+    });
+
+    it('começa com lista vazia enquanto as estatísticas não chegaram', () => {
+        getUserStats.mockReturnValue(new Promise(() => {})); // nunca resolve
+        const { result } = renderHook(() => useAchievements(USER, { achievements: {} }));
+        expect(result.current.achievementsList).toEqual([]);
+    });
+
+    it('publica a lista avaliada quando as estatísticas chegam', async () => {
+        getUserStats.mockResolvedValue({ totalWorkouts: 3, achievements: {} });
+
+        const { result } = renderHook(() => useAchievements(USER, { achievements: {} }));
+
+        await waitFor(() => expect(result.current.achievementsList).toHaveLength(1));
+        expect(result.current.achievementsList[0].id).toBe('lista');
+    });
+
+    it('o histórico calculado tem precedência sobre o mapa do perfil', async () => {
+        // Mesma conquista nos dois lados, com datas diferentes.
+        getUserStats.mockResolvedValue({
+            totalWorkouts: 3,
+            achievements: { primeiro_treino: '2026-01-01' }
+        });
+
+        const profile = { achievements: { primeiro_treino: '2026-08-01' } };
+        const { result } = renderHook(() => useAchievements(USER, profile));
+
+        await waitFor(() => expect(result.current.achievementsList).toHaveLength(1));
+        // O calculado (servidor) vence: é mais preciso para "quando foi a primeira vez".
+        expect(result.current.achievementsList[0].map.primeiro_treino).toBe('2026-01-01');
+    });
+
+    it('reavalia quando o perfil muda, sem refazer a busca', async () => {
+        getUserStats.mockResolvedValue({ totalWorkouts: 3, achievements: {} });
+
+        const { result, rerender } = renderHook(
+            ({ profile }) => useAchievements(USER, profile),
+            { initialProps: { profile: { weeklyGoal: 4, achievements: { a: 'antes' } } } }
+        );
+
+        await waitFor(() => expect(result.current.achievementsList).toHaveLength(1));
+        expect(result.current.achievementsList[0].map.a).toBe('antes');
+
+        const buscasAntes = getUserStats.mock.calls.length;
+        rerender({ profile: { weeklyGoal: 4, achievements: { a: 'depois' } } });
+
+        await waitFor(() => expect(result.current.achievementsList[0].map.a).toBe('depois'));
+        // Mudar overrides do perfil não pode custar uma ida ao servidor.
+        expect(getUserStats.mock.calls.length).toBe(buscasAntes);
+    });
+
+    it('não avalia nada sem usuário', () => {
+        const { result } = renderHook(() => useAchievements(null, { achievements: {} }));
+        expect(result.current.achievementsList).toEqual([]);
+        expect(evaluateAchievements).not.toHaveBeenCalled();
+        expect(getUserStats).not.toHaveBeenCalled();
+    });
+});

--- a/src/hooks/profile/useProfileData.js
+++ b/src/hooks/profile/useProfileData.js
@@ -71,6 +71,15 @@ export function useProfileData(user) {
                     label: 'Tentar Novamente',
                     onClick: () => {
                         fetchingRef.current = false; // Allow retry
+                        // Auto-referência: a const ainda não existe quando o
+                        // useCallback é montado, e a regra não distingue isso de
+                        // um uso em TDZ. Aqui a chamada é diferida — só acontece
+                        // no clique, muito depois da atribuição. Tentei trocar
+                        // por um ref atualizado em efeito (28/08/2026) e saiu
+                        // pior: rendeu um erro de preserve-manual-memoization no
+                        // useCallback mais um set-state-in-effect novo. Dois
+                        // achados no lugar de um.
+                        // eslint-disable-next-line react-hooks/immutability
                         fetchProfileData();
                     }
                 }

--- a/src/hooks/useWorkoutTimer.js
+++ b/src/hooks/useWorkoutTimer.js
@@ -19,7 +19,6 @@ export function useWorkoutTimer(running = true, initialSeconds = 0) {
     // Sincronizar com initialSeconds se mudar essencialmente (e.g. carregado de persistência)
     useEffect(() => {
         if (initialSeconds !== elapsedRef.current) {
-            // eslint-disable-next-line react-hooks/set-state-in-effect
             setElapsedSeconds(initialSeconds);
             startTimeRef.current = Date.now() - (initialSeconds * 1000);
             elapsedRef.current = initialSeconds;

--- a/src/pages/CreateWorkoutPage.jsx
+++ b/src/pages/CreateWorkoutPage.jsx
@@ -274,6 +274,11 @@ export default function CreateWorkoutPage({ user }) {
         } else {
             // Adicionar novo
             const exercise = {
+                // `handleAddExercise` só existe como onClick do botão de adicionar,
+                // nunca é chamada em render — a regra não consegue provar isso e
+                // assume o pior. O id continua sendo o timestamp: trocá-lo mudaria o formato
+                // de dado já gravado em workout_templates sem ganho real.
+                // eslint-disable-next-line react-hooks/purity
                 id: Date.now().toString(),
                 ...finalExercise
             };


### PR DESCRIPTION
> **Empilhado sobre o #79** (que está sobre o #77, sobre o #76 — todos tocam o lockfile). Ordem: **#76 → #77 → #79 → este**. Sem run de CI aqui até a base virar `main`.

## O resultado curto

**3 correções, 2 anotações justificadas, 11 avisos, 5 testes novos.** O tratamento não é uniforme porque os 14 achados não são a mesma coisa — li um a um.

## O que virou correção de verdade

**`useAchievements.js` guardava estado derivado.** A lista de conquistas vivia num `useState` alimentado por efeito, sendo função pura de estatísticas + perfil + histórico calculado. Custava um render a mais a cada mudança e permitia que a lista discordasse das próprias entradas por um quadro. Virou `useMemo` — um estado e um efeito a menos.

**Essa é a única mudança de comportamento do PR, e ela estava sem teste nenhum:** `src/hooks/profile/` não tinha arquivo de teste. Isso me pareceu inaceitável para mexer ali, então vão **5 casos novos**, incluindo a precedência do merge (o histórico calculado vence o mapa do perfil, porque é mais preciso para "quando foi a primeira vez") e a garantia de que mudar overrides do perfil reavalia sem custar ida ao servidor.

Para não entregar teste que passa à toa, quebrei o código de propósito:

| Mutação | Resultado |
|---|---|
| Inverter a precedência do merge | 1 caso falha |
| Tirar `profile` das dependências do memo | 1 caso falha |
| Restaurado | 5 passam |

**`useWorkoutTimer.js`** tinha um `eslint-disable` de `set-state-in-effect` que o 7.1.1 tornou desnecessário — a mesma versão que apertou 12 outros lugares afrouxou este. Removido.

## O que virou anotação, com o motivo escrito

**`react-hooks/purity` em `CreateWorkoutPage.jsx`** — `Date.now()` na geração de id. Confirmei que `handleAddExercise` só existe como `onClick` do botão de adicionar e nunca roda em render; a regra não consegue provar isso e assume o pior. Trocar o gerador mudaria o formato de dado já gravado em `workout_templates` sem ganho real.

**`react-hooks/immutability` em `useProfileData.js`** — o "Tentar Novamente" chama a própria busca de dentro dela. **Tentei a correção estrutural e saiu pior:** um ref atualizado por efeito rendeu um erro de `preserve-manual-memoization` no `useCallback` **mais** um `set-state-in-effect` novo — dois achados no lugar de um. Desfiz e deixei o registro no código, para ninguém repetir a tentativa achando que é fácil.

## O que virou aviso, e por quê

As 12 ocorrências de `set-state-in-effect` são de dois tipos só:

- **busca de dados no mount** — `AppAuthed`, `TrainerDashboard`, `WorkoutsPage`, `HistoryPage`;
- **reset de estado quando a identidade muda** — `NumericKeypad`, `HistoryPage`, `RestTimer`.

É o padrão canônico do React sem uma biblioteca de dados, sem alternativa mais simples. Reescrever isso valeria **um render economizado** contra risco real nos fluxos centrais do app — a lista de treinos, o diário, o painel do personal, o teclado numérico, o timer de descanso. Não me parece troca defensável, ainda mais porque não consigo verificar tela autenticada.

A regra foi para **`'warn'`**, e essa escolha é deliberada contra as duas alternativas: `'off'` esconderia ocorrência nova, e 11 supressões espalhadas por nove arquivos seriam a mesma decisão repetida onze vezes, com ruído em cada uma. Em `'warn'`: nada some do relatório de lint, ocorrência nova aparece junto das velhas, e o CI não quebra por dívida herdada. O motivo está escrito no `eslint.config.js`, junto da condição que o transformaria em `'error'` (adotar o React Compiler).

**Estado final do lint: 0 erros, 11 avisos** — todos listados acima, nenhum invisível.

## Como foi testado

| Comando | Resultado |
|---|---|
| `npm run lint` | 0 erros, 11 avisos (os 11 documentados) |
| `npm test -- --run` | **454 testes**, 52 arquivos (+5, +1 arquivo) |
| `npm --prefix functions test` | 12 testes |
| `npm run test:rules` | 12 cenários no emulador |
| `VITE_ENABLE_PDF_IMPORT=true npm run build` | OK |
| bundle de produção executado | sobe até o login, sem erro |

O bundle foi rodado em `localhost:4173` porque este PR mexe em código de aplicação: sai da tela "Carregando..." e chega ao login, e o único recurso com falha na carga é o `/_vercel/speed-insights/script.js`, que só existe servido pela Vercel.

**O que não foi verificado:** as telas autenticadas. Não faço login, então `ProfilePage` (que consome o `useAchievements` alterado) não passou por conferência visual minha — a cobertura ali são os 5 testes novos. Vale abrir o perfil uma vez depois de mesclar e confirmar que a lista de conquistas aparece como antes.

## Impacto em segurança

Nenhum. Nada de autenticação, autorização, credenciais ou rede.

## Impacto em Firestore/rules/indexes

Nenhum. Regras intocadas; suíte rodada mesmo assim, 12 cenários passando. O id de exercício segue no formato atual justamente para não mexer em dado já gravado.

## Impacto visual

Nenhum pretendido. O `useAchievements` devolve a mesma lista para as mesmas entradas — a diferença é quando ela é calculada, não o quê.

## Checklist

- [x] Rodei `npm run lint`
- [x] Rodei `npm test -- --run`
- [x] Rodei `npm run test:rules` — 12 cenários no emulador
- [x] Rodei `npm run build` — e executei o bundle
- [ ] Revisei regras do Firestore — não aplicável, nada tocado
- [x] Atualizei documentação — o `eslint.config.js` carrega a decisão e a condição de revertê-la

🤖 Generated with [Claude Code](https://claude.com/claude-code)
