### PR TITLE
feat: troca a leitura de ficha por PDF para o Claude Opus 5

### DIFF
--- a/api/parse-workout-pdf.js
+++ b/api/parse-workout-pdf.js
@@ -17,9 +17,10 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { createRemoteJWKSet, jwtVerify } from 'jose';
 
-// Modelo com suporte nativo a PDF. Opus 4.8 pela precisão de extração —
-// erro de leitura vira série/repetição errada na ficha do aluno.
-const MODEL = 'claude-opus-4-8';
+// Modelo com suporte nativo a PDF. Opus 5 pela precisão de extração — erro de
+// leitura vira série/repetição errada na ficha do aluno — e pelo mesmo preço por
+// token do 4.8 que ele substituiu (US$ 5 / US$ 25 por milhão).
+const MODEL = 'claude-opus-5';
 // ~3,3 MB de PDF em base64. Protege o limite de corpo das funções da Vercel.
 const MAX_PDF_BASE64 = 4_400_000;
 
@@ -225,7 +226,17 @@ export default async function handler(req, res) {
         const client = new Anthropic({ apiKey });
         const message = await client.messages.create({
             model: MODEL,
-            max_tokens: 8192,
+            // Explícito de propósito: o padrão de `thinking` MUDA entre modelos —
+            // no 4.8 omitir significava não pensar, no Opus 5 significa pensar.
+            // Deixar implícito faria o comportamento virar junto com o modelo, em
+            // silêncio. Aqui pensar é desejável: a alternativa (`disabled`) faz o
+            // Opus 5 às vezes escrever a chamada de ferramenta como texto comum,
+            // e esta função depende inteiramente de receber um bloco `tool_use`.
+            thinking: { type: 'adaptive' },
+            // 8192 era justo para a resposta sozinha. O `max_tokens` limita
+            // pensamento + resposta juntos, então uma ficha longa truncaria no
+            // meio agora que o modelo pensa.
+            max_tokens: 16000,
             tools: [WORKOUT_TOOL],
             tool_choice: { type: 'tool', name: WORKOUT_TOOL.name },
             messages: [{
@@ -236,6 +247,20 @@ export default async function handler(req, res) {
                 ]
             }]
         });
+
+        // O Opus 5 pode recusar por classificador de segurança: chega 200, com
+        // `stop_reason: 'refusal'` e nenhum `tool_use`. Sem este ramo viraria um
+        // `parse_failed` genérico, mandando o operador procurar defeito num PDF
+        // que está perfeito. O status segue 422 porque o cliente mapeia por
+        // status, não pelo código do corpo — quem precisa distinguir é o log.
+        if (message?.stop_reason === 'refusal') {
+            console.error('pdf_import_recusado', {
+                categoria: message?.stop_details?.category ?? null,
+                explicacao: message?.stop_details?.explanation ?? null,
+                acao: 'PDF legítimo recusado pelo classificador; reportar à Anthropic se repetir'
+            });
+            return res.status(422).json({ error: 'ai_refused' });
+        }
 
         const toolUse = Array.isArray(message?.content)
             ? message.content.find(c => c.type === 'tool_use' && c.name === WORKOUT_TOOL.name)

--- a/api/parse-workout-pdf.test.js
+++ b/api/parse-workout-pdf.test.js
@@ -143,6 +143,43 @@ describe('/api/parse-workout-pdf', () => {
         expect(res.statusCode).toBe(422);
     });
 
+    describe('recusa do classificador (Opus 5)', () => {
+        it('responde 422 e distingue no log, sem culpar o PDF', async () => {
+            const erro = vi.spyOn(console, 'error').mockImplementation(() => {});
+            // 200 da API, mas sem tool_use: é o formato de uma recusa.
+            createMock.mockResolvedValueOnce({
+                content: [],
+                stop_reason: 'refusal',
+                stop_details: { type: 'refusal', category: 'cyber', explanation: 'motivo' }
+            });
+
+            const res = makeRes();
+            await handler(makeReq(), res);
+
+            expect(res.statusCode).toBe(422);
+            expect(res.body).toEqual({ error: 'ai_refused' });
+            // O status é o mesmo de "PDF ilegível"; quem separa os dois é o log.
+            expect(erro).toHaveBeenCalledWith('pdf_import_recusado', expect.objectContaining({ categoria: 'cyber' }));
+            erro.mockRestore();
+        });
+    });
+
+    describe('forma da requisição', () => {
+        it('manda thinking adaptativo e teto que cabe pensamento + resposta', async () => {
+            createMock.mockResolvedValueOnce(toolResponse);
+            await handler(makeReq(), makeRes());
+
+            const params = createMock.mock.calls[0][0];
+            expect(params.model).toBe('claude-opus-5');
+            // Implícito seria pior: o padrão de thinking muda entre modelos.
+            expect(params.thinking).toEqual({ type: 'adaptive' });
+            // Com thinking ligado, o teto vale para pensamento + resposta.
+            expect(params.max_tokens).toBeGreaterThan(8192);
+            // O que faz a função funcionar: ferramenta forçada.
+            expect(params.tool_choice).toEqual({ type: 'tool', name: 'registrar_treinos' });
+        });
+    });
+
     describe('decomposição de bi-set/tri-set', () => {
         it('quebra "A + B" num bi-set de dois exercícios ligados', async () => {
             createMock.mockResolvedValueOnce(toolResp([{


### PR DESCRIPTION
Mesmo preço por token do Opus 4.8 que ele substitui — US$ 5 / US$ 25 por milhão — com extração melhor. Nesta função isso importa mais que o normal: erro de leitura vira série ou repetição errada na ficha de quem treina.

## Não era só trocar a string

O guia de migração aponta uma mudança silenciosa que pega exatamente esta chamada: **o padrão de `thinking` inverteu**. No 4.8, omitir o parâmetro significava *não* pensar; no Opus 5, significa pensar. Como o código omitia, o comportamento mudaria sozinho junto com o modelo — sem ninguém pedir, e sem aparecer no diff.

**1. O `thinking` agora é explícito.** Deixá-lo implícito é o que permitiu a armadilha existir; escrito, o comportamento para de depender de qual modelo está na constante.

Escolhi `adaptive` em vez de `disabled`, e o motivo é específico desta função. O guia registra que, com o pensamento desligado, o Opus 5 às vezes **escreve a chamada de ferramenta como texto comum** em vez de emitir um bloco `tool_use` — a requisição volta 200, parecendo bem-sucedida, e a chamada simplesmente não aconteceu. Esta função depende inteiramente de receber um `tool_use` (`tool_choice` forçado + `content.find(type === 'tool_use')`). Seria trocar um custo previsível por uma falha silenciosa, que é o tipo de defeito que o #75 existiu para eliminar.

**2. O `max_tokens` subiu de 8192 para 16000.** O teto cobre pensamento **mais** resposta, e 8192 era justo para a resposta sozinha. Sem a folga, uma ficha longa passaria a truncar no meio agora que o modelo pensa.

**3. Recusa do classificador passa a ser distinguível.** O Opus 5 pode recusar por segurança, e a recusa chega como 200 com `stop_reason: 'refusal'` e nenhum `tool_use`. Sem tratamento viraria o `parse_failed` genérico, mandando o operador procurar defeito num PDF que está perfeito.

O status devolvido continua **422 de propósito**: o cliente (`workoutPdfImport.js`) mapeia por status HTTP, não pelo código do corpo, então um status novo exigiria mexer no cliente sem ganho para quem usa o app. Quem separa os dois casos é o log do servidor — mesmo padrão que o erro de saldo já usa.

## Como foi testado

| Comando | Resultado |
|---|---|
| `npm run lint` | 0 erros (11 avisos conhecidos, do #80) |
| `npm test -- --run` | **456 testes**, 52 arquivos (+2) |
| `npm --prefix functions test` | 12 testes |
| `npm run test:rules` | 12 cenários no emulador |
| `VITE_ENABLE_PDF_IMPORT=true npm run build` | OK |

Dois casos novos, ambos verificados por mutação — teste que passa à toa não vale nada aqui:

| Mutação | Resultado |
|---|---|
| Remover o ramo de recusa | 1 caso falha |
| Voltar `thinking` para `disabled` | 1 caso falha |
| Voltar `max_tokens` para 8192 | 1 caso falha |

E como a suíte **mocka o SDK inteiro** e por isso não exercita a chamada real, repeti a verificação de fio contra o pacote 0.122 de verdade (servidor HTTP local, `baseURL` apontado para ele): 14 conferências passando, incluindo que `thinking: {type:'adaptive'}` e `max_tokens: 16000` chegam no corpo, que o `tool_choice` continua forçado e que o bloco `document` base64 vai intacto antes do texto.

Mudança é **server-only**: `claude-opus` não aparece em `dist/assets` e o precache do PWA ficou idêntico (2211,66 KiB).

## O que NÃO foi testado — leia antes de mesclar

**Nenhum PDF real foi importado.** Isso exige uma chamada paga contra a API, que eu não disparo sem você pedir. Então duas coisas dependem de você rodar uma importação depois do deploy:

**1. Latência.** Pensar aumenta o tempo de resposta, e a função **não tem `maxDuration` configurado** — nem no arquivo, nem no `vercel.json`. Não consegui descobrir o teto real: o projeto está no plano **Hobby** (a retenção de logs de 1h denuncia) e o padrão da Vercel para isso mudou ao longo do tempo, entre 10s e valores bem maiores com Fluid compute. Não quis chutar um `maxDuration` e correr o risco de *reduzir* um teto que hoje é maior. **Se a primeira importação der 504, é isto** — e a correção é uma linha (`export const config = { maxDuration: 60 }`, o máximo do Hobby).

**2. Custo por PDF sobe.** O preço por token é o mesmo, mas pensamento são tokens de saída, cobrados a US$ 25/milhão. Os ~US$ 0,04 por PDF documentados no `MANUAL_TECNICO` vão subir — provavelmente para algo entre US$ 0,05 e US$ 0,08, mas é estimativa, não medição. Vale conferir o consumo real no console depois das primeiras importações e atualizar o número na doc.

Se o custo ou a latência incomodarem, o lever é `output_config: { effort: 'medium' }` (ou `'low'`): o guia registra que o Opus 5 é "excepcionalmente forte" nesses níveis e que effort é a alavanca principal de custo e latência. Não apliquei porque a razão de esta função usar um modelo Opus é precisão, e reduzir effort sem medir seria trocar exatamente o que se foi buscar.

**Uma coisa que deixei de fora deliberadamente:** o guia recomenda o parâmetro `fallbacks: "default"` por padrão em código Opus 5, para uma recusa ser re-executada noutro modelo em vez de voltar como falha. Não incluí porque exige mudar para `client.beta.messages.create` mais um header beta — superfície beta no único caminho pago, que eu não consigo exercitar. Uma recusa de classificador num PDF de treino é praticamente impossível, e agora ela fica visível no log. Se quiser, adiciono em PR próprio.

## Impacto em segurança

Nenhum. A `ANTHROPIC_API_KEY` continua sendo variável de servidor, e a fronteira de responsabilidade não muda: a função só parseia, quem grava em `workout_templates` segue sendo o cliente autenticado via `workoutService.createTemplate`, sob as `firestore.rules`.

## Impacto em Firestore/rules/indexes

Nenhum. Regras intocadas; suíte rodada mesmo assim, 12 cenários passando. O formato da resposta (`{ workouts: [...] }`, `groupedWithPrevious`) não mudou, então a decomposição de bi-set e a fila de revisão continuam iguais.

## Impacto visual

Nenhum. Server-only.

## Checklist

- [x] Rodei `npm run lint`
- [x] Rodei `npm test -- --run`
- [x] Rodei `npm run test:rules` — 12 cenários no emulador
- [x] Rodei `npm run build`
- [ ] Revisei regras do Firestore — não aplicável, nada tocado
- [ ] Atualizei documentação — o custo por PDF no `MANUAL_TECNICO` só deve ser atualizado com medição real, depois das primeiras importações

🤖 Generated with [Claude Code](https://claude.com/claude-code)
