### PR TITLE
fix: chip "Todos" encostava na borda do cartão de filtros

### DIFF
--- a/src/components/workout/SourceFilterChips.jsx
+++ b/src/components/workout/SourceFilterChips.jsx
@@ -9,6 +9,11 @@ import { SOURCE_FILTERS } from '../../utils/workoutSourceFilter';
  * um degradê na borda direita avisa que ainda há filtro fora da tela; sem ele
  * "Arquivados" simplesmente não existiria para quem não tentasse arrastar.
  *
+ * O `scroll-px-4` acompanha o `px-4` e não é redundante: sem ele o `snap-start`
+ * alinha o primeiro chip com o início da área de rolagem, o navegador rola os
+ * 16px do padding para compensar e "Todos" encosta na borda do cartão. Com ele
+ * a faixa para em zero e os chips ficam na mesma coluna da lupa da busca.
+ *
  * O contador é decorativo (`aria-hidden`): a lista logo abaixo já é a resposta
  * para leitores de tela, e mantê-lo fora do nome acessível deixa cada chip
  * anunciado só pelo próprio rótulo.
@@ -35,7 +40,7 @@ export function SourceFilterChips({ value, counts, onChange }) {
             <div
                 ref={stripRef}
                 onScroll={syncFade}
-                className="no-scrollbar flex snap-x gap-1.5 overflow-x-auto px-3 py-2.5"
+                className="no-scrollbar flex snap-x scroll-px-4 gap-1.5 overflow-x-auto px-4 py-2.5"
             >
                 {SOURCE_FILTERS.map(({ id, label }) => {
                     const isActive = value === id;


### PR DESCRIPTION
## O problema

No iPhone, o chip "Todos" fica a **1px** da borda do cartão de filtros — parece defeito de alinhamento.

Não é o padding que está faltando. A faixa já tem `px-3`, mas também `snap-x` com `snap-start` em cada chip. O `snap-start` alinha a borda do primeiro chip com o início da área de rolagem, **ignorando o padding** — então o navegador rola a faixa exatamente 12px para satisfazer o snap, anulando o espaço.

Confirmado por medição no navegador, em viewport de iPhone:

| Estado | `scrollLeft` | Chip até a borda |
|---|---|---|
| Como estava | 12 | 1px |
| Forçando `scrollLeft = 0` | volta para 12 | 1px — o snap desfaz |
| Com `scroll-padding` | 0 | 17px |

O terceiro caso é o diagnóstico: o snap devolve a rolagem enquanto não souber do padding.

## A correção

Duas classes:

- **`scroll-px-4`** — ensina o snap a respeitar o padding, em vez de anulá-lo.
- **`px-3` → `px-4`** — põe os chips a 17px da borda, que é exatamente onde está a lupa da busca logo acima. As duas linhas passam a compartilhar a mesma coluna.

## Resultado, medido

| Medida | Antes | Depois |
|---|---|---|
| `scrollLeft` de repouso | 12 | **0** |
| Chip "Todos" até a borda | 1px | **17px** |
| Lupa da busca até a borda | 17px | 17px |
| "Arquivados" no fim da rolagem | colado | **17,3px** |

Folga simétrica nas duas pontas. Rolagem horizontal e degradê da borda direita seguem idênticos — só o ponto de parada mudou.

O porquê do `scroll-px-4` ficou registrado no comentário do componente: sem essa nota é fácil olhar, achar que duplica o `px-4` e remover, trazendo o bug de volta em silêncio.

## Verificação

- `npm run lint` — 0 erros (11 warnings, os mesmos da `main`)
- `npm test -- --run` — 53 arquivos, 472 testes
- `npm run build` — ✓
- Medido no navegador antes e depois, em viewport de iPhone (375x812). Sem teste automatizado: asserção de classe CSS quebraria ao primeiro ajuste de estilo e não provaria alinhamento.

🤖 Generated with [Claude Code](https://claude.com/claude-code)