### PR TITLE
fix: qualquer autenticado conseguia enumerar os convites de personal

### DIFF
--- a/docs/firestore-model.md
+++ b/docs/firestore-model.md
@@ -111,7 +111,9 @@ Escrita:
 
 ## `trainer_invites/{inviteId}`
 
-Convites revogáveis, expiráveis e de uso único.
+Convites revogáveis, expiráveis e de uso único. **O `inviteId` é o próprio código de
+8 caracteres** (alfabeto `ABCDEFGHJKLMNPQRSTUVWXYZ23456789`), e o campo `code`
+repete esse valor — as rules exigem `code == inviteId` na criação.
 
 Campos:
 
@@ -125,9 +127,10 @@ Campos:
 
 Regras principais:
 
-- Personal cria convite para si mesmo.
+- Personal cria convite para si mesmo, com o código como ID do documento.
 - Personal pode revogar convite ativo.
-- Aluno autenticado pode ler convite ativo e não expirado.
+- Aluno autenticado pode ler (`get`) convite ativo e não expirado — resgatar exige conhecer o código.
+- Só o personal dono pode listar (`list`) a coleção; ver "Por que `get` e `list` são separados" em [security-rules.md](security-rules.md).
 - Ao aceitar, o aluno cria `trainer_students` e atualiza o convite para `expired` no mesmo batch.
 
 ## `user_stats/{userId}`

--- a/docs/security-rules.md
+++ b/docs/security-rules.md
@@ -24,10 +24,50 @@ O fluxo de convite agora usa `trainer_invites` com código revogável, expiraç�
 ## Convites Aluno-Personal
 
 - O personal cria um convite ativo em `trainer_invites`.
+- **O código de 8 caracteres é o próprio ID do documento**, e as rules exigem `code == inviteId` na criação.
 - O aluno informa o código no perfil.
-- O app busca um convite `active` não expirado.
+- O app resgata o convite com `getDoc(trainer_invites/CODIGO)` — nunca por consulta.
 - O aceite cria `trainer_students/{studentId_trainerId}` e atualiza o convite para `expired` com `usedBy` e `usedAt` no mesmo batch.
 - As rules bloqueiam criação de vínculo sem convite consumido no mesmo batch.
+
+### Por que `get` e `list` são separados
+
+`allow read` cobre `get` e `list` de uma vez, e isso era um vazamento: o motor de
+rules libera um `list` quando **os filtros da consulta**, sozinhos, provam a
+condição da regra — ele não checa documento por documento. Com a regra antiga, a
+consulta abaixo era liberada para qualquer autenticado, sem filtrar por `code`, e
+devolvia todos os convites ativos com `code` e `trainerId`:
+
+```js
+query(collection(db, 'trainer_invites'),
+      where('status', '==', 'active'),
+      where('expiresAt', '>', umInstanteAdianteDoRelogioDoServidor))
+```
+
+Os dois filtros provam `resource.data.status == 'active' && resource.data.expiresAt
+> request.time`, então a regra vale para qualquer resultado possível. De posse dos
+códigos, um autenticado qualquer queimava o convite de outro aluno (o aceite grava
+`status: 'expired'` e `usedBy`) e criava vínculo espúrio com o personal.
+
+Hoje as duas operações são separadas:
+
+- `allow get`: dono, ou convite ativo e não expirado, ou quem já usou. Resgatar exige
+  **conhecer o código**, que é o ID — 32⁸ ≈ 1,1 × 10¹² combinações.
+- `allow list`: só `resource.data.trainerId == request.auth.uid`. Toda consulta à
+  coleção precisa filtrar por `trainerId`, o que cobre `getActiveTrainerInvite`,
+  `createTrainerInvite` e a exportação LGPD.
+
+Cenário de regressão: `bloqueia enumeracao de convites ativos por quem nao e o dono`
+em `tests/security/firestore.rules.test.js`. Ele usa um limite de `expiresAt`
+deliberadamente à frente do relógio do servidor — com `Timestamp.now()` do cliente o
+`list` pode ser negado por acaso e o teste passa sem provar nada.
+
+### Convites criados antes da mudança
+
+Convites antigos têm ID automático e não podem mais ser resgatados. Não há migração:
+o TTL é de 7 dias e cada personal tem no máximo um convite ativo. `getActiveTrainerInvite`
+ignora convite cujo `code` não bate com o ID do documento, então `ensureActiveTrainerInvite`
+emite um substituto e revoga o antigo na primeira vez que o personal abre o painel.
 
 ## Checklist ao Alterar Rules
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -34,3 +34,5 @@ Cenários prioritários:
 - Usuário não cria vínculo `trainer_students` em nome de outro aluno.
 - Aluno só cria vínculo se consumir convite ativo no mesmo batch.
 - Convites expirados ou revogados não podem ser usados.
+- Convite exige `code` igual ao ID do documento na criação.
+- Só o personal dono lista `trainer_invites`; terceiro autenticado não enumera convites ativos.

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -83,24 +83,6 @@
       "queryScope": "COLLECTION",
       "fields": [
         {
-          "fieldPath": "code",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "status",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "expiresAt",
-          "order": "ASCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "trainer_invites",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
           "fieldPath": "trainerId",
           "order": "ASCENDING"
         },

--- a/firestore.rules
+++ b/firestore.rules
@@ -179,11 +179,12 @@ service cloud.firestore {
       ];
     }
 
-    function validInviteCreate() {
+    function validInviteCreate(inviteId) {
       return request.resource.data.keys().hasOnly(inviteCreateFields())
         && request.resource.data.keys().hasAll(['trainerId', 'code', 'status', 'createdAt', 'expiresAt'])
         && request.resource.data.trainerId == request.auth.uid
         && request.resource.data.code is string
+        && request.resource.data.code == inviteId
         && request.resource.data.status == 'active'
         && request.resource.data.expiresAt is timestamp
         && request.resource.data.expiresAt > request.time;
@@ -282,7 +283,11 @@ service cloud.firestore {
     }
 
     match /trainer_invites/{inviteId} {
-      allow read: if signedIn() && (
+      // O codigo do convite e o proprio ID do documento, entao resgatar exige
+      // conhecer o codigo. `list` fica restrito ao dono: sem essa separacao uma
+      // query por status/expiresAt devolveria todos os convites ativos, porque o
+      // motor de rules prova o `list` a partir dos filtros da consulta.
+      allow get: if signedIn() && (
         request.auth.uid == resource.data.trainerId ||
         (
           resource.data.status == 'active' &&
@@ -290,7 +295,8 @@ service cloud.firestore {
         ) ||
         request.auth.uid == resource.data.usedBy
       );
-      allow create: if signedIn() && validInviteCreate();
+      allow list: if signedIn() && resource.data.trainerId == request.auth.uid;
+      allow create: if signedIn() && validInviteCreate(inviteId);
       allow update: if signedIn() && (
         validInviteRevoke() ||
         validInviteAccept(inviteId)

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -3,6 +3,10 @@ import { getFirestoreDeps } from '../firebaseDb';
 const INVITES_COLLECTION = 'trainer_invites';
 const TRAINER_STUDENTS_COLLECTION = 'trainer_students';
 const INVITE_TTL_DAYS = 7;
+// O codigo do convite e o ID do documento, entao precisa ser um ID valido.
+const INVITE_CODE_PATTERN = /^[A-Z0-9]{8}$/;
+// Colisao de codigo cai em `create` negado pelas rules; sorteia outro e tenta de novo.
+const INVITE_CODE_MAX_ATTEMPTS = 3;
 
 function getInviteExpiryDate() {
     return new Date(Date.now() + INVITE_TTL_DAYS * 24 * 60 * 60 * 1000);
@@ -29,6 +33,23 @@ function toDate(value) {
     if (value instanceof Date) return value;
     if (typeof value.toDate === 'function') return value.toDate();
     return new Date(value);
+}
+
+function normalizeInviteCode(rawCode) {
+    const normalized = rawCode?.trim().toUpperCase();
+    return normalized && INVITE_CODE_PATTERN.test(normalized) ? normalized : null;
+}
+
+/**
+ * Convite so vale se estiver ativo, dentro do prazo e com o codigo no ID do
+ * documento. Convites antigos, criados com ID automatico, caem fora daqui.
+ */
+function isRedeemableInvite(docSnap) {
+    const data = docSnap.data();
+    if (!data || docSnap.id !== data.code) return false;
+    if (data.status !== 'active') return false;
+    const expiresAt = toDate(data.expiresAt);
+    return Boolean(expiresAt) && expiresAt.getTime() > Date.now();
 }
 
 function mapInviteDoc(docSnap) {
@@ -90,43 +111,40 @@ export const userService = {
      * @returns {Promise<void>}
      */
     async linkTrainer(studentId, trainerCode) {
-        const normalizedTrainerCode = trainerCode?.trim();
-        if (!normalizedTrainerCode || normalizedTrainerCode === studentId) {
+        const normalizedCode = normalizeInviteCode(trainerCode);
+        if (!normalizedCode || normalizedCode === studentId) {
             throw new Error("PERSONAL_NOT_FOUND");
         }
 
         const {
             db,
-            collection,
-            query,
-            where,
-            limit,
-            getDocs,
             getDoc,
             doc,
             writeBatch,
-            serverTimestamp,
-            Timestamp
+            serverTimestamp
         } = await getFirestoreDeps();
 
-        const normalizedCode = normalizedTrainerCode.toUpperCase();
-        const inviteQuery = query(
-            collection(db, INVITES_COLLECTION),
-            where('code', '==', normalizedCode),
-            where('status', '==', 'active'),
-            where('expiresAt', '>', Timestamp.now()),
-            limit(1)
-        );
-        const inviteSnap = await getDocs(inviteQuery);
-
-        if (inviteSnap.empty) {
+        // Busca por ID, nao por consulta: o codigo e o proprio ID do documento.
+        // Uma consulta aqui obrigaria as rules a liberar `list` da colecao, o que
+        // deixaria qualquer autenticado enumerar os convites ativos de todo mundo.
+        const inviteDoc = doc(db, INVITES_COLLECTION, normalizedCode);
+        let inviteSnap;
+        try {
+            inviteSnap = await getDoc(inviteDoc);
+        } catch (error) {
+            // As rules negam a leitura de convite inexistente, revogado ou expirado.
+            // Falha de rede continua subindo, para nao virar "convite invalido".
+            if (error?.code !== 'permission-denied') throw error;
             throw new Error("PERSONAL_NOT_FOUND");
         }
 
-        const inviteDoc = inviteSnap.docs[0];
-        const invite = inviteDoc.data();
+        if (!inviteSnap.exists() || !isRedeemableInvite(inviteSnap)) {
+            throw new Error("PERSONAL_NOT_FOUND");
+        }
 
-        if (invite.trainerId === studentId) {
+        const invite = inviteSnap.data();
+
+        if (!invite.trainerId || invite.trainerId === studentId) {
             throw new Error("PERSONAL_NOT_FOUND");
         }
 
@@ -144,10 +162,10 @@ export const userService = {
                 trainerId: invite.trainerId,
                 studentId,
                 status: 'active',
-                inviteId: inviteDoc.id,
+                inviteId: normalizedCode,
                 linkedAt: serverTimestamp()
             });
-            batch.update(inviteDoc.ref, {
+            batch.update(inviteDoc, {
                 status: 'expired',
                 usedBy: studentId,
                 usedAt: serverTimestamp()
@@ -165,17 +183,18 @@ export const userService = {
      * @returns {Promise<Object|null>}
      */
     async getActiveTrainerInvite(trainerId) {
-        const { db, collection, query, where, limit, getDocs, Timestamp } = await getFirestoreDeps();
+        const { db, collection, query, where, getDocs, Timestamp } = await getFirestoreDeps();
         const q = query(
             collection(db, INVITES_COLLECTION),
             where('trainerId', '==', trainerId),
             where('status', '==', 'active'),
-            where('expiresAt', '>', Timestamp.now()),
-            limit(1)
+            where('expiresAt', '>', Timestamp.now())
         );
         const snap = await getDocs(q);
-        if (snap.empty) return null;
-        return mapInviteDoc(snap.docs[0]);
+        // Convite antigo, com ID automatico, nao pode mais ser resgatado: ignorar
+        // aqui faz `ensureActiveTrainerInvite` emitir um substituto e revogar o velho.
+        const redeemable = snap.docs.find(isRedeemableInvite);
+        return redeemable ? mapInviteDoc(redeemable) : null;
     },
 
     /**
@@ -184,7 +203,7 @@ export const userService = {
      * @returns {Promise<Object>}
      */
     async createTrainerInvite(trainerId) {
-        const { db, collection, query, where, getDocs, updateDoc, addDoc, serverTimestamp, Timestamp } = await getFirestoreDeps();
+        const { db, collection, query, where, getDocs, updateDoc, setDoc, doc, serverTimestamp, Timestamp } = await getFirestoreDeps();
         const activeInvitesQuery = query(
             collection(db, INVITES_COLLECTION),
             where('trainerId', '==', trainerId),
@@ -197,15 +216,27 @@ export const userService = {
         ));
 
         const expiresAt = Timestamp.fromDate(getInviteExpiryDate());
-        const docRef = await addDoc(collection(db, INVITES_COLLECTION), {
-            trainerId,
-            code: generateInviteCode(),
-            status: 'active',
-            createdAt: serverTimestamp(),
-            expiresAt
-        });
+        let lastError;
 
-        return this.getTrainerInviteById(docRef.id);
+        // O codigo e o ID do documento. Se o sorteio bater num codigo ja usado, a
+        // escrita vira `update` e as rules negam — basta sortear outro.
+        for (let attempt = 0; attempt < INVITE_CODE_MAX_ATTEMPTS; attempt += 1) {
+            const code = generateInviteCode();
+            try {
+                await setDoc(doc(db, INVITES_COLLECTION, code), {
+                    trainerId,
+                    code,
+                    status: 'active',
+                    createdAt: serverTimestamp(),
+                    expiresAt
+                });
+                return this.getTrainerInviteById(code);
+            } catch (error) {
+                lastError = error;
+            }
+        }
+
+        throw lastError;
     },
 
     /**

--- a/src/services/userService.test.js
+++ b/src/services/userService.test.js
@@ -137,9 +137,22 @@ describe('userService', () => {
     });
 
     describe('linkTrainer', () => {
+        const activeInvite = (overrides = {}) => ({
+            exists: () => true,
+            id: 'ABC12345',
+            data: () => ({
+                trainerId: 'trainerCode',
+                code: 'ABC12345',
+                status: 'active',
+                expiresAt: { toDate: () => new Date(Date.now() + 60_000) },
+                ...overrides
+            })
+        });
+
         it('should throw PERSONAL_NOT_FOUND if trainer code is empty', async () => {
             await expect(userService.linkTrainer('studentId', '   '))
                 .rejects.toThrow('PERSONAL_NOT_FOUND');
+            expect(getDoc).not.toHaveBeenCalled();
         });
 
         it('should throw PERSONAL_NOT_FOUND if trainer code is the student id', async () => {
@@ -147,26 +160,43 @@ describe('userService', () => {
                 .rejects.toThrow('PERSONAL_NOT_FOUND');
         });
 
-        it('should create link if valid', async () => {
-            const inviteDoc = {
-                id: 'invite-1',
-                ref: { path: 'trainer_invites/invite-1' },
-                data: () => ({ trainerId: 'trainerCode', code: 'ABC123', status: 'active' })
-            };
-            getDocs.mockResolvedValueOnce({ empty: false, docs: [inviteDoc] });
-            getDoc.mockResolvedValueOnce({ exists: () => false });
+        it('rejeita codigo fora do formato sem tocar no Firestore', async () => {
+            for (const badCode of ['abc', 'ABC1234', 'ABC123456', 'ABC-1234', '../users/x']) {
+                await expect(userService.linkTrainer('studentId', badCode))
+                    .rejects.toThrow('PERSONAL_NOT_FOUND');
+            }
+            expect(getDoc).not.toHaveBeenCalled();
+        });
 
-            await userService.linkTrainer('studentId', ' abc123 ');
+        it('busca o convite pelo ID do documento, nunca por consulta', async () => {
+            getDoc
+                .mockResolvedValueOnce(activeInvite())
+                .mockResolvedValueOnce({ exists: () => false });
+
+            await userService.linkTrainer('studentId', ' abc12345 ');
+
+            expect(getDocs).not.toHaveBeenCalled();
+            expect(doc).toHaveBeenCalledWith(expect.anything(), 'trainer_invites', 'ABC12345');
+        });
+
+        it('should create link if valid', async () => {
+            const inviteRef = { path: 'trainer_invites/ABC12345' };
+            doc.mockReturnValueOnce(inviteRef);
+            getDoc
+                .mockResolvedValueOnce(activeInvite())
+                .mockResolvedValueOnce({ exists: () => false });
+
+            await userService.linkTrainer('studentId', ' abc12345 ');
 
             expect(doc).toHaveBeenCalledWith(expect.anything(), 'trainer_students', 'studentId_trainerCode');
             expect(mockBatch.set).toHaveBeenCalledWith(expect.anything(), {
                 trainerId: 'trainerCode',
                 studentId: 'studentId',
                 status: 'active',
-                inviteId: 'invite-1',
+                inviteId: 'ABC12345',
                 linkedAt: 'ts'
             });
-            expect(mockBatch.update).toHaveBeenCalledWith(inviteDoc.ref, {
+            expect(mockBatch.update).toHaveBeenCalledWith(inviteRef, {
                 status: 'expired',
                 usedBy: 'studentId',
                 usedAt: 'ts'
@@ -175,42 +205,63 @@ describe('userService', () => {
         });
 
         it('should throw PERSONAL_NOT_FOUND if invite does not exist', async () => {
-            getDocs.mockResolvedValueOnce({ empty: true, docs: [] });
+            getDoc.mockResolvedValueOnce({ exists: () => false });
 
-            await expect(userService.linkTrainer('studentId', 'ABC123'))
+            await expect(userService.linkTrainer('studentId', 'ABC12345'))
                 .rejects.toThrow('PERSONAL_NOT_FOUND');
         });
 
-        it('should throw ALREADY_LINKED if link exists', async () => {
-            getDocs.mockResolvedValueOnce({
-                empty: false,
-                docs: [{
-                    id: 'invite-1',
-                    ref: {},
-                    data: () => ({ trainerId: 'trainerCode', code: 'ABC123', status: 'active' })
-                }]
-            });
-            getDoc.mockResolvedValueOnce({ exists: () => true });
+        it('traduz leitura negada pelas rules em PERSONAL_NOT_FOUND', async () => {
+            getDoc.mockRejectedValueOnce(Object.assign(new Error('denied'), { code: 'permission-denied' }));
 
-            await expect(userService.linkTrainer('studentId', 'ABC123'))
+            await expect(userService.linkTrainer('studentId', 'ABC12345'))
+                .rejects.toThrow('PERSONAL_NOT_FOUND');
+        });
+
+        it('deixa falha de rede subir, em vez de virar convite invalido', async () => {
+            getDoc.mockRejectedValueOnce(Object.assign(new Error('offline'), { code: 'unavailable' }));
+
+            await expect(userService.linkTrainer('studentId', 'ABC12345'))
+                .rejects.toThrow('offline');
+        });
+
+        it('recusa convite revogado, expirado ou com codigo fora do ID', async () => {
+            const cases = [
+                activeInvite({ status: 'revoked' }),
+                activeInvite({ expiresAt: { toDate: () => new Date(Date.now() - 60_000) } }),
+                { exists: () => true, id: 'auto-id-legado', data: () => ({
+                    trainerId: 'trainerCode',
+                    code: 'ABC12345',
+                    status: 'active',
+                    expiresAt: { toDate: () => new Date(Date.now() + 60_000) }
+                }) }
+            ];
+
+            for (const snapshot of cases) {
+                getDoc.mockResolvedValueOnce(snapshot);
+                await expect(userService.linkTrainer('studentId', 'ABC12345'))
+                    .rejects.toThrow('PERSONAL_NOT_FOUND');
+            }
+        });
+
+        it('should throw ALREADY_LINKED if link exists', async () => {
+            getDoc
+                .mockResolvedValueOnce(activeInvite())
+                .mockResolvedValueOnce({ exists: () => true });
+
+            await expect(userService.linkTrainer('studentId', 'ABC12345'))
                 .rejects.toThrow('ALREADY_LINKED');
         });
 
         it('maps Firestore failures to LINK_TRAINER_FAILED', async () => {
             const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-            getDocs.mockResolvedValueOnce({
-                empty: false,
-                docs: [{
-                    id: 'invite-1',
-                    ref: {},
-                    data: () => ({ trainerId: 'trainerCode', code: 'ABC123', status: 'active' })
-                }]
-            });
-            getDoc.mockResolvedValueOnce({ exists: () => false });
+            getDoc
+                .mockResolvedValueOnce(activeInvite())
+                .mockResolvedValueOnce({ exists: () => false });
             mockBatch.commit.mockRejectedValueOnce(new Error('permission-denied'));
 
             try {
-                await expect(userService.linkTrainer('studentId', 'trainerCode'))
+                await expect(userService.linkTrainer('studentId', 'ABC12345'))
                     .rejects.toThrow('LINK_TRAINER_FAILED');
             } finally {
                 consoleSpy.mockRestore();
@@ -219,33 +270,48 @@ describe('userService', () => {
     });
 
     describe('trainer invites', () => {
+        const inviteSnapshot = (id, overrides = {}) => ({
+            id,
+            data: () => ({
+                code: id,
+                trainerId: 'trainer-1',
+                status: 'active',
+                expiresAt: { toDate: () => new Date(Date.now() + 60_000) },
+                ...overrides
+            })
+        });
+
         it('returns active invite when found', async () => {
+            getDocs.mockResolvedValueOnce({ docs: [inviteSnapshot('ABC12345')] });
+
+            const result = await userService.getActiveTrainerInvite('trainer-1');
+
+            expect(result).toMatchObject({ id: 'ABC12345', code: 'ABC12345', trainerId: 'trainer-1' });
+            expect(result.expiresAt).toBeInstanceOf(Date);
+        });
+
+        it('ignora convite legado, cujo codigo nao e o ID do documento', async () => {
             getDocs.mockResolvedValueOnce({
-                empty: false,
                 docs: [{
-                    id: 'invite-1',
+                    id: 'auto-id-legado',
                     data: () => ({
-                        code: 'ABC123',
+                        code: 'ABC12345',
                         trainerId: 'trainer-1',
-                        expiresAt: { toDate: () => new Date('2026-01-01') }
+                        status: 'active',
+                        expiresAt: { toDate: () => new Date(Date.now() + 60_000) }
                     })
                 }]
             });
 
-            const result = await userService.getActiveTrainerInvite('trainer-1');
-
-            expect(result).toMatchObject({ id: 'invite-1', code: 'ABC123', trainerId: 'trainer-1' });
-            expect(result.expiresAt).toBeInstanceOf(Date);
+            await expect(userService.getActiveTrainerInvite('trainer-1')).resolves.toBeNull();
         });
 
         it('creates invite and revokes active previous invites', async () => {
             const previousInviteRef = { path: 'trainer_invites/old' };
-            getDocs.mockResolvedValueOnce({
-                docs: [{ ref: previousInviteRef }]
-            });
+            getDocs.mockResolvedValueOnce({ docs: [{ ref: previousInviteRef }] });
             getDoc.mockResolvedValueOnce({
                 exists: () => true,
-                id: 'invite-1',
+                id: 'NEWCODE1',
                 data: () => ({
                     code: 'NEWCODE1',
                     trainerId: 'trainer-1',
@@ -256,19 +322,51 @@ describe('userService', () => {
             const result = await userService.createTrainerInvite('trainer-1');
 
             expect(updateDoc).toHaveBeenCalledWith(previousInviteRef, { status: 'revoked' });
-            expect(addDoc).toHaveBeenCalledWith(
-                expect.anything(),
-                expect.objectContaining({
-                    trainerId: 'trainer-1',
-                    status: 'active',
-                    createdAt: 'ts'
-                })
-            );
+            expect(addDoc).not.toHaveBeenCalled();
+
+            const [[, payload]] = setDoc.mock.calls;
+            expect(payload).toMatchObject({ trainerId: 'trainer-1', status: 'active', createdAt: 'ts' });
+            // o codigo gravado tem que ser o mesmo usado como ID do documento
+            expect(payload.code).toMatch(/^[A-Z0-9]{8}$/);
+            expect(doc).toHaveBeenCalledWith(expect.anything(), 'trainer_invites', payload.code);
             expect(result.code).toBe('NEWCODE1');
         });
 
+        it('sorteia outro codigo quando o ID ja existe', async () => {
+            getDocs.mockResolvedValueOnce({ docs: [] });
+            setDoc
+                .mockRejectedValueOnce(Object.assign(new Error('denied'), { code: 'permission-denied' }))
+                .mockResolvedValueOnce();
+            getDoc.mockResolvedValueOnce({
+                exists: () => true,
+                id: 'NEWCODE1',
+                data: () => ({ code: 'NEWCODE1', trainerId: 'trainer-1' })
+            });
+
+            const result = await userService.createTrainerInvite('trainer-1');
+
+            expect(setDoc).toHaveBeenCalledTimes(2);
+            const [firstCall, secondCall] = setDoc.mock.calls;
+            expect(firstCall[1].code).not.toBe(secondCall[1].code);
+            expect(result.code).toBe('NEWCODE1');
+        });
+
+        it('propaga o erro quando todas as tentativas de codigo falham', async () => {
+            getDocs.mockResolvedValueOnce({ docs: [] });
+            // `Once` em cada tentativa: um mockRejectedValue fixo vazaria para os
+            // testes seguintes, porque clearAllMocks nao remove implementacao.
+            setDoc
+                .mockRejectedValueOnce(new Error('sem permissao'))
+                .mockRejectedValueOnce(new Error('sem permissao'))
+                .mockRejectedValueOnce(new Error('sem permissao'));
+
+            await expect(userService.createTrainerInvite('trainer-1'))
+                .rejects.toThrow('sem permissao');
+            expect(setDoc).toHaveBeenCalledTimes(3);
+        });
+
         it('revokes invite by id', async () => {
-            await userService.revokeTrainerInvite('invite-1');
+            await userService.revokeTrainerInvite('ABC12345');
 
             expect(updateDoc).toHaveBeenCalledWith(expect.anything(), { status: 'revoked' });
         });

--- a/tests/security/firestore.rules.test.js
+++ b/tests/security/firestore.rules.test.js
@@ -6,17 +6,28 @@ import {
     initializeTestEnvironment
 } from '@firebase/rules-unit-testing';
 import {
+    collection,
     deleteDoc,
     doc,
     getDoc,
+    getDocs,
+    limit,
+    query,
     setDoc,
     Timestamp,
     updateDoc,
+    where,
     writeBatch
 } from 'firebase/firestore';
 
 const PROJECT_ID = 'demo-vitalita-rules';
 const futureDate = Timestamp.fromDate(new Date('2099-01-01T00:00:00.000Z'));
+
+// O `list` so e liberado quando o limite de expiresAt supera o request.time do
+// servidor; um Timestamp.now() do cliente pode ficar atras dele e mascarar a falha.
+function aheadOfServerClock() {
+    return Timestamp.fromMillis(Date.now() + 60_000);
+}
 const pastDate = Timestamp.fromDate(new Date('2020-01-01T00:00:00.000Z'));
 
 let testEnv;
@@ -234,7 +245,7 @@ describe('firestore.rules', () => {
         await seedUser('trainer-1');
 
         const trainerDb = authedDb('trainer-1');
-        await assertSucceeds(setDoc(doc(trainerDb, 'trainer_invites/invite-1'), {
+        await assertSucceeds(setDoc(doc(trainerDb, 'trainer_invites/ABC12345'), {
             trainerId: 'trainer-1',
             code: 'ABC12345',
             status: 'active',
@@ -243,7 +254,7 @@ describe('firestore.rules', () => {
         }));
 
         const studentDb = authedDb('student-1');
-        await assertSucceeds(getDoc(doc(studentDb, 'trainer_invites/invite-1')));
+        await assertSucceeds(getDoc(doc(studentDb, 'trainer_invites/ABC12345')));
 
         const batch = writeBatch(studentDb);
         batch.set(doc(studentDb, 'trainer_students/student-1_trainer-1'), {
@@ -251,9 +262,9 @@ describe('firestore.rules', () => {
             trainerId: 'trainer-1',
             status: 'active',
             linkedAt: Timestamp.now(),
-            inviteId: 'invite-1'
+            inviteId: 'ABC12345'
         });
-        batch.update(doc(studentDb, 'trainer_invites/invite-1'), {
+        batch.update(doc(studentDb, 'trainer_invites/ABC12345'), {
             status: 'expired',
             usedBy: 'student-1',
             usedAt: Timestamp.now()
@@ -265,7 +276,7 @@ describe('firestore.rules', () => {
     it('bloqueia consumo de convite sem criar vinculo correspondente', async () => {
         await seedUser('student-1');
         await seedUser('trainer-1');
-        await seed('trainer_invites/invite-1', {
+        await seed('trainer_invites/ABC12345', {
             trainerId: 'trainer-1',
             code: 'ABC12345',
             status: 'active',
@@ -273,7 +284,7 @@ describe('firestore.rules', () => {
             expiresAt: futureDate
         });
 
-        await assertFails(updateDoc(doc(authedDb('student-1'), 'trainer_invites/invite-1'), {
+        await assertFails(updateDoc(doc(authedDb('student-1'), 'trainer_invites/ABC12345'), {
             status: 'expired',
             usedBy: 'student-1',
             usedAt: Timestamp.now()
@@ -282,7 +293,7 @@ describe('firestore.rules', () => {
 
     it('bloqueia convite expirado e revogacao por terceiro', async () => {
         await seedUser('trainer-1');
-        await seed('trainer_invites/expired-invite', {
+        await seed('trainer_invites/OLD12345', {
             trainerId: 'trainer-1',
             code: 'OLD12345',
             status: 'active',
@@ -290,20 +301,91 @@ describe('firestore.rules', () => {
             expiresAt: pastDate
         });
 
-        await assertFails(getDoc(doc(authedDb('student-1'), 'trainer_invites/expired-invite')));
-        await assertFails(updateDoc(doc(authedDb('student-1'), 'trainer_invites/expired-invite'), {
+        await assertFails(getDoc(doc(authedDb('student-1'), 'trainer_invites/OLD12345')));
+        await assertFails(updateDoc(doc(authedDb('student-1'), 'trainer_invites/OLD12345'), {
             status: 'revoked'
         }));
-        await assertSucceeds(updateDoc(doc(authedDb('trainer-1'), 'trainer_invites/expired-invite'), {
+        await assertSucceeds(updateDoc(doc(authedDb('trainer-1'), 'trainer_invites/OLD12345'), {
             status: 'revoked'
         }));
+    });
+
+    it('exige que o codigo do convite seja o proprio ID do documento', async () => {
+        await seedUser('trainer-1');
+        const trainerDb = authedDb('trainer-1');
+
+        await assertFails(setDoc(doc(trainerDb, 'trainer_invites/invite-1'), {
+            trainerId: 'trainer-1',
+            code: 'ABC12345',
+            status: 'active',
+            createdAt: Timestamp.now(),
+            expiresAt: futureDate
+        }));
+    });
+
+    it('bloqueia enumeracao de convites ativos por quem nao e o dono', async () => {
+        await seedUser('trainer-1');
+        await seed('trainer_invites/ABC12345', {
+            trainerId: 'trainer-1',
+            code: 'ABC12345',
+            status: 'active',
+            createdAt: Timestamp.now(),
+            expiresAt: futureDate
+        });
+
+        const strangerDb = authedDb('stranger-1');
+        const invites = collection(strangerDb, 'trainer_invites');
+
+        // O motor de rules prova o `list` pelos filtros da consulta: com um limite
+        // de expiresAt acima de request.time, `status == 'active' && expiresAt >
+        // request.time` fica provado sem filtrar por code, e a consulta devolveria
+        // todos os convites ativos.
+        await assertFails(getDocs(query(
+            invites,
+            where('status', '==', 'active'),
+            where('expiresAt', '>', aheadOfServerClock())
+        )));
+        await assertFails(getDocs(query(
+            invites,
+            where('code', '==', 'ABC12345'),
+            where('status', '==', 'active'),
+            where('expiresAt', '>', aheadOfServerClock()),
+            limit(1)
+        )));
+        await assertFails(getDocs(invites));
+    });
+
+    it('permite ao personal listar apenas os proprios convites', async () => {
+        await seedUser('trainer-1');
+        await seed('trainer_invites/ABC12345', {
+            trainerId: 'trainer-1',
+            code: 'ABC12345',
+            status: 'active',
+            createdAt: Timestamp.now(),
+            expiresAt: futureDate
+        });
+
+        const trainerDb = authedDb('trainer-1');
+        const invites = collection(trainerDb, 'trainer_invites');
+
+        await assertSucceeds(getDocs(query(
+            invites,
+            where('trainerId', '==', 'trainer-1'),
+            where('status', '==', 'active'),
+            where('expiresAt', '>', aheadOfServerClock())
+        )));
+        await assertFails(getDocs(query(
+            invites,
+            where('trainerId', '==', 'trainer-2'),
+            where('status', '==', 'active')
+        )));
     });
 
     it('bloqueia criacao de vinculo em nome de outro aluno', async () => {
         await seedUser('student-1');
         await seedUser('student-2');
         await seedUser('trainer-1');
-        await seed('trainer_invites/invite-1', {
+        await seed('trainer_invites/ABC12345', {
             trainerId: 'trainer-1',
             code: 'ABC12345',
             status: 'active',
@@ -318,9 +400,9 @@ describe('firestore.rules', () => {
             trainerId: 'trainer-1',
             status: 'active',
             linkedAt: Timestamp.now(),
-            inviteId: 'invite-1'
+            inviteId: 'ABC12345'
         });
-        batch.update(doc(db, 'trainer_invites/invite-1'), {
+        batch.update(doc(db, 'trainer_invites/ABC12345'), {
             status: 'expired',
             usedBy: 'student-1',
             usedAt: Timestamp.now()


### PR DESCRIPTION
## O problema

A regra de `trainer_invites` cobria `get` e `list` num único `allow read`. O motor de rules prova um `list` **a partir dos filtros da consulta**, não documento a documento — então `status == 'active'` mais um limite de `expiresAt` à frente do relógio do servidor provavam a condição da regra para qualquer resultado possível, **sem filtrar por `code`**:

```js
query(collection(db, 'trainer_invites'),
      where('status', '==', 'active'),
      where('expiresAt', '>', umInstanteAdianteDoRelogioDoServidor))
```

Qualquer autenticado, sem nenhum vínculo, recebia todos os convites ativos com `code` e `trainerId`. De posse dos códigos, dava para queimar o convite de outro aluno (o aceite grava `status: 'expired'` e `usedBy`) e criar vínculo espúrio com o personal. Não havia leitura de dado do personal — `canReadUserData` só vale do personal para o aluno.

Medido no emulador. O gatilho é o limite de `expiresAt`:

| Limite na consulta | Resultado |
|---|---|
| `> agora - 1s` / `> agora` | negado |
| `> agora + 1s` ou mais | **todos os convites ativos, com `code` e `trainerId`** |

Por isso o ataque parece intermitente com `Timestamp.now()` do cliente: só funciona quando a latência joga a favor. Com um limite explicitamente adiantado, é determinístico.

## A correção

O código de 8 caracteres passa a ser o próprio ID do documento.

- **`firestore.rules`** — `allow read` vira `allow get` (condição intacta) mais `allow list: resource.data.trainerId == request.auth.uid`. `validInviteCreate` recebe o `inviteId` e exige `code == inviteId`, tornando o vínculo ID↔código uma invariante do servidor. Resgatar passa a exigir conhecer o código: 32⁸ ≈ 1,1 × 10¹² combinações.
- **`linkTrainer`** — resgata com `getDoc(trainer_invites/CODIGO)` em vez de consulta. Valida o formato antes de tocar no Firestore e confere `status`/`expiresAt` no cliente, porque as rules liberam `get` ao dono mesmo expirado. Só `permission-denied` vira `PERSONAL_NOT_FOUND`; falha de rede continua subindo, para não virar "convite inválido" quando o aluno está offline.
- **`createTrainerInvite`** — grava com `setDoc(doc(..., code))`. Colisão cai como `update` negado pelas rules, então o laço sorteia outro código (3 tentativas) e propaga o último erro se todas falharem.
- **Índice** — `code + status + expiresAt` fica sem uso e sai do `firestore.indexes.json`.

## Convites que já existem

Sem migração. `getActiveTrainerInvite` ignora convite cujo `code` não bate com o ID do documento, então `ensureActiveTrainerInvite` emite um substituto e revoga o antigo na primeira vez que o personal abre o painel. Sem isso, um convite antigo continuaria `active` e o painel exibiria por até 7 dias um código que aluno nenhum consegue resgatar.

## Testes

Dois cenários novos em `tests/security/firestore.rules.test.js` (enumeração negada; `code` obrigatoriamente igual ao ID) mais um que fixa o `list` permitido ao dono. Conferi que **falham contra as rules antigas e passam contra as novas** — não passam por acidente. Eles usam um limite de `expiresAt` deliberadamente à frente do relógio do servidor; com `Timestamp.now()` o `list` pode ser negado por acaso e o teste passaria sem provar nada.

Sequência do CI, toda verde: lint (0 erros, 11 warnings pré-existentes), 480 testes Vitest, 12 das Functions, build e 15 de rules.

## Nota

`docs/app-check.md` não tinha parágrafo sobre `trainer_invites` — nada lá descrevia a enumeração como comportamento conhecido. A explicação foi para `docs/security-rules.md`, com atualização em `docs/firestore-model.md` e `docs/testing.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
