### PR TITLE
chore: versiona o índice userId+templateId de workout_sessions

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -51,6 +51,20 @@
       ]
     },
     {
+      "collectionGroup": "workout_sessions",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "userId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "templateId",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "workout_templates",
       "queryScope": "COLLECTION",
       "fields": [


### PR DESCRIPTION
Sobrou do #86. Ao publicar os índices em produção, o levantamento mostrou que o `firestore.indexes.json` e o projeto `app-treino-17bbf` divergiam: produção tinha um índice que o arquivo não declarava.

## Por que importa

Enquanto a divergência existir, **todo `firebase deploy --only firestore:indexes` propõe apagar esse índice** — e um deploy com `--force` o remove sem perguntar. Foi exatamente o que aconteceu no deploy de ontem: precisei declarar o índice num arquivo temporário para que a ferramenta não oferecesse a deleção.

## O índice

```json
{ "collectionGroup": "workout_sessions", "fields": ["userId", "templateId"] }
```

Atende o `getRecentSessions` em `src/hooks/workout-session/useSessionLoader.js`, que filtra por `userId` e `templateId` com `limit(20)` e ordena no cliente, sem `orderBy`.

Vale registrar: o índice de `userId + templateId + completedAt`, que também está no arquivo, cobriria essa mesma consulta — então o de dois campos é redundante em teoria. Não mexi nisso porque é ele que serve tráfego hoje, e consolidar os dois é uma decisão separada. Este PR só elimina a divergência.

## Resultado

O arquivo passa a espelhar exatamente os 7 índices compostos que existem em produção — conferido campo a campo contra `firebase firestore:indexes`, sem sobra dos dois lados.

Sem mudança de comportamento: o índice já existe no projeto, então o próximo deploy não cria nem apaga nada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
