### PR TITLE
fix: filtro por grupo muscular só achava exercícios de peito e ombro

### DIFF
--- a/src/components/execution/ExerciseCard.jsx
+++ b/src/components/execution/ExerciseCard.jsx
@@ -37,7 +37,7 @@ export function ExerciseCard({ exercise: ex, activeSetIndices, progression, hand
             exerciseId={ex.id}
             setId={activeSet.id}
             exerciseName={ex.name}
-            muscleGroup={ex.muscleFocus?.primary || ex.group || 'Geral'}
+            muscleGroup={ex.muscleGroup || ex.muscleFocus?.primary || ex.group || 'Geral'}
             method={ex.method || "Convencional"}
             repsGoal={repsGoal}
             currentSet={safeIdx + 1}

--- a/src/data/muscleGroups.js
+++ b/src/data/muscleGroups.js
@@ -1,0 +1,69 @@
+/**
+ * muscleGroups.js
+ * Fonte única dos 10 grupos musculares do app e da tradução entre eles e o
+ * vocabulário gravado no catálogo global (`exercises_catalog`).
+ *
+ * Por que a tradução existe: o catálogo foi populado por
+ * `scripts/import_exercises.js`, que grava `primaryMuscles[0]` do dataset pt-BR
+ * de origem apenas capitalizado — sem acento ("Biceps"), no plural
+ * ("Panturrilhas") e com a divisão anatômica original ("Dorsais",
+ * "Isquiotibiais", "Meio-das-costas"). Os rótulos desta tela seguem outra
+ * convenção, então a busca por igualdade exata só acertava "Peito" e "Ombros":
+ * os outros oito grupos vinham sempre vazios.
+ *
+ * A coleção é somente-leitura pelas regras (`allow write: if false` em
+ * firestore.rules), então a tradução mora aqui, no cliente, em vez de depender
+ * de uma reimportação do catálogo com credencial de admin.
+ */
+
+export const MUSCLE_GROUPS = [
+    'Peito', 'Costas', 'Ombros', 'Bíceps', 'Tríceps',
+    'Quadríceps', 'Posteriores', 'Glúteos', 'Panturrilha', 'Abdômen'
+];
+
+/**
+ * Rótulo da tela → valores que o campo `muscleGroup` pode ter no catálogo.
+ * O próprio rótulo entra na lista de propósito: cobre exercícios salvos pelo
+ * app e mantém tudo funcionando se um dia o catálogo for reimportado já
+ * normalizado. O maior conjunto tem 5 valores, bem abaixo do limite de 30
+ * disjunções do operador `in` do Firestore.
+ */
+export const CATALOG_ALIASES = {
+    'Peito': ['Peito'],
+    'Costas': ['Costas', 'Dorsais', 'Meio-das-costas', 'Inferior-das-costas', 'Trapezio'],
+    'Ombros': ['Ombros'],
+    'Bíceps': ['Bíceps', 'Biceps'],
+    'Tríceps': ['Tríceps', 'Triceps'],
+    'Quadríceps': ['Quadríceps', 'Quadriceps'],
+    'Posteriores': ['Posteriores', 'Isquiotibiais'],
+    'Glúteos': ['Glúteos', 'Gluteos'],
+    'Panturrilha': ['Panturrilha', 'Panturrilhas'],
+    'Abdômen': ['Abdômen', 'Abdominais']
+};
+
+/**
+ * Valores a consultar no catálogo para um rótulo da tela.
+ * @param {string} label
+ * @returns {string[]}
+ */
+export function catalogValuesFor(label) {
+    return CATALOG_ALIASES[label] || [label];
+}
+
+// Índice inverso, montado uma vez: valor do catálogo (minúsculo) → rótulo.
+const CANONICAL_BY_VALUE = new Map();
+for (const [label, values] of Object.entries(CATALOG_ALIASES)) {
+    for (const value of values) {
+        CANONICAL_BY_VALUE.set(value.toLowerCase(), label);
+    }
+}
+
+/**
+ * Caminho inverso: 'Isquiotibiais' → 'Posteriores', 'peito' → 'Peito'.
+ * @param {string} value
+ * @returns {string|null} `null` para valor desconhecido — quem chama decide o fallback.
+ */
+export function toCanonicalMuscleGroup(value) {
+    if (!value || typeof value !== 'string') return null;
+    return CANONICAL_BY_VALUE.get(value.trim().toLowerCase()) || null;
+}

--- a/src/data/muscleGroups.test.js
+++ b/src/data/muscleGroups.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { MUSCLE_GROUPS, CATALOG_ALIASES, catalogValuesFor, toCanonicalMuscleGroup } from './muscleGroups';
+
+describe('muscleGroups', () => {
+    it('tem alias para todos os 10 grupos da tela', () => {
+        expect(MUSCLE_GROUPS).toHaveLength(10);
+        MUSCLE_GROUPS.forEach(group => {
+            expect(CATALOG_ALIASES[group], `sem alias para ${group}`).toBeDefined();
+            expect(CATALOG_ALIASES[group].length).toBeGreaterThan(0);
+        });
+    });
+
+    it('inclui o próprio rótulo nos aliases, para o dia de uma reimportação normalizada', () => {
+        MUSCLE_GROUPS.forEach(group => {
+            expect(catalogValuesFor(group)).toContain(group);
+        });
+    });
+
+    it('respeita o limite de 30 disjunções do operador `in` do Firestore', () => {
+        MUSCLE_GROUPS.forEach(group => {
+            expect(catalogValuesFor(group).length).toBeLessThanOrEqual(30);
+        });
+    });
+
+    it('traduz "Costas" para a divisão anatômica usada no catálogo', () => {
+        const values = catalogValuesFor('Costas');
+        expect(values).toEqual(expect.arrayContaining([
+            'Dorsais', 'Meio-das-costas', 'Inferior-das-costas', 'Trapezio'
+        ]));
+    });
+
+    it('cobre as variações sem acento e no plural do catálogo', () => {
+        expect(catalogValuesFor('Bíceps')).toContain('Biceps');
+        expect(catalogValuesFor('Tríceps')).toContain('Triceps');
+        expect(catalogValuesFor('Quadríceps')).toContain('Quadriceps');
+        expect(catalogValuesFor('Glúteos')).toContain('Gluteos');
+        expect(catalogValuesFor('Panturrilha')).toContain('Panturrilhas');
+        expect(catalogValuesFor('Abdômen')).toContain('Abdominais');
+        expect(catalogValuesFor('Posteriores')).toContain('Isquiotibiais');
+    });
+
+    it('usa o próprio rótulo como fallback para grupo desconhecido', () => {
+        expect(catalogValuesFor('Antebraço')).toEqual(['Antebraço']);
+    });
+
+    describe('toCanonicalMuscleGroup', () => {
+        it('traduz o vocabulário do catálogo para o rótulo da tela', () => {
+            expect(toCanonicalMuscleGroup('Isquiotibiais')).toBe('Posteriores');
+            expect(toCanonicalMuscleGroup('Meio-das-costas')).toBe('Costas');
+            expect(toCanonicalMuscleGroup('Abdominais')).toBe('Abdômen');
+            expect(toCanonicalMuscleGroup('Gluteos')).toBe('Glúteos');
+        });
+
+        it('ignora caixa e espaços em volta', () => {
+            expect(toCanonicalMuscleGroup('peito')).toBe('Peito');
+            expect(toCanonicalMuscleGroup('  BICEPS  ')).toBe('Bíceps');
+        });
+
+        it('devolve null para valor desconhecido ou vazio', () => {
+            expect(toCanonicalMuscleGroup('Antebracos')).toBeNull();
+            expect(toCanonicalMuscleGroup('')).toBeNull();
+            expect(toCanonicalMuscleGroup(undefined)).toBeNull();
+            expect(toCanonicalMuscleGroup(null)).toBeNull();
+        });
+
+        it('é idempotente para rótulos que já são canônicos', () => {
+            MUSCLE_GROUPS.forEach(group => {
+                expect(toCanonicalMuscleGroup(group)).toBe(group);
+            });
+        });
+    });
+});

--- a/src/pages/CreateWorkoutPage.jsx
+++ b/src/pages/CreateWorkoutPage.jsx
@@ -12,11 +12,7 @@ import { EmptyState } from '../components/design-system/EmptyState';
 import { PageHeader } from '../components/design-system/PageHeader';
 import { notify } from '../utils/notifyStore';
 import { Reorder, useDragControls } from 'framer-motion';
-
-const muscleGroups = [
-    'Peito', 'Costas', 'Ombros', 'Bíceps', 'Tríceps',
-    'Quadríceps', 'Posteriores', 'Glúteos', 'Panturrilha', 'Abdômen'
-];
+import { MUSCLE_GROUPS, toCanonicalMuscleGroup } from '../data/muscleGroups';
 
 const methods = [
     'Convencional', 'Drop-set', 'Pirâmide Crescente', 'Pirâmide Decrescente',
@@ -250,7 +246,9 @@ export default function CreateWorkoutPage({ user }) {
         setNewExercise(prev => ({
             ...prev,
             name: suggestion.name,
-            muscleGroup: suggestion.muscleGroup || prev.muscleGroup || 'Geral', // Auto-preencher músculo se ausente
+            // O catálogo devolve o vocabulário dele ("Isquiotibiais"); a ficha
+            // guarda sempre o rótulo da tela ("Posteriores").
+            muscleGroup: toCanonicalMuscleGroup(suggestion.muscleGroup) || prev.muscleGroup || 'Geral',
             // Poderia também auto-preencher instruções/notas se quiséssemos
         }));
         setSuggestions([]); // Limpar sugestões
@@ -300,9 +298,9 @@ export default function CreateWorkoutPage({ user }) {
 
         let mappedMuscle = exerciseToEdit.muscleGroup || exerciseToEdit.group || exerciseToEdit.muscleFocus?.primary || '';
 
-        // Tentar corresponder maiúsculas/minúsculas com muscleGroups
-        const exactMatch = muscleGroups.find(m => m.toLowerCase() === mappedMuscle.toLowerCase());
-        if (exactMatch) mappedMuscle = exactMatch;
+        // Normaliza caixa/acento e traduz valor de catálogo salvo em ficha antiga
+        // ("Meio-das-costas" → "Costas"), para o <select> vir pré-selecionado.
+        mappedMuscle = toCanonicalMuscleGroup(mappedMuscle) || mappedMuscle;
 
         setNewExercise({
             muscleGroup: mappedMuscle,
@@ -554,7 +552,7 @@ export default function CreateWorkoutPage({ user }) {
                                     className="w-full rounded-xl border border-slate-600 bg-slate-800/50 text-white px-4 py-3 text-sm outline-none focus:border-cyan-500 focus:ring-1 focus:ring-cyan-500/50 transition-all appearance-none"
                                 >
                                     <option value="">Todos (Global)</option>
-                                    {muscleGroups.map(g => <option key={g} value={g}>{g}</option>)}
+                                    {MUSCLE_GROUPS.map(g => <option key={g} value={g}>{g}</option>)}
                                 </select>
                             </label>
 
@@ -590,7 +588,7 @@ export default function CreateWorkoutPage({ user }) {
                                             >
                                                 <div className="text-white font-medium text-sm">{s.name}</div>
                                                 <div className="text-[10px] text-cyan-400 flex gap-2">
-                                                    <span>{s.muscleGroup}</span>
+                                                    <span>{toCanonicalMuscleGroup(s.muscleGroup) || s.muscleGroup}</span>
                                                     {s.equipment && <span className="opacity-50">• {s.equipment}</span>}
                                                 </div>
                                             </div>
@@ -683,15 +681,7 @@ export default function CreateWorkoutPage({ user }) {
                                     onClick={() => {
                                         setShowAddExercise(false);
                                         setEditingExerciseId(null);
-                                        setNewExercise({
-                                            muscleGroup: '',
-                                            name: '',
-                                            sets: '3',
-                                            reps: '12',
-                                            method: 'Convencional',
-                                            rest: '',
-                                            notes: ''
-                                        });
+                                        setNewExercise({ ...EMPTY_EXERCISE });
                                     }}
                                     variant="secondary"
                                     fullWidth

--- a/src/pages/CreateWorkoutPage.test.jsx
+++ b/src/pages/CreateWorkoutPage.test.jsx
@@ -244,4 +244,56 @@ describe('CreateWorkoutPage Integration', () => {
         expect(await screen.findByDisplayValue('Loaded Workout')).toBeInTheDocument();
         expect(await screen.findByText(/Agachamento/i)).toBeInTheDocument();
     });
+
+    it('salva o rótulo da tela quando a sugestão vem com o vocabulário do catálogo', async () => {
+        const { workoutService } = await import('../services/workoutService');
+        workoutService.searchExercises.mockResolvedValue([
+            { id: 'cat-1', name: 'Mesa Flexora', muscleGroup: 'Isquiotibiais' }
+        ]);
+
+        try {
+            render(
+                <MemoryRouter>
+                    <CreateWorkoutPage user={mockUser} />
+                </MemoryRouter>
+            );
+
+            fireEvent.change(screen.getByPlaceholderText(/Ex: Treino A/i), {
+                target: { value: 'Treino B' }
+            });
+
+            fireEvent.click(screen.getByText('Adicionar Exercício'));
+            fireEvent.change(screen.getByPlaceholderText('Digite para buscar...'), {
+                target: { value: 'mesa' }
+            });
+
+            // A sugestão é exibida com o rótulo da tela, não com "Isquiotibiais".
+            const suggestion = await screen.findByText('Mesa Flexora', undefined, { timeout: 2000 });
+            // "Posteriores" também é uma <option> do filtro, então olhamos a
+            // própria linha da sugestão em vez do documento inteiro.
+            expect(suggestion.parentElement).toHaveTextContent('Posteriores');
+            expect(screen.queryByText('Isquiotibiais')).not.toBeInTheDocument();
+
+            fireEvent.click(suggestion);
+            fireEvent.click(screen.getByText('Adicionar'));
+
+            await waitFor(() => {
+                expect(screen.queryByText('Novo Exercício')).not.toBeInTheDocument();
+            });
+
+            fireEvent.click(screen.getByText('Salvar Treino'));
+
+            await waitFor(() => {
+                expect(workoutService.createTemplate).toHaveBeenCalledTimes(1);
+            });
+
+            const [payload] = workoutService.createTemplate.mock.calls[0];
+            expect(payload.exercises[0]).toMatchObject({
+                name: 'Mesa Flexora',
+                muscleGroup: 'Posteriores'
+            });
+        } finally {
+            workoutService.searchExercises.mockResolvedValue([]);
+        }
+    });
 });

--- a/src/pages/WorkoutsPage.jsx
+++ b/src/pages/WorkoutsPage.jsx
@@ -604,9 +604,9 @@ export default function WorkoutsPage({ onNavigateToCreate, onNavigateToWorkout, 
                                                         <ExerciseCard
                                                             key={i}
                                                             name={exercise.name}
-                                                            muscleGroup={exercise.group || 'Geral'}
-                                                            sets={exercise.target ? exercise.target.split('x')[0] : '?'}
-                                                            lastReps={exercise.target || '-'}
+                                                            muscleGroup={exercise.muscleGroup || exercise.group || 'Geral'}
+                                                            sets={exercise.sets || (exercise.target ? exercise.target.split('x')[0] : '?')}
+                                                            lastReps={exercise.reps || exercise.target || '-'}
                                                             lastWeight={null} // We don't have weight in template, only in history
                                                             onPress={() => setEditingExercise({ workoutId: workout.id, index: i, data: exercise })}
                                                         />

--- a/src/services/workoutService.js
+++ b/src/services/workoutService.js
@@ -1,4 +1,5 @@
 import { getFirestoreDeps } from '../firebaseDb';
+import { catalogValuesFor } from '../data/muscleGroups';
 import { sortWorkoutTemplates } from '../utils/workoutTemplateOrder';
 import { notify } from '../utils/notifyStore';
 
@@ -18,6 +19,14 @@ let templatesCache = {
     timestamp: 0
 };
 const CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
+
+// Catálogo global por grupo muscular. Sem expiração de propósito:
+// `exercises_catalog` é somente-leitura pelas regras, então o conteúdo não muda
+// durante a sessão. Evita reler 100 documentos a cada troca do filtro — e agora
+// que os 10 grupos retornam resultado, a troca acontece muito mais.
+// Não é limpo por `clearCache()`: não tem relação com o usuário logado.
+const catalogByMuscleCache = new Map();
+const CATALOG_GROUP_FETCH_LIMIT = 100;
 
 function mapSessionDoc(doc) {
     return { id: doc.id, ...doc.data() };
@@ -449,32 +458,45 @@ export const workoutService = {
         try {
             const { db, collection, query, where, limit, getDocs } = await getFirestoreDeps();
             const catalogRef = collection(db, 'exercises_catalog');
-            let constraints = [];
             const term = searchTerm ? searchTerm.toLowerCase().trim() : '';
 
             // ESTRATÉGIA:
-            // 1. Se Filtro Muscular ON: Query por Grupo Muscular (Igualdade) -> Filtro por Nome client-side.
+            // 1. Se Filtro Muscular ON: Query por Grupo Muscular -> Filtro por Nome client-side.
             //    Razão: Evita necessidade de Índice Composto (Músculo + ChaveBusca) que quebra se ausente.
             // 2. Se Filtro Muscular OFF: Query por ChaveBusca (Range) -> Busca prefixo padrão.
 
-            if (muscleFilter) {
-                constraints.push(where('muscleGroup', '==', muscleFilter));
-                // fetch more to allow for filtering
-                constraints.push(limit(100)); // Reasonable limit for a single muscle group
-            } else if (term) {
-                // Busca Global (Prefixo)
-                constraints.push(where('searchKey', '>=', term));
-                constraints.push(where('searchKey', '<=', term + '\uf8ff'));
-                constraints.push(limit(limitCount));
-            } else {
-                // Sem filtro, sem termo? Apenas retornar alguns aleatórios ou vazio?
-                // Retornar vazio é mais seguro para evitar leituras enormes, mas se limite for pequeno ok.
-                constraints.push(limit(limitCount));
-            }
+            let results;
 
-            const q = query(catalogRef, ...constraints);
-            const snap = await getDocs(q);
-            let results = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+            if (muscleFilter) {
+                // O catálogo grava o vocabulário do dataset de origem ("Isquiotibiais",
+                // "Meio-das-costas", "Biceps"), não o rótulo desta tela. Comparar por
+                // igualdade só acertava "Peito" e "Ombros"; daí o `in` com os aliases.
+                // Ver src/data/muscleGroups.js.
+                results = catalogByMuscleCache.get(muscleFilter);
+                if (!results) {
+                    const q = query(
+                        catalogRef,
+                        where('muscleGroup', 'in', catalogValuesFor(muscleFilter)),
+                        limit(CATALOG_GROUP_FETCH_LIMIT)
+                    );
+                    const snap = await getDocs(q);
+                    results = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+                    catalogByMuscleCache.set(muscleFilter, results);
+                }
+            } else {
+                const constraints = term
+                    // Busca Global (Prefixo)
+                    ? [
+                        where('searchKey', '>=', term),
+                        where('searchKey', '<=', term + '\uf8ff'),
+                        limit(limitCount)
+                    ]
+                    // Sem filtro e sem termo: devolve só alguns, para não varrer o catálogo.
+                    : [limit(limitCount)];
+
+                const snap = await getDocs(query(catalogRef, ...constraints));
+                results = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+            }
 
             // Filtragem no cliente se usamos estratégia de filtro muscular com um termo
             if (muscleFilter && term) {

--- a/src/services/workoutService.test.js
+++ b/src/services/workoutService.test.js
@@ -419,4 +419,90 @@ describe('workoutService', () => {
             ]);
         });
     });
+
+    describe('searchExercises', () => {
+        // O cache do catálogo é de módulo e não expira (a coleção é somente-leitura),
+        // então cada caso usa um grupo diferente para não herdar o anterior.
+        const docsOf = (items) => ({
+            docs: items.map(({ id, ...data }) => ({ id, data: () => data }))
+        });
+
+        it('consulta os aliases do catálogo, e não o rótulo da tela', async () => {
+            getDocs.mockResolvedValue(docsOf([
+                { id: 'c1', name: 'Remada Curvada', muscleGroup: 'Meio-das-costas' }
+            ]));
+
+            const results = await workoutService.searchExercises('', 'Costas');
+
+            // "Costas" não existe no catálogo: os exercícios estão sob Dorsais,
+            // Meio-das-costas, Inferior-das-costas e Trapezio.
+            expect(where).toHaveBeenCalledWith(
+                'muscleGroup',
+                'in',
+                expect.arrayContaining(['Costas', 'Dorsais', 'Meio-das-costas', 'Inferior-das-costas', 'Trapezio'])
+            );
+            expect(where).not.toHaveBeenCalledWith('muscleGroup', '==', 'Costas');
+            expect(results).toEqual([
+                { id: 'c1', name: 'Remada Curvada', muscleGroup: 'Meio-das-costas' }
+            ]);
+        });
+
+        it('mantém a busca global por prefixo quando não há grupo selecionado', async () => {
+            getDocs.mockResolvedValue(docsOf([
+                { id: 'c2', name: 'Supino Reto', searchKey: 'supino reto' }
+            ]));
+
+            const results = await workoutService.searchExercises('Supino', null, 15);
+
+            expect(where).toHaveBeenCalledWith('searchKey', '>=', 'supino');
+            expect(where).toHaveBeenCalledWith('searchKey', '<=', 'supino\uf8ff');
+            expect(limit).toHaveBeenCalledWith(15);
+            expect(results).toHaveLength(1);
+        });
+
+        it('reaproveita o cache na segunda busca do mesmo grupo', async () => {
+            getDocs.mockResolvedValue(docsOf([
+                { id: 'c3', name: 'Elevação Pélvica', muscleGroup: 'Gluteos' }
+            ]));
+
+            const first = await workoutService.searchExercises('', 'Glúteos');
+            const second = await workoutService.searchExercises('', 'Glúteos');
+
+            expect(getDocs).toHaveBeenCalledTimes(1);
+            expect(second).toEqual(first);
+        });
+
+        it('filtra por nome no cliente sem corromper o cache do grupo', async () => {
+            getDocs.mockResolvedValue(docsOf([
+                { id: 'c4', name: 'Panturrilha em Pé', muscleGroup: 'Panturrilhas' },
+                { id: 'c5', name: 'Panturrilha Sentado', muscleGroup: 'Panturrilhas' }
+            ]));
+
+            const todos = await workoutService.searchExercises('', 'Panturrilha');
+            expect(todos).toHaveLength(2);
+
+            const filtrados = await workoutService.searchExercises('sentado', 'Panturrilha');
+            expect(filtrados).toHaveLength(1);
+            expect(filtrados[0].id).toBe('c5');
+
+            // A filtragem não pode ter encolhido o que ficou guardado.
+            const dnovo = await workoutService.searchExercises('', 'Panturrilha');
+            expect(dnovo).toHaveLength(2);
+            expect(getDocs).toHaveBeenCalledTimes(1);
+        });
+
+        it('devolve lista vazia e avisa o usuário quando a query falha', async () => {
+            const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+            getDocs.mockRejectedValue(new Error('offline'));
+
+            try {
+                const results = await workoutService.searchExercises('', 'Abdômen');
+
+                expect(results).toEqual([]);
+                expect(notify.error).toHaveBeenCalledWith('Erro ao buscar exercícios. Verifique sua conexão.');
+            } finally {
+                consoleSpy.mockRestore();
+            }
+        });
+    });
 });


### PR DESCRIPTION
## O problema

Ao cadastrar um treino, escolher um grupo muscular no modal de exercício não abria o menu de sugestões — em 8 dos 10 grupos. Dava a impressão de que o catálogo só tinha exercícios de peitoral.

Não tinha nada de errado com o banco. O filtro usava igualdade exata:

```js
where('muscleGroup', '==', muscleFilter)
```

Mas o valor gravado em `exercises_catalog` não é o rótulo da tela. Ele vem de `primaryMuscles[0]` do dataset pt-BR, apenas capitalizado por `scripts/import_exercises.js` — sem acento, no plural e com a divisão anatômica de origem. Só "Peito" e "Ombros" coincidiam por acaso.

Conferido contra o Firestore de produção:

| Opção da tela | O que o Firestore devolve | Antes |
|---|---|---|
| Peito | `Peito` (84) | ✅ |
| Ombros | `Ombros` (127) | ✅ |
| Costas | `Dorsais`, `Meio-das-costas`, `Inferior-das-costas`, `Trapezio` (114) | ❌ 0 |
| Bíceps / Tríceps / Quadríceps / Glúteos | `Biceps`, `Triceps`, `Quadriceps`, `Gluteos` | ❌ 0 |
| Posteriores | `Isquiotibiais` (79) | ❌ 0 |
| Panturrilha | `Panturrilhas` (28) | ❌ 0 |
| Abdômen | `Abdominais` (93) | ❌ 0 |

Os 873 exercícios sempre estiveram no catálogo, e a busca por nome — que usa `searchKey`, outro caminho — nunca foi afetada.

## A correção

`exercises_catalog` é somente-leitura pelas regras (`allow write: if false`), então reimportar exigiria credencial de admin e escrita direta em produção. A tradução fica no cliente:

- **`src/data/muscleGroups.js`** (novo) — fonte única dos 10 grupos e dos aliases do catálogo. A consulta passa a usar `in` com eles. Cada lista inclui o próprio rótulo canônico, então uma eventual reimportação normalizada continua funcionando sem alterar código.
- **Cache de módulo por grupo**, sem expiração — a coleção é imutável pelas regras. Agora que os 10 grupos respondem, a troca de filtro leria 100 documentos toda vez. Medido em produção: **596ms na primeira leitura, 1ms nas seguintes**.
- **Vocabulário canônico na ficha** — escolher uma sugestão gravava o valor cru do catálogo (`Isquiotibiais`). Agora grava `Posteriores`. A edição também traduz fichas antigas, que voltavam com o `<select>` em "Todos (Global)".

Sem mudança em `firestore.rules` (nenhum campo de topo novo) nem em `firestore.indexes.json` (`in` de campo único usa o índice automático).

## De quebra: dois campos legados que ninguém escreve

`ex.muscleFocus?.primary` e `ex.group` eram lidos no card da execução e no da lista de treinos, mas não são escritos em lugar nenhum do app — quem a ficha salva é `muscleGroup`. Os dois mostravam "Geral" sempre. Os campos antigos ficam como fallback.

## Verificação

- `npm run lint` — 0 erros (11 warnings, idênticos à `main`)
- `npm test -- --run` — 53 arquivos, 472 testes (16 novos)
- `npm --prefix functions test` — 12 testes
- `npm run build` — ✓
- Reprodução no emulador com as regras reais, semeado com os 873 exercícios: os 10 grupos respondem em menos de 45ms.
- **Contra o Firestore de produção, autenticado**, pela UI: os 10 grupos abrem o menu (84, 100, 100, 53, 71, 100, 79, 22, 28, 93 linhas), todos exibindo o rótulo da tela, nenhum spinner preso. Escolher "Remada Renegada Alternada" (catálogo: `Meio-das-costas`) grava `Costas` na ficha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)