### PR TITLE
docs: descreve o parâmetro de linkTrainer como código de convite

### DIFF
--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -105,13 +105,15 @@ export const userService = {
     },
 
     /**
-     * Vincular estudante ao treinador
-     * @param {string} studentId 
-     * @param {string} trainerCode (trainerId)
+     * Vincula o aluno ao personal resgatando um convite pelo código.
+     * @param {string} studentId
+     * @param {string} inviteCode Código de 8 caracteres gerado pelo personal; é o
+     *   próprio ID do documento em `trainer_invites`. Aceita espaços e minúsculas.
      * @returns {Promise<void>}
+     * @throws {Error} PERSONAL_NOT_FOUND, ALREADY_LINKED ou LINK_TRAINER_FAILED
      */
-    async linkTrainer(studentId, trainerCode) {
-        const normalizedCode = normalizeInviteCode(trainerCode);
+    async linkTrainer(studentId, inviteCode) {
+        const normalizedCode = normalizeInviteCode(inviteCode);
         if (!normalizedCode || normalizedCode === studentId) {
             throw new Error("PERSONAL_NOT_FOUND");
         }


### PR DESCRIPTION
Primeiro item de código do D01 da revisão geral (#88). Substitui o #108, que fechou sozinho quando apaguei a branch remota antes da hora — o conteúdo é o mesmo, agora rebaseado na `main`.

O JSDoc de `linkTrainer` dizia `@param {string} trainerCode (trainerId)` — descrição do fluxo de antes de 03/07/2026, quando o aluno digitava o UID do personal e o vínculo era direto, sem convite. Desde então ele digita o código de convite de 8 caracteres, e desde o #86 esse código é o próprio ID do documento em `trainer_invites`.

Mudança: o parâmetro vira `inviteCode`, o JSDoc descreve o que ele é de fato e lista os três erros que a função lança. Nenhuma linha de lógica muda; a chamada em `ProfilePage.jsx` é posicional e os testes já passam o código como string.

Refs #88 — a issue fica aberta até o Tiago confirmar no console do Google Cloud se a chave reCAPTCHA órfã foi apagada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
